### PR TITLE
Make test generator check 'include' keys in tests.toml

### DIFF
--- a/generators/generate
+++ b/generators/generate
@@ -7,6 +7,7 @@ import re
 import sys
 import textwrap
 import urllib.request
+import tomllib
 
 
 def camel_to_snake(s):
@@ -81,10 +82,16 @@ def gen_test_file(mod, version, cases):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("exercise")
+    parser.add_argument("-i", "--ignore-toml", action="store_true")
     args = parser.parse_args()
     data = download_canonical_data(args.exercise)
     version = data.get("version", 0)
     cases = flatten_cases(data)
+    if not args.ignore_toml:
+        test_toml = f"{sys.path[0]}/../exercises/practice/{args.exercise}/.meta/tests.toml"
+        with open(test_toml, "rb") as f:
+            test_toml = tomllib.load(f)
+        cases = list(filter(lambda case : test_toml.get(case['uuid'],{}).get('include', True), cases))
     exercise = args.exercise.replace("-", "_")
     mod = importlib.import_module("exercises." + exercise)
     s = gen_test_file(mod, version, cases)


### PR DESCRIPTION
As proposed in https://github.com/exercism/x86-64-assembly/pull/204#discussion_r1492511787

In accordance with https://github.com/exercism/docs/blob/main/building/configlet/sync.md, tests are not included if the `include` field in `tests.toml` is set to `false`.

In any other case, notably also if the there is no entry with the corresponding UUID in `tests.toml`, the test is included.

The include check can be disabled by supplying the `-i` or `--ignore-toml` flags to the `generate.py` script.