### PR TITLE
Fix badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Exercism x86-64 Assembly Track
 
-[![Configlet Status](https://github.com/exercism/x86-64-assembly/workflows/configlet/badge.svg)]
-[![Exercise Test Status](https://github.com/exercism/x86-64-assembly/workflows/x86-64-assembly%20%2F%20main/badge.svg)]
+[![Configlet Status](https://github.com/exercism/x86-64-assembly/workflows/configlet/badge.svg)](https://github.com/exercism/x86-64-assembly/actions/workflows/configlet.yml)
+[![Exercise Test Status](https://github.com/exercism/x86-64-assembly/workflows/x86-64-assembly%20%2F%20main/badge.svg)](https://github.com/exercism/x86-64-assembly/actions/workflows/ci.yml)
 
 Exercism exercises in x86-64 Assembly.
 


### PR DESCRIPTION
The two badges at the top of the README should link to the github actions for configlet and the ci workflow with the tests. So far it didn't do that. Moreover it looked a little bit strange. I fixed that.

I set the links analogous  to the [typescript](https://github.com/exercism/typescript) and [sml](https://github.com/exercism/sml) track.