### PR TITLE
ci uses ubuntu-24.04 gcc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             compiler: gcc
           - os: ubuntu-22.04
             compiler: clang


### PR DESCRIPTION
This provides test coverage for #160