### PR TITLE
resistor-color: sync

### DIFF
--- a/exercises/practice/resistor-color/.docs/instructions.md
+++ b/exercises/practice/resistor-color/.docs/instructions.md
@@ -15,16 +15,16 @@ In this exercise you are going to create a helpful program so that you don't hav
 
 These colors are encoded as follows:
 
-- Black: 0
-- Brown: 1
-- Red: 2
-- Orange: 3
-- Yellow: 4
-- Green: 5
-- Blue: 6
-- Violet: 7
-- Grey: 8
-- White: 9
+- black: 0
+- brown: 1
+- red: 2
+- orange: 3
+- yellow: 4
+- green: 5
+- blue: 6
+- violet: 7
+- grey: 8
+- white: 9
 
 The goal of this exercise is to create a way:
 

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -13,7 +13,7 @@
       ".meta/example.asm"
     ]
   },
-  "blurb": "Convert a resistor band's color to its numeric representation",
+  "blurb": "Convert a resistor band's color to its numeric representation.",
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1458"
 }


### PR DESCRIPTION
Sync the `resistor-color` exercise with the latest data, as defined in https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color.

- Feel free to close this PR if there is another PR that also syncs this exercise.
- When approved, feel free to merge this PR yourselves (you don't have to wait for me).

As this PR only updates docs and/or metadata, it won't trigger a re-run of existing solutions (see [the docs](https://exercism.org/docs/building/tracks)).