### PR TITLE
triangle: return int, fixes #164

### DIFF
--- a/exercises/practice/triangle/.meta/example.asm
+++ b/exercises/practice/triangle/.meta/example.asm
@@ -49,6 +49,7 @@ global is_isosceles:
 is_isosceles:
         xor     eax, eax
         xor     ecx, ecx
+        xor     edx, edx
         movsd   xmm5, QWORD [rsp+8]
         movsd   xmm6, QWORD [rsp+16]
         movsd   xmm4, QWORD [rsp+24]

--- a/exercises/practice/triangle/.meta/example.asm
+++ b/exercises/practice/triangle/.meta/example.asm
@@ -21,6 +21,7 @@ triangle_equality:
 
 global is_equilateral:
 is_equilateral:
+        xor     eax, eax
         push    QWORD [rsp+24]
         push    QWORD [rsp+24]
         push    QWORD [rsp+24]
@@ -45,6 +46,8 @@ is_equilateral:
         ret
 global is_isosceles:
 is_isosceles:
+        xor     eax, eax
+        xor     ecx, ecx
         movsd   xmm5, QWORD [rsp+8]
         movsd   xmm6, QWORD [rsp+16]
         movsd   xmm4, QWORD [rsp+24]
@@ -72,6 +75,7 @@ is_isosceles:
 
 global is_scalene
 is_scalene:
+        xor     eax, eax
         push    QWORD [rsp+24]
         push    QWORD [rsp+24]
         push    QWORD [rsp+24]

--- a/exercises/practice/triangle/.meta/example.asm
+++ b/exercises/practice/triangle/.meta/example.asm
@@ -22,6 +22,7 @@ triangle_equality:
 global is_equilateral:
 is_equilateral:
         xor     eax, eax
+        xor     edx, edx
         push    QWORD [rsp+24]
         push    QWORD [rsp+24]
         push    QWORD [rsp+24]

--- a/exercises/practice/triangle/triangle_test.c
+++ b/exercises/practice/triangle/triangle_test.c
@@ -1,6 +1,5 @@
 // Version: 0
 
