### PR TITLE
Use int instead of bool for return types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ compiler:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y nasm; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install nasm; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl -O https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/macosx/nasm-2.14.02-macosx.zip && unzip nasm-2.14.02-macosx.zip && export PATH=$(pwd)/nasm-2.14.02:$PATH; fi
 
 script:
   - bin/fetch-configlet

--- a/exercises/allergies/allergies_test.c
+++ b/exercises/allergies/allergies_test.c
@@ -1,7 +1,5 @@
 // Version: 2.0.0
 
-#include <stdbool.h>
-
 #include "vendor/unity.h"
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
@@ -23,7 +21,7 @@ struct item_list {
     enum item items[MAX_ITEMS];
 };
 
-extern bool allergic_to(enum item item, unsigned int score);
+extern int allergic_to(enum item item, unsigned int score);
 extern void list(unsigned int score, struct item_list *list);
 
 void setUp(void) {

--- a/exercises/allergies/example.asm
+++ b/exercises/allergies/example.asm
@@ -11,6 +11,7 @@
 section .text
 global allergic_to
 allergic_to:
+    xor eax, eax ; Set return value
     bt esi, edi  ; Select the bit in score at the bit-position represented by the item
     setc al      ; Return true if the bit is set, else false
     ret

--- a/exercises/isogram/example.asm
+++ b/exercises/isogram/example.asm
@@ -9,17 +9,18 @@
 section .text
 global is_isogram
 is_isogram:
-    xor eax, eax           ; Initialize bitmap of used letters
+    xor eax, eax           ; Set return value
+    xor ecx, ecx           ; Initialize bitmap of used letters
 
     cmp byte [rdi], 0      ; Check if input string is empty
     je .loop_end           ; If empty, skip loop
 .loop_start:
-    movzx ecx, byte [rdi]  ; Read char from input string
-    or ecx, 32             ; If uppercase, convert to lowercase
-    sub ecx, 'a'
-    cmp ecx, 26            ; Check if alphabetic
+    movzx edx, byte [rdi]  ; Read char from input string
+    or edx, 32             ; If uppercase, convert to lowercase
+    sub edx, 'a'
+    cmp edx, 26            ; Check if alphabetic
     jae .next              ; If not, process next char
-    bts eax, ecx           ; Mark letter as used in bitmap
+    bts ecx, edx           ; Mark letter as used in bitmap
     jc .loop_end           ; If letter has already been used, return false
 .next:
     inc rdi                ; Advance input string to next char

--- a/exercises/isogram/isogram_test.c
+++ b/exercises/isogram/isogram_test.c
@@ -1,10 +1,8 @@
 // Version: 1.7.0
 
-#include <stdbool.h>
-
 #include "vendor/unity.h"
 
-extern bool is_isogram(const char *str);
+extern int is_isogram(const char *str);
 
 void setUp(void) {
 }

--- a/exercises/leap/leap_test.c
+++ b/exercises/leap/leap_test.c
@@ -1,10 +1,8 @@
-// Version: 1.5.1
-
-#include <stdbool.h>
+// Version: 1.6.0
 
 #include "vendor/unity.h"
 
-extern bool leap_year(int year);
+extern int leap_year(int year);
 
 void setUp(void) {
 }
@@ -26,14 +24,29 @@ void test_year_divisible_by_4_not_divisible_by_100_in_leap_year(void) {
     TEST_ASSERT_TRUE(leap_year(1996));
 }
 
+void test_year_divisible_by_4_and_5_is_still_a_leap_year(void) {
+    TEST_IGNORE();
+    TEST_ASSERT_TRUE(leap_year(1960));
+}
+
 void test_year_divisible_by_100_not_divisible_by_400_in_common_year(void) {
     TEST_IGNORE();
     TEST_ASSERT_FALSE(leap_year(2100));
 }
 
+void test_year_divisible_by_100_but_not_by_3_is_still_not_a_leap_year(void) {
+    TEST_IGNORE();
+    TEST_ASSERT_FALSE(leap_year(1900));
+}
+
 void test_year_divisible_by_400_in_leap_year(void) {
     TEST_IGNORE();
     TEST_ASSERT_TRUE(leap_year(2000));
+}
+
+void test_year_divisible_by_400_but_not_by_125_is_still_a_leap_year(void) {
+    TEST_IGNORE();
+    TEST_ASSERT_TRUE(leap_year(2400));
 }
 
 void test_year_divisible_by_200_not_divisible_by_400_in_common_year(void) {
@@ -46,8 +59,11 @@ int main(void) {
     RUN_TEST(test_year_not_divisible_by_4_in_common_year);
     RUN_TEST(test_year_divisible_by_2_not_divisible_by_4_in_common_year);
     RUN_TEST(test_year_divisible_by_4_not_divisible_by_100_in_leap_year);
+    RUN_TEST(test_year_divisible_by_4_and_5_is_still_a_leap_year);
     RUN_TEST(test_year_divisible_by_100_not_divisible_by_400_in_common_year);
+    RUN_TEST(test_year_divisible_by_100_but_not_by_3_is_still_not_a_leap_year);
     RUN_TEST(test_year_divisible_by_400_in_leap_year);
+    RUN_TEST(test_year_divisible_by_400_but_not_by_125_is_still_a_leap_year);
     RUN_TEST(test_year_divisible_by_200_not_divisible_by_400_in_common_year);
     return UNITY_END();
 }

--- a/exercises/matching-brackets/matching_brackets_test.c
+++ b/exercises/matching-brackets/matching_brackets_test.c
@@ -1,10 +1,8 @@
 // Version: 2.0.0
 
-#include <stdbool.h>
-
 #include "vendor/unity.h"
 
-extern bool is_paired(const char *str);
+extern int is_paired(const char *str);
 
 void setUp(void) {
 }

--- a/exercises/pangram/example.asm
+++ b/exercises/pangram/example.asm
@@ -9,23 +9,24 @@
 section .text
 global is_pangram
 is_pangram:
-    xor eax, eax           ; Initialize bitmap of used letters
+    xor eax, eax           ; Set return value
+    xor ecx, ecx           ; Initialize bitmap of used letters
 
     cmp byte [rdi], 0      ; Check if input string is empty
     je .loop_end           ; If empty, skip loop
 .loop_start:
-    movzx ecx, byte [rdi]  ; Read char from input string
-    or ecx, 32             ; If uppercase, convert to lowercase
-    sub ecx, 'a'
-    cmp ecx, 26            ; Check if alphabetic
+    movzx edx, byte [rdi]  ; Read char from input string
+    or edx, 32             ; If uppercase, convert to lowercase
+    sub edx, 'a'
+    cmp edx, 26            ; Check if alphabetic
     jae .next              ; If not, process next char
-    bts eax, ecx           ; Mark letter as used in bitmap
+    bts ecx, edx           ; Mark letter as used in bitmap
 .next:
     inc rdi                ; Advance input string to next char
     cmp byte [rdi], 0      ; See if we reached the end
     jne .loop_start        ; If chars remain, loop back
 
 .loop_end:
-    cmp eax, 0x3FFFFFF     ; Check if every letter of the alphabet is used
+    cmp ecx, 0x3FFFFFF     ; Check if every letter of the alphabet is used
     sete al                ; If so, return true, else return false
     ret

--- a/exercises/pangram/pangram_test.c
+++ b/exercises/pangram/pangram_test.c
@@ -1,10 +1,8 @@
 // Version: 2.0.0
 
-#include <stdbool.h>
-
 #include "vendor/unity.h"
 
-extern bool is_pangram(const char *str);
+extern int is_pangram(const char *str);
 
 void setUp(void) {
 }

--- a/generators/exercises/allergies.py
+++ b/generators/exercises/allergies.py
@@ -1,6 +1,4 @@
 FUNC_PROTO = """\
-#include <stdbool.h>
-
 #include "vendor/unity.h"
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
@@ -22,7 +20,7 @@ struct item_list {
     enum item items[MAX_ITEMS];
 };
 
-extern bool allergic_to(enum item item, unsigned int score);
+extern int allergic_to(enum item item, unsigned int score);
 extern void list(unsigned int score, struct item_list *list);
 """
 

--- a/generators/exercises/isogram.py
+++ b/generators/exercises/isogram.py
@@ -1,9 +1,7 @@
 FUNC_PROTO = """\
-#include <stdbool.h>
-
 #include "vendor/unity.h"
 
-extern bool is_isogram(const char *str);
+extern int is_isogram(const char *str);
 """
 
 def gen_func_body(prop, inp, expected):

--- a/generators/exercises/leap.py
+++ b/generators/exercises/leap.py
@@ -1,9 +1,7 @@
 FUNC_PROTO = """\
-#include <stdbool.h>
-
 #include "vendor/unity.h"
 
-extern bool leap_year(int year);
+extern int leap_year(int year);
 """
 
 def gen_func_body(prop, inp, expected):

--- a/generators/exercises/matching_brackets.py
+++ b/generators/exercises/matching_brackets.py
@@ -1,9 +1,7 @@
 FUNC_PROTO = """\
-#include <stdbool.h>
-
 #include "vendor/unity.h"
 
-extern bool is_paired(const char *str);
+extern int is_paired(const char *str);
 """
 
 def gen_func_body(prop, inp, expected):

--- a/generators/exercises/pangram.py
+++ b/generators/exercises/pangram.py
@@ -1,9 +1,7 @@
 FUNC_PROTO = """\
-#include <stdbool.h>
-
 #include "vendor/unity.h"
 
-extern bool is_pangram(const char *str);
+extern int is_pangram(const char *str);
 """
 
 def gen_func_body(prop, inp, expected):


### PR DESCRIPTION
The compiler is depending on bool being one byte in size and holding the
value 1 or 0. Using bool makes an empty solution pass all the tests, because
rax will hold garbage on function entry.

Ref: https://github.com/exercism/x86-64-assembly/issues/69