### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -1,3 +1,5 @@
+# About
+
 x86-64 assembly is a low-level language. In assembly there are no variables,
 instead we use registers to store values. There are 16 general purpose 64-bit
 registers, `rax`, `rbx`, `rcx`, `rdx`, `rsp`, `rbp`, `rsi`, `rdi`, and `r8`

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 x86-64 assembly is a low-level language. In assembly there are no variables,
 instead we use registers to store values. Some registers have a special purpose
 such as returning a value from a function, or passing function arguments. To

--- a/config/exercise-readme-insert.md
+++ b/config/exercise-readme-insert.md
@@ -1,0 +1,2 @@
+# exercise readme insert
+

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 x86-64 assembly is the programming language for the 64-bit version of the x86
 instruction set. It is based on the original 8086 instruction set from 1978.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 ### Requirements
 
 * A 64-bit x86 CPU

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,6 +1,6 @@
 # Installation
 
-### Requirements
+## Requirements
 
 * A 64-bit x86 CPU
 * A modern C compiler
@@ -11,7 +11,7 @@ Please note that this track only supports the calling convention of the System
 V AMD64 ABI. Windows users will need to install Windows Subsystem for Linux
 (WSL), or set up a Linux virtual machine.
 
-### Linux
+## Linux
 
 Install the required software using your system's package manager:
 
@@ -21,7 +21,7 @@ Install the required software using your system's package manager:
 * Arch Linux: `$ sudo pacman -S gcc make nasm`
 * OpenSUSE: `$ sudo zypper install gcc make nasm`
 
-### macOS
+## macOS
 
 Install the Xcode Command Line Tools:
 
@@ -35,6 +35,6 @@ Install NASM using [Homebrew](http://brew.sh/):
 $ brew install nasm
 ```
 
-### Windows
+## Windows
 
 To install WSL, see https://docs.microsoft.com/en-us/windows/wsl/install-win10.

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 Exercism provides exercises and feedback but can be difficult to jump into for
 those learning x86-64 assembly for the first time. These resources can help you
 get started:

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,4 +1,4 @@
-## Recommended Learning Resources
+# Recommended Learning Resources
 
 * [The NASM Manual](https://www.nasm.us/doc/)
 * [Compiler Explorer](https://godbolt.org/)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 ## Running Tests
 
 To run the tests, execute the following command:

--- a/exercises/concept/basics/.docs/hints.md
+++ b/exercises/concept/basics/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - You need to make the functions [visible to other files][global].

--- a/exercises/concept/basics/.docs/instructions.md
+++ b/exercises/concept/basics/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you're going to write some code to help you cook a brilliant lasagna from your favorite cooking book.
 
 You have four tasks, all related to the time spent cooking the lasagna.

--- a/exercises/concept/basics/.docs/introduction.md
+++ b/exercises/concept/basics/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 x86-64 assembly is a low-level language. In assembly there are no variables,
 instead we use registers to store values. Some registers have a special purpose
 such as returning a value from a function, or passing function arguments. To

--- a/exercises/concept/basics/.meta/design.md
+++ b/exercises/concept/basics/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what the text section is.


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
