### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 bin/configlet
 bin/configlet.exe
 build/
-**/test-*
+**/tests
 **/*.o
 *.pyc


### PR DESCRIPTION
The test executables are renamed from test-* to tests.