### PR TITLE
Bringing your track in line with the latest changes to Problem Specifications

### DIFF
--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -1,0 +1,157 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[17fc7296-2440-4ac4-ad7b-d07c321bc5a0]
+description = "testing for eggs allergy -> not allergic to anything"
+
+[07ced27b-1da5-4c2e-8ae2-cb2791437546]
+description = "testing for eggs allergy -> allergic only to eggs"
+
+[5035b954-b6fa-4b9b-a487-dae69d8c5f96]
+description = "testing for eggs allergy -> allergic to eggs and something else"
+
+[64a6a83a-5723-4b5b-a896-663307403310]
+description = "testing for eggs allergy -> allergic to something, but not eggs"
+
+[90c8f484-456b-41c4-82ba-2d08d93231c6]
+description = "testing for eggs allergy -> allergic to everything"
+
+[d266a59a-fccc-413b-ac53-d57cb1f0db9d]
+description = "testing for peanuts allergy -> not allergic to anything"
+
+[ea210a98-860d-46b2-a5bf-50d8995b3f2a]
+description = "testing for peanuts allergy -> allergic only to peanuts"
+
+[eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b]
+description = "testing for peanuts allergy -> allergic to peanuts and something else"
+
+[9152058c-ce39-4b16-9b1d-283ec6d25085]
+description = "testing for peanuts allergy -> allergic to something, but not peanuts"
+
+[d2d71fd8-63d5-40f9-a627-fbdaf88caeab]
+description = "testing for peanuts allergy -> allergic to everything"
+
+[b948b0a1-cbf7-4b28-a244-73ff56687c80]
+description = "testing for shellfish allergy -> not allergic to anything"
+
+[9ce9a6f3-53e9-4923-85e0-73019047c567]
+description = "testing for shellfish allergy -> allergic only to shellfish"
+
+[b272fca5-57ba-4b00-bd0c-43a737ab2131]
+description = "testing for shellfish allergy -> allergic to shellfish and something else"
+
+[21ef8e17-c227-494e-8e78-470a1c59c3d8]
+description = "testing for shellfish allergy -> allergic to something, but not shellfish"
+
+[cc789c19-2b5e-4c67-b146-625dc8cfa34e]
+description = "testing for shellfish allergy -> allergic to everything"
+
+[651bde0a-2a74-46c4-ab55-02a0906ca2f5]
+description = "testing for strawberries allergy -> not allergic to anything"
+
+[b649a750-9703-4f5f-b7f7-91da2c160ece]
+description = "testing for strawberries allergy -> allergic only to strawberries"
+
+[50f5f8f3-3bac-47e6-8dba-2d94470a4bc6]
+description = "testing for strawberries allergy -> allergic to strawberries and something else"
+
+[23dd6952-88c9-48d7-a7d5-5d0343deb18d]
+description = "testing for strawberries allergy -> allergic to something, but not strawberries"
+
+[74afaae2-13b6-43a2-837a-286cd42e7d7e]
+description = "testing for strawberries allergy -> allergic to everything"
+
+[c49a91ef-6252-415e-907e-a9d26ef61723]
+description = "testing for tomatoes allergy -> not allergic to anything"
+
+[b69c5131-b7d0-41ad-a32c-e1b2cc632df8]
+description = "testing for tomatoes allergy -> allergic only to tomatoes"
+
+[1ca50eb1-f042-4ccf-9050-341521b929ec]
+description = "testing for tomatoes allergy -> allergic to tomatoes and something else"
+
+[e9846baa-456b-4eff-8025-034b9f77bd8e]
+description = "testing for tomatoes allergy -> allergic to something, but not tomatoes"
+
+[b2414f01-f3ad-4965-8391-e65f54dad35f]
+description = "testing for tomatoes allergy -> allergic to everything"
+
+[978467ab-bda4-49f7-b004-1d011ead947c]
+description = "testing for chocolate allergy -> not allergic to anything"
+
+[59cf4e49-06ea-4139-a2c1-d7aad28f8cbc]
+description = "testing for chocolate allergy -> allergic only to chocolate"
+
+[b0a7c07b-2db7-4f73-a180-565e07040ef1]
+description = "testing for chocolate allergy -> allergic to chocolate and something else"
+
+[f5506893-f1ae-482a-b516-7532ba5ca9d2]
+description = "testing for chocolate allergy -> allergic to something, but not chocolate"
+
+[02debb3d-d7e2-4376-a26b-3c974b6595c6]
+description = "testing for chocolate allergy -> allergic to everything"
+
+[17f4a42b-c91e-41b8-8a76-4797886c2d96]
+description = "testing for pollen allergy -> not allergic to anything"
+
+[7696eba7-1837-4488-882a-14b7b4e3e399]
+description = "testing for pollen allergy -> allergic only to pollen"
+
+[9a49aec5-fa1f-405d-889e-4dfc420db2b6]
+description = "testing for pollen allergy -> allergic to pollen and something else"
+
+[3cb8e79f-d108-4712-b620-aa146b1954a9]
+description = "testing for pollen allergy -> allergic to something, but not pollen"
+
+[1dc3fe57-7c68-4043-9d51-5457128744b2]
+description = "testing for pollen allergy -> allergic to everything"
+
+[d3f523d6-3d50-419b-a222-d4dfd62ce314]
+description = "testing for cats allergy -> not allergic to anything"
+
+[eba541c3-c886-42d3-baef-c048cb7fcd8f]
+description = "testing for cats allergy -> allergic only to cats"
+
+[ba718376-26e0-40b7-bbbe-060287637ea5]
+description = "testing for cats allergy -> allergic to cats and something else"
+
+[3c6dbf4a-5277-436f-8b88-15a206f2d6c4]
+description = "testing for cats allergy -> allergic to something, but not cats"
+
+[1faabb05-2b98-4995-9046-d83e4a48a7c1]
+description = "testing for cats allergy -> allergic to everything"
+
+[f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f]
+description = "list when: -> no allergies"
+
+[9e1a4364-09a6-4d94-990f-541a94a4c1e8]
+description = "list when: -> just eggs"
+
+[8851c973-805e-4283-9e01-d0c0da0e4695]
+description = "list when: -> just peanuts"
+
+[2c8943cb-005e-435f-ae11-3e8fb558ea98]
+description = "list when: -> just strawberries"
+
+[6fa95d26-044c-48a9-8a7b-9ee46ec32c5c]
+description = "list when: -> eggs and peanuts"
+
+[19890e22-f63f-4c5c-a9fb-fb6eacddfe8e]
+description = "list when: -> more than eggs but not peanuts"
+
+[4b68f470-067c-44e4-889f-c9fe28917d2f]
+description = "list when: -> lots of stuff"
+
+[0881b7c5-9efa-4530-91bd-68370d054bc7]
+description = "list when: -> everything"
+
+[12ce86de-b347-42a0-ab7c-2e0570f0c65b]
+description = "list when: -> no allergen score parts"

