### PR TITLE
Quickfix for failing tests of exercise resistor-color

### DIFF
--- a/exercises/practice/resistor-color/.meta/example.asm
+++ b/exercises/practice/resistor-color/.meta/example.asm
@@ -12,6 +12,7 @@ violet: db "violet", 0
 grey: db "grey", 0
 white: db "white", 0
 
+section .data
 color_array:
 dq black
 dq brown


### PR DESCRIPTION
Currently the tests for `resitor-color` fail. I fixed that.

The error message (see one of the [latest](https://github.com/exercism/x86-64-assembly/actions/runs/4989690769/jobs/8933942166#step:5:196) CI runs) is the following:

```
OK
/usr/bin/ld: resistor_color.o: warning: relocation in read-only section `.rodata'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
collect2: error: ld returned 1 exit status
make: *** [Makefile:32: tests] Error 1
Error: Process completed with exit code 2.
```

I must admit that I do not 100% understand what is going on but putting the `color_array` into the `.data` section silenced the warning and made the tests green again. I am not an expert in this low-level stuff.