-#include <stdbool.h>
 #include "vendor/unity.h"
 
 typedef struct {
@@ -9,9 +8,9 @@ typedef struct {
    double c;
 } triangle_t;
 
-extern bool is_equilateral(triangle_t sides);
-extern bool is_isosceles(triangle_t sides);
-extern bool is_scalene(triangle_t sides);
+extern int is_equilateral(triangle_t sides);
+extern int is_isosceles(triangle_t sides);
+extern int is_scalene(triangle_t sides);
 
 void setUp(void) {
 }
@@ -21,115 +20,115 @@ void tearDown(void) {
 
 void test_equilateral_triangle_all_sides_are_equal(void) {
     triangle_t sides = { 2, 2, 2 } ;
-    TEST_ASSERT_TRUE(is_equilateral(sides));
+    TEST_ASSERT_EQUAL_INT(1, is_equilateral(sides));
 }
 
 void test_equilateral_triangle_any_side_is_unequal(void) {
     TEST_IGNORE();
     triangle_t sides = { 2, 3, 2 } ;
-    TEST_ASSERT_FALSE(is_equilateral(sides));
+    TEST_ASSERT_EQUAL_INT(0, is_equilateral(sides));
 }
 
 void test_equilateral_triangle_no_sides_are_equal(void) {
     TEST_IGNORE();
     triangle_t sides = { 5, 4, 6 } ;
-    TEST_ASSERT_FALSE(is_equilateral(sides));
+    TEST_ASSERT_EQUAL_INT(0, is_equilateral(sides));
 }
 
 void test_equilateral_triangle_all_zero_sides_is_not_a_triangle(void) {
     TEST_IGNORE();
     triangle_t sides = { 0, 0, 0 } ;
-    TEST_ASSERT_FALSE(is_equilateral(sides));
+    TEST_ASSERT_EQUAL_INT(0, is_equilateral(sides));
 }
 
 void test_equilateral_triangle_sides_may_be_floats(void) {
     TEST_IGNORE();
     triangle_t sides = { 0.5, 0.5, 0.5 } ;
-    TEST_ASSERT_TRUE(is_equilateral(sides));
+    TEST_ASSERT_EQUAL_INT(1, is_equilateral(sides));
 }
 
 void test_isosceles_triangle_last_two_sides_are_equal(void) {
     TEST_IGNORE();
     triangle_t sides = { 3, 4, 4 } ;
-    TEST_ASSERT_TRUE(is_isosceles(sides));
+    TEST_ASSERT_EQUAL_INT(1, is_isosceles(sides));
 }
 
 void test_isosceles_triangle_first_two_sides_are_equal(void) {
     TEST_IGNORE();
     triangle_t sides = { 4, 4, 3 } ;
-    TEST_ASSERT_TRUE(is_isosceles(sides));
+    TEST_ASSERT_EQUAL_INT(1, is_isosceles(sides));
 }
 
 void test_isosceles_triangle_first_and_last_sides_are_equal(void) {
     TEST_IGNORE();
     triangle_t sides = { 4, 3, 4 } ;
-    TEST_ASSERT_TRUE(is_isosceles(sides));
+    TEST_ASSERT_EQUAL_INT(1, is_isosceles(sides));
 }
 
 void test_isosceles_triangle_equilateral_triangles_are_also_isosceles(void) {
     TEST_IGNORE();
     triangle_t sides = { 4, 4, 4 } ;
-    TEST_ASSERT_TRUE(is_isosceles(sides));
+    TEST_ASSERT_EQUAL_INT(1, is_isosceles(sides));
 }
 
 void test_isosceles_triangle_no_sides_are_equal(void) {
     TEST_IGNORE();
     triangle_t sides = { 2, 3, 4 } ;
-    TEST_ASSERT_FALSE(is_isosceles(sides));
+    TEST_ASSERT_EQUAL_INT(0, is_isosceles(sides));
 }
 
 void test_isosceles_triangle_first_triangle_inequality_violation(void) {
     TEST_IGNORE();
     triangle_t sides = { 1, 1, 3 } ;
-    TEST_ASSERT_FALSE(is_isosceles(sides));
+    TEST_ASSERT_EQUAL_INT(0, is_isosceles(sides));
 }
 
 void test_isosceles_triangle_second_triangle_inequality_violation(void) {
     TEST_IGNORE();
     triangle_t sides = { 1, 3, 1 } ;
-    TEST_ASSERT_FALSE(is_isosceles(sides));
+    TEST_ASSERT_EQUAL_INT(0, is_isosceles(sides));
 }
 
 void test_isosceles_triangle_third_triangle_inequality_violation(void) {
     TEST_IGNORE();
     triangle_t sides = { 3, 1, 1 } ;
-    TEST_ASSERT_FALSE(is_isosceles(sides));
+    TEST_ASSERT_EQUAL_INT(0, is_isosceles(sides));
 }
 
 void test_isosceles_triangle_sides_may_be_floats(void) {
     TEST_IGNORE();
     triangle_t sides = { 0.5, 0.4, 0.5 } ;
-    TEST_ASSERT_TRUE(is_isosceles(sides));
+    TEST_ASSERT_EQUAL_INT(1, is_isosceles(sides));
 }
 
 void test_scalene_triangle_no_sides_are_equal(void) {
     TEST_IGNORE();
     triangle_t sides = { 5, 4, 6 } ;
-    TEST_ASSERT_TRUE(is_scalene(sides));
+    TEST_ASSERT_EQUAL_INT(1, is_scalene(sides));
 }
 
 void test_scalene_triangle_all_sides_are_equal(void) {
     TEST_IGNORE();
     triangle_t sides = { 4, 4, 4 } ;
-    TEST_ASSERT_FALSE(is_scalene(sides));
+    TEST_ASSERT_EQUAL_INT(0, is_scalene(sides));
 }
 
 void test_scalene_triangle_two_sides_are_equal(void) {
     TEST_IGNORE();
     triangle_t sides = { 4, 4, 3 } ;
-    TEST_ASSERT_FALSE(is_scalene(sides));
+    TEST_ASSERT_EQUAL_INT(0, is_scalene(sides));
 }
 
 void test_scalene_triangle_may_not_violate_triangle_inequality(void) {
     TEST_IGNORE();
     triangle_t sides = { 7, 3, 2 } ;
-    TEST_ASSERT_FALSE(is_scalene(sides));
+    TEST_ASSERT_EQUAL_INT(0, is_scalene(sides));
 }
 
 void test_scalene_triangle_sides_may_be_floats(void) {
     TEST_IGNORE();
     triangle_t sides = { 0.5, 0.4, 0.6 } ;
-    TEST_ASSERT_TRUE(is_scalene(sides));
+    TEST_ASSERT_EQUAL_INT(1, is_scalene(sides));
 }
 
 int main(void) {


### PR DESCRIPTION
As discussed in #164 - this should enforce returning 1/0 instead of true/false.