--- a/exercises/practice/binary-search/.meta/tests.toml
+++ b/exercises/practice/binary-search/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[b55c24a9-a98d-4379-a08c-2adcf8ebeee8]
+description = "finds a value in an array with one element"
+
+[73469346-b0a0-4011-89bf-989e443d503d]
+description = "finds a value in the middle of an array"
+
+[327bc482-ab85-424e-a724-fb4658e66ddb]
+description = "finds a value at the beginning of an array"
+
+[f9f94b16-fe5e-472c-85ea-c513804c7d59]
+description = "finds a value at the end of an array"
+
+[f0068905-26e3-4342-856d-ad153cadb338]
+description = "finds a value in an array of odd length"
+
+[fc316b12-c8b3-4f5e-9e89-532b3389de8c]
+description = "finds a value in an array of even length"
+
+[da7db20a-354f-49f7-a6a1-650a54998aa6]
+description = "identifies that a value is not included in the array"
+
+[95d869ff-3daf-4c79-b622-6e805c675f97]
+description = "a value smaller than the array's smallest value is not found"
+
+[8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba]
+description = "a value larger than the array's largest value is not found"
+
+[f439a0fa-cf42-4262-8ad1-64bf41ce566a]
+description = "nothing is found in an empty array"
+
+[2c353967-b56d-40b8-acff-ce43115eed64]
+description = "nothing is found when the left and right bounds cross"

