### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "da5dd9e9-e0ce-4cfb-a701-f9a6b49ec748",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing x86-64 Assembly locally",
+      "blurb": "Learn how to install x86-64 Assembly locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "88b35d06-bd68-4f82-8caa-f324c3ae7c8c",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn x86-64 Assembly",
+      "blurb": "An overview of how to get started from scratch with x86-64 Assembly"
+    },
+    {
+      "uuid": "34286f86-e0ea-4bc7-9109-732151c02f5a",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the x86-64 Assembly track",
+      "blurb": "Learn how to test your x86-64 Assembly exercises on Exercism"
+    },
+    {
+      "uuid": "501b89cd-82a4-45bf-8ebc-e2ed52f26738",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful x86-64 Assembly resources",
+      "blurb": "A collection of useful resources to help you master x86-64 Assembly"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
