### PR TITLE
🤖 Remove obsolete pattern properties from track's `config.json` file

### DIFF
--- a/config.json
+++ b/config.json
@@ -19,9 +19,6 @@
   "test_runner": {
     "average_run_time": 1.0
   },
-  "ignore_pattern": "[Ee]xample",
-  "solution_pattern": "[Ee]xample",
-  "test_pattern": "[Tt]est",
   "files": {
     "solution": [
       "%{snake_slug}.asm"


### PR DESCRIPTION
The `config.json` file previously supported the following keys:

- `test_pattern`
- `ignore_pattern`
- `solution_pattern`

These keys are now obsolete and have been replaced with the `files` property in `.meta/config.json` files (see [the docs](https://github.com/exercism/docs/blob/main/building/tracks/practice-exercises.md#file-metaconfigjson)).

To make things less confusing to maintainers, this PR removes those obsoleted pattern properties from the `config.json` files.

See https://github.com/exercism/v3-launch/issues/47