--- a/exercises/practice/difference-of-squares/.meta/tests.toml
+++ b/exercises/practice/difference-of-squares/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[e46c542b-31fc-4506-bcae-6b62b3268537]
+description = "Square the sum of the numbers up to the given number -> square of sum 1"
+
+[9b3f96cb-638d-41ee-99b7-b4f9c0622948]
+description = "Square the sum of the numbers up to the given number -> square of sum 5"
+
+[54ba043f-3c35-4d43-86ff-3a41625d5e86]
+description = "Square the sum of the numbers up to the given number -> square of sum 100"
+
+[01d84507-b03e-4238-9395-dd61d03074b5]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 1"
+
+[c93900cd-8cc2-4ca4-917b-dd3027023499]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 5"
+
+[94807386-73e4-4d9e-8dec-69eb135b19e4]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 100"
+
+[44f72ae6-31a7-437f-858d-2c0837adabb6]
+description = "Subtract sum of squares from square of sums -> difference of squares 1"
+
+[005cb2bf-a0c8-46f3-ae25-924029f8b00b]
+description = "Subtract sum of squares from square of sums -> difference of squares 5"
+
+[b1bf19de-9a16-41c0-a62b-1f02ecc0b036]
+description = "Subtract sum of squares from square of sums -> difference of squares 100"

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,0 +1,61 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
+description = "empty strands"
+
+[54681314-eee2-439a-9db0-b0636c656156]
+description = "single letter identical strands"
+
+[294479a3-a4c8-478f-8d63-6209815a827b]
+description = "single letter different strands"
+
+[9aed5f34-5693-4344-9b31-40c692fb5592]
+description = "long identical strands"
+
+[cd2273a5-c576-46c8-a52b-dee251c3e6e5]
+description = "long different strands"
+
+[919f8ef0-b767-4d1b-8516-6379d07fcb28]
+description = "disallow first strand longer"
+
+[b9228bb1-465f-4141-b40f-1f99812de5a8]
+description = "disallow first strand longer"
+reimplements = "919f8ef0-b767-4d1b-8516-6379d07fcb28"
+
+[8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
+description = "disallow second strand longer"
+
+[dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
+description = "disallow second strand longer"
+reimplements = "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e"
+
+[5dce058b-28d4-4ca7-aa64-adfe4e17784c]
+description = "disallow left empty strand"
+
+[db92e77e-7c72-499d-8fe6-9354d2bfd504]
+description = "disallow left empty strand"
+reimplements = "5dce058b-28d4-4ca7-aa64-adfe4e17784c"
+
+[b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
+description = "disallow empty first strand"
+reimplements = "db92e77e-7c72-499d-8fe6-9354d2bfd504"
+
+[38826d4b-16fb-4639-ac3e-ba027dec8b5f]
+description = "disallow right empty strand"
+
+[920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
+description = "disallow right empty strand"
+reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
+
+[9ab9262f-3521-4191-81f5-0ed184a5aa89]
+description = "disallow empty second strand"
+reimplements = "920cd6e3-18f4-4143-b6b8-74270bb8f8a3"

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -1,0 +1,13 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[af9ffe10-dc13-42d8-a742-e7bdafac449d]
+description = "Say Hi!"

--- a/exercises/practice/isogram/.meta/tests.toml
+++ b/exercises/practice/isogram/.meta/tests.toml
@@ -1,0 +1,52 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[a0e97d2d-669e-47c7-8134-518a1e2c4555]
+description = "empty string"
+
+[9a001b50-f194-4143-bc29-2af5ec1ef652]
+description = "isogram with only lower case characters"
+
+[8ddb0ca3-276e-4f8b-89da-d95d5bae78a4]
+description = "word with one duplicated character"
+
+[6450b333-cbc2-4b24-a723-0b459b34fe18]
+description = "word with one duplicated character from the end of the alphabet"
+
+[a15ff557-dd04-4764-99e7-02cc1a385863]
+description = "longest reported english isogram"
+
+[f1a7f6c7-a42f-4915-91d7-35b2ea11c92e]
+description = "word with duplicated character in mixed case"
+
+[14a4f3c1-3b47-4695-b645-53d328298942]
+description = "word with duplicated character in mixed case, lowercase first"
+
+[423b850c-7090-4a8a-b057-97f1cadd7c42]
+description = "hypothetical isogrammic word with hyphen"
+
+[93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2]
+description = "hypothetical word with duplicated character following hyphen"
+
+[36b30e5c-173f-49c6-a515-93a3e825553f]
+description = "isogram with duplicated hyphen"
+
+[cdabafa0-c9f4-4c1f-b142-689c6ee17d93]
+description = "made-up name that is an isogram"
+
+[5fc61048-d74e-48fd-bc34-abfc21552d4d]
+description = "duplicated character in the middle"
+
+[310ac53d-8932-47bc-bbb4-b2b94f25a83e]
+description = "same first and last characters"
+
+[0d0b8644-0a1e-4a31-a432-2b3ee270d847]
+description = "word with duplicated character and with two hyphens"

--- a/exercises/practice/leap/.meta/tests.toml
+++ b/exercises/practice/leap/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[6466b30d-519c-438e-935d-388224ab5223]
+description = "year not divisible by 4 in common year"
+
+[ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
+description = "year divisible by 2, not divisible by 4 in common year"
+
+[4fe9b84c-8e65-489e-970b-856d60b8b78e]
+description = "year divisible by 4, not divisible by 100 in leap year"
+
+[7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
+description = "year divisible by 4 and 5 is still a leap year"
+
+[78a7848f-9667-4192-ae53-87b30c9a02dd]
+description = "year divisible by 100, not divisible by 400 in common year"
+
+[9d70f938-537c-40a6-ba19-f50739ce8bac]
+description = "year divisible by 100 but not by 3 is still not a leap year"
+
+[42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
+description = "year divisible by 400 is leap year"
+
+[57902c77-6fe9-40de-8302-587b5c27121e]
+description = "year divisible by 400 but not by 125 is still a leap year"
+
+[c30331f6-f9f6-4881-ad38-8ca8c12520c1]
+description = "year divisible by 200, not divisible by 400 in common year"

--- a/exercises/practice/matching-brackets/.meta/tests.toml
+++ b/exercises/practice/matching-brackets/.meta/tests.toml
@@ -1,0 +1,61 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[81ec11da-38dd-442a-bcf9-3de7754609a5]
+description = "paired square brackets"
+
+[287f0167-ac60-4b64-8452-a0aa8f4e5238]
+description = "empty string"
+
+[6c3615a3-df01-4130-a731-8ef5f5d78dac]
+description = "unpaired brackets"
+
+[9d414171-9b98-4cac-a4e5-941039a97a77]
+description = "wrong ordered brackets"
+
+[f0f97c94-a149-4736-bc61-f2c5148ffb85]
+description = "wrong closing bracket"
+
+[754468e0-4696-4582-a30e-534d47d69756]
+description = "paired with whitespace"
+
+[ba84f6ee-8164-434a-9c3e-b02c7f8e8545]
+description = "partially paired brackets"
+
+[3c86c897-5ff3-4a2b-ad9b-47ac3a30651d]
+description = "simple nested brackets"
+
+[2d137f2c-a19e-4993-9830-83967a2d4726]
+description = "several paired brackets"
+
+[2e1f7b56-c137-4c92-9781-958638885a44]
+description = "paired and nested brackets"
+
+[84f6233b-e0f7-4077-8966-8085d295c19b]
+description = "unopened closing brackets"
+
+[9b18c67d-7595-4982-b2c5-4cb949745d49]
+description = "unpaired and nested brackets"
+
+[a0205e34-c2ac-49e6-a88a-899508d7d68e]
+description = "paired and wrong nested brackets"
+
+[ef47c21b-bcfd-4998-844c-7ad5daad90a8]
+description = "paired and incomplete brackets"
+
+[a4675a40-a8be-4fc2-bc47-2a282ce6edbe]
+description = "too many closing brackets"
+
+[99255f93-261b-4435-a352-02bdecc9bdf2]
+description = "math expression"
+
+[8e357d79-f302-469a-8515-2561877256a1]
+description = "complex latex expression"

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -1,0 +1,40 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[64f61791-508e-4f5c-83ab-05de042b0149]
+description = "empty sentence"
+
+[74858f80-4a4d-478b-8a5e-c6477e4e4e84]
+description = "perfect lower case"
+
+[61288860-35ca-4abe-ba08-f5df76ecbdcd]
+description = "only lower case"
+
+[6564267d-8ac5-4d29-baf2-e7d2e304a743]
+description = "missing the letter 'x'"
+
+[c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0]
+description = "missing the letter 'h'"
+
+[d835ec38-bc8f-48e4-9e36-eb232427b1df]
+description = "with underscores"
+
+[8cc1e080-a178-4494-b4b3-06982c9be2a8]
+description = "with numbers"
+
+[bed96b1c-ff95-45b8-9731-fdbdcb6ede9a]
+description = "missing letters replaced by numbers"
+
+[938bd5d8-ade5-40e2-a2d9-55a338a01030]
+description = "mixed case and punctuation"
+
+[2577bf54-83c8-402d-a64b-a2c0f7bb213a]
+description = "case insensitive"

--- a/exercises/practice/resistor-color/.meta/tests.toml
+++ b/exercises/practice/resistor-color/.meta/tests.toml
@@ -1,0 +1,22 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[49eb31c5-10a8-4180-9f7f-fea632ab87ef]
+description = "Color codes -> Black"
+
+[0a4df94b-92da-4579-a907-65040ce0b3fc]
+description = "Color codes -> White"
+
+[5f81608d-f36f-4190-8084-f45116b6f380]
+description = "Color codes -> Orange"
+
+[581d68fa-f968-4be2-9f9d-880f2fb73cf7]
+description = "Colors"

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -1,0 +1,28 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[c3b7d806-dced-49ee-8543-933fd1719b1c]
+description = "an empty string"
+
+[01ebf55b-bebb-414e-9dec-06f7bb0bee3c]
+description = "a word"
+
+[0f7c07e4-efd1-4aaa-a07a-90b49ce0b746]
+description = "a capitalized word"
+
+[71854b9c-f200-4469-9f5c-1e8e5eff5614]
+description = "a sentence with punctuation"
+
+[1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c]
+description = "a palindrome"
+
+[b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
+description = "an even-sized word"

--- a/exercises/practice/rna-transcription/.meta/tests.toml
+++ b/exercises/practice/rna-transcription/.meta/tests.toml
@@ -1,0 +1,28 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[b4631f82-c98c-4a2f-90b3-c5c2b6c6f661]
+description = "Empty RNA sequence"
+
+[a9558a3c-318c-4240-9256-5d5ed47005a6]
+description = "RNA complement of cytosine is guanine"
+
+[6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7]
+description = "RNA complement of guanine is cytosine"
+
+[870bd3ec-8487-471d-8d9a-a25046488d3e]
+description = "RNA complement of thymine is adenine"
+
+[aade8964-02e1-4073-872f-42d3ffd74c5f]
+description = "RNA complement of adenine is uracil"
+
+[79ed2757-f018-4f47-a1d7-34a559392dbf]
+description = "RNA complement"

--- a/exercises/practice/rotational-cipher/.meta/tests.toml
+++ b/exercises/practice/rotational-cipher/.meta/tests.toml
@@ -1,0 +1,40 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[74e58a38-e484-43f1-9466-877a7515e10f]
+description = "rotate a by 0, same output as input"
+
+[7ee352c6-e6b0-4930-b903-d09943ecb8f5]
+description = "rotate a by 1"
+
+[edf0a733-4231-4594-a5ee-46a4009ad764]
+description = "rotate a by 26, same output as input"
+
+[e3e82cb9-2a5b-403f-9931-e43213879300]
+description = "rotate m by 13"
+
+[19f9eb78-e2ad-4da4-8fe3-9291d47c1709]
+description = "rotate n by 13 with wrap around alphabet"
+
+[a116aef4-225b-4da9-884f-e8023ca6408a]
+description = "rotate capital letters"
+
+[71b541bb-819c-4dc6-a9c3-132ef9bb737b]
+description = "rotate spaces"
+
+[ef32601d-e9ef-4b29-b2b5-8971392282e6]
+description = "rotate numbers"
+
+[32dd74f6-db2b-41a6-b02c-82eb4f93e549]
+description = "rotate punctuation"
+
+[9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9]
+description = "rotate all letters"

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -1,0 +1,34 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[84f609af-5a91-4d68-90a3-9e32d8a5cd34]
+description = "age on Earth"
+
+[ca20c4e9-6054-458c-9312-79679ffab40b]
+description = "age on Mercury"
+
+[502c6529-fd1b-41d3-8fab-65e03082b024]
+description = "age on Venus"
+
+[9ceadf5e-a0d5-4388-9d40-2c459227ceb8]
+description = "age on Mars"
+
+[42927dc3-fe5e-4f76-a5b5-f737fc19bcde]
+description = "age on Jupiter"
+
+[8469b332-7837-4ada-b27c-00ee043ebcad]
+description = "age on Saturn"
+
+[999354c1-76f8-4bb5-a672-f317b6436743]
+description = "age on Uranus"
+
+[80096d30-a0d4-4449-903e-a381178355d8]
+description = "age on Neptune"

--- a/exercises/practice/two-fer/.meta/tests.toml
+++ b/exercises/practice/two-fer/.meta/tests.toml
@@ -1,0 +1,19 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce]
+description = "no name given"
+
+[b4c6dbb8-b4fb-42c2-bafd-10785abe7709]
+description = "a name given"
+
+[3549048d-1a6e-4653-9a79-b0bda163e8d5]
+description = "another name given"


### PR DESCRIPTION
We're in the process of re-opening the [Problem Specifications repo](https://github.com/exercism/problem-specifications), as discussed in [this issue](https://github.com/exercism/problem-specifications/issues/1674).
This PR adds `.meta/tests.toml` files for all exercises for which canonical data is defined in the Problem Specifications repo.
We'll now discuss _why_ we're making this change.
## Keeping track of implemented tests
While most of the changes to the Problem Specifications repo are specific to that repo, there is one track-specific change:
> If a track implements an exercise for which test data exists, the exercise _must_ contain a `.meta/tests.toml` file.
The goal of the `tests.toml` file is to keep track of which tests are implemented by the exercise.
Tests in this file are identified by their UUID and each test has a boolean value that indicates if it is implemented by that exercise.
A `tests.toml` file for a track's `two-fer` exercise looks like this:
```toml
[canonical-tests]
# no name given
"19709124-b82e-4e86-a722-9e5c5ebf3952" = true
# a name given
"3451eebd-123f-4256-b667-7b109affce32" = true
# another name given
"653611c6-be9f-4935-ab42-978e25fe9a10" = false
```
In this case, the track has chosen to implement two of the three available tests.
If a track uses a _test generator_ to generate an exercise's test suite, it _must_ use the contents of the `tests.toml` file to determine which tests to include in the generated test suite.
## Tooling
To make it easy to keep the `tests.toml` up to date, tracks can use the [`canonical_data_syncer` application](https://github.com/exercism/canonical-data-syncer).
This application is a small, standalone binary that will compare the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data.
It then interactively gives the maintainer the option to include or exclude test cases that are currently missing, updating the `tests.toml` file accordingly.
To use the canonical data syncer tool, tracks should copying the [`fetch-canonical_data_syncer`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer) and/or [`fetch-canonical_data_syncer.ps1`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer.ps1) scripts into their repository.
Then, running either of these scripts will download the latest version of the tool to the track's `bin` directory.
The tool can be run using `./bin/canonical_data_syncer` or `.\bin\canonical_data_syncer.exe`, depending on your operating system.
## Changes
In this PR, we're adding `meta/tests.toml` files for all the exercises for which canonical data is defined.
We've initially marked all tests as _included_, which means that we'll assume that your track has implemented those tests.
If there isn't anything obviously wrong with the PR, I would suggest to merge this PR first, and then later on update the `meta/tests.toml` files according to your track's actual implementation.
