### PR TITLE
Update argument type for grains

### DIFF
--- a/exercises/grains/grains_test.c
+++ b/exercises/grains/grains_test.c
@@ -2,7 +2,7 @@
 
 #include "vendor/unity.h"
 
-extern uint64_t square(int number);
+extern uint64_t square(int64_t number);
 extern uint64_t total(void);
 
 void setUp(void) {

--- a/generators/exercises/grains.py
+++ b/generators/exercises/grains.py
@@ -1,7 +1,7 @@
 FUNC_PROTO = """\
 #include "vendor/unity.h"
 
-extern uint64_t square(int number);
+extern uint64_t square(int64_t number);
 extern uint64_t total(void);
 """
 


### PR DESCRIPTION
Pass a 64-bit integer instead of 32-bit to avoid issues using the 64-bit
register rdi when testing for negative values. The compiler will pass -1
as 0xffffffff, which won't get sign-extended into rdi.