### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/hello_world.asm
+++ b/exercises/practice/hello-world/hello_world.asm
@@ -1,7 +1,7 @@
 default rel
 
 section .rodata
-msg: db "", 0
+msg: db "Goodbye, Mars!", 0
 
 section .text
 global hello


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46

