### PR TITLE
First revision pass

### DIFF
--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -34,29 +34,17 @@ In x86-64, there are 16 64-bit General Purpose Registers (GPRs), which can also 
 
 The GPRs are described bellow, where `x` in `rx` ranges from 8 to 15: `r8`, `r9`, `r10`, `r11`, `r12`, `r13`, `r14` and `r15`.
 
-```
-+-----------+-----------+-----------+-----------+
-|   64-bit  |   32-bit  |   16-bit  |   8-bit   |
-+-----------+-----------+-----------+-----------+
+| 64-bit    | 32-bit    | 16-bit    | 8-bit     |
+|:---------:|:---------:|:---------:|:---------:|
 |   rax     |   eax     |   ax      |   ah/al   |
-+-----------+-----------+-----------+-----------+
 |   rbx     |   ebx     |   bx      |   bh/bl   |
-+-----------+-----------+-----------+-----------+
 |   rcx     |   ecx     |   cx      |   ch/cl   |
-+-----------+-----------+-----------+-----------+
 |   rdx     |   edx     |   dx      |   dh/dl   |
-+-----------+-----------+-----------+-----------+
 |   rsi     |   esi     |   si      |   sil     |
-+-----------+-----------+-----------+-----------+
 |   rdi     |   edi     |   di      |   dil     |
-+-----------+-----------+-----------+-----------+
 |   rbp     |   ebp     |   bp      |   bpl     |
-+-----------+-----------+-----------+-----------+
 |   rsp     |   esp     |   sp      |   spl     |
-+-----------+-----------+-----------+-----------+
 |   rx      |   rxd     |   rxw     |   rxb     |
-+-----------+-----------+-----------+-----------+
-```
 
 When using less than 64-bits, the bits accessed are usually from the lower portion of the register.
 
@@ -97,6 +85,9 @@ opcode destination, source
 So, the `opcode` is placed first, then at least one whitespace, followed by the destination operand, a comma (`,`) and finally a source operand.
 
 The source operand isn't typically modified by an instruction, just the destination operand.
+
+Unless otherwise noted, both operands must have the same size.
+So, for example, if the source operand has 16-bits, the destination operand must also have 16-bits.
 
 For instance, to store a value in a register, we can use the [mov][mov] instruction:
 

--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -79,10 +79,10 @@ Some of them can only operate on specific registers or under specific conditions
 They usually have the following form:
 
 ```nasm
-opcode destination, source
+name destination, source
 ```
 
-So, the `opcode` is placed first, then at least one whitespace, followed by the destination operand, a comma (`,`) and finally a source operand.
+So, the name of the instruction is placed first, then at least one whitespace, followed by the destination operand, a comma (`,`) and finally a source operand.
 
 The source operand isn't typically modified by an instruction, just the destination operand.
 

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -30,6 +30,40 @@ Others have special or dedicated purposes.
 
 In x86-64 there are 16 64-bit General Purpose Registers (GPRs), which can also be accessed as 32-bit, 16-bit, or 8-bit.
 
+The GPRs are described bellow, where `x` in `rx` ranges from 8 to 15: `r8`, `r9`, `r10`, `r11`, `r12`, `r13`, `r14` and `r15`.
+
+| 64-bit    | 32-bit    | 16-bit    | 8-bit     |
+|:---------:|:---------:|:---------:|:---------:|
+|   rax     |   eax     |   ax      |   ah/al   |
+|   rbx     |   ebx     |   bx      |   bh/bl   |
+|   rcx     |   ecx     |   cx      |   ch/cl   |
+|   rdx     |   edx     |   dx      |   dh/dl   |
+|   rsi     |   esi     |   si      |   sil     |
+|   rdi     |   edi     |   di      |   dil     |
+|   rbp     |   ebp     |   bp      |   bpl     |
+|   rsp     |   esp     |   sp      |   spl     |
+|   rx      |   rxd     |   rxw     |   rxb     |
+
+When using less than 64-bits, the bits accessed are usually from the lower portion of the register.
+
+The exception to this rule are `ah`, `bh`, `ch` and `dh`, which access the upper 8-bits from the 16-bits portion of the register.
+
+Illustration of how the bits are accessed for the `rax` register:
+
+
+
+```
++--------+---------------------------------------+
+| 64-bit |                  rax                  |
++--------+-------------------+-------------------+
+| 32-bit |                   |        eax        |
++--------+-------------------+---------+---------+
+| 16-bit |                             |    ax   |
++--------+-----------------------------+----+----+
+| 8-bit  |                             | ah | al |
++--------+-----------------------------+----+----+
+```
+
 Some of those registers must be preserved accross function calls: `rbp`, `rsp`, `rbx`, `r12`, `r13`, `r14` and `r15`.
 Failing to preserve them may lead to an error or to undefined behaviour.
 
@@ -42,12 +76,15 @@ Instructions are pieces of computations a CPU can perform.
 They usually have the following form:
 
 ```nasm
-opcode destination, source
+name destination, source
 ```
 
-So, the `opcode` is placed first, then at least one whitespace, followed by the destination operand, a comma (`,`) and finally a source operand.
+So, the name for the instruction is placed first, then at least one whitespace, followed by the destination operand, a comma (`,`) and finally a source operand.
 
 The source operand isn't typically modified by an instruction, just the destination operand.
+
+Unless otherwise noted, both operands must have the same size.
+So, for example, if the source operand has 16-bits, the destination operand must also have 16-bits.
 
 To store a value in a register, we can use the `mov` instruction:
 

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -50,8 +50,6 @@ The exception to this rule are `ah`, `bh`, `ch` and `dh`, which access the upper
 
 Illustration of how the bits are accessed for the `rax` register:
 
-
-
 ```
 +--------+---------------------------------------+
 | 64-bit |                  rax                  |

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -77,7 +77,7 @@ They usually have the following form:
 name destination, source
 ```
 
-So, the name for the instruction is placed first, then at least one whitespace, followed by the destination operand, a comma (`,`) and finally a source operand.
+So, the name of the instruction is placed first, then at least one whitespace, followed by the destination operand, a comma (`,`) and finally a source operand.
 
 The source operand isn't typically modified by an instruction, just the destination operand.
 

--- a/concepts/basics/links.json
+++ b/concepts/basics/links.json
@@ -16,27 +16,7 @@
     "description": "System V AMD64 ABI Documentation"
   },
   {
-    "url": "https://www.felixcloutier.com/x86/mov",
-    "description": "Reference for the MOV instruction"
-  },
-  {
-    "url": "https://www.felixcloutier.com/x86/add",
-    "description": "Reference for the ADD instruction"
-  },
-  {
-    "url": "https://www.felixcloutier.com/x86/sub",
-    "description": "Reference for the SUB instruction"
-  },
-  {
-    "url": "https://www.felixcloutier.com/x86/imul",
-    "description": "Reference for the IMUL instruction"
-  },
-  {
-    "url": "https://www.felixcloutier.com/x86/call",
-    "description": "Reference for the CALL instruction"
-  },
-  {
-    "url": "https://www.felixcloutier.com/x86/ret",
-    "description": "Reference for the RET instruction"
+    "url": "https://www.felixcloutier.com/x86",
+    "description": "Reference for x86-64 instructions"
   }
 ]

--- a/concepts/bit-manipulation/about.md
+++ b/concepts/bit-manipulation/about.md
@@ -10,151 +10,111 @@ This is why x86-64 offers a variety of different instructions for bit manipulati
 
 These instructions work on single bits in a operand.
 
-### Bt
+They all take two operands, the second indicates the index of the bit being operated in the first operand.
+All of them copy the selected bit into the `carry flag (CF)`.
 
-The instruction `bt` selects the bit in the first operand at the bit-position designated by the second operand.
-This bit is then stored in the `carry flag`.
-
-### Bts
-
-The instruction `bts` selects the bit in the destination operand at the bit-position designated by the second operand, storing it in the `carry flag`.
-This bit is not only selected, but also set in the destination operand.
-
-### Btr
-
-The instruction `btr` selects the bit in the destination operand at the bit-position designated by the second operand, storing it in the `carry flag`.
-This bit is not only selected, but also cleared in the destination operand.
-
-### Btc
-
-The instruction `btc` selects the bit in the destination operand at the bit-position designated by the second operand, storing it in the `carry flag`.
-This bit is not only selected, but also complemented in the destination operand, so that if it was set before, it is now cleared, and if it was cleared, it is now set.
+| Name | Description                                                                   |
+|------|-------------------------------------------------------------------------------|
+|bt    |copies the bit into `CF` without modifying any operand                         |
+|bts   |copies the bit into `CF` and sets it in the destination operand                |
+|btr   |copies the bit into `CF` and clears it in the destination operand              |
+|btc   |copies the bit into `CF` and complements (flips) it in the destination operand |
 
 ## Bitwise operations
 
 [Bitwise operations][bitwise] are performed in all bits of an operand.
 
-## Not
+They all have an instruction with the same name as the performed bitwise operation:
 
-The instruction [not][not] flips all the bits in the destination operand.
-Every set bit is cleared, and every cleared bit is set.
+| Name   | Description                                  |
+|--------|----------------------------------------------|
+|and     |1 if both bits are 1                          |
+|or      |1 if at least one of the bits is 1            |
+|xor     |1 if the bits differ                          |
+|not     |1 if bit was 0; 0 if bit was 1                |
 
-## Or
+Most of them take two operands, perform a bitwise operation on both and store the result in the destination operand.
+The exception is `not`, which takes just one destination operand.
 
-The instruction [or][or] sets in the destination operand all bits which are set in either the destination operand or the source operand.
-Any other bit is cleared.
+## Shift operations
 
-## And
+These instructions move the bits in the destination operand by a number of positions specified by the second operand.
+The second operand must be a constant number (an `immediate`) or the register `cl` (the lowest 8-bits of `rcx`).
 
-The instruction [and][and] sets in the destination operand all bits which are set in both the destination operand and the source operand.
-Any other bit is cleared.
+| Name    | Description             |
+|---------|-------------------------|
+|shl/sal  |Shifts bits to the left  |
+|shr/sar  |Shifts bits to the right |
 
-## Xor
+### Shl / Sal
 
-The instruction [xor][xor] sets in the destination operand all bits which are set in only one of the destination operand or the source operand.
-If a bit is set in both or cleared in both, it is cleared.
+Both `shl` and `sal` perform the exact same operation, one is an alias of the other.
 
-## Shl
-
-The instruction [shl][shift] moves all bits in the destination operand a number of positions to the left equal to the source operand.
-
-For instance, this shifts the contents of the `rax` register 2 positions to the left:
-
-```nasm
-shl rax, 2
-```
-
-The source operand must be a constant number (an `immediate`) or the register `cl` (the 8-bit lowest portion of `rcx`).
-
-Whenever a shift left is made, bits closer to the end of the sequence than the length of the shift are first moved to the `carry flag` and then discarded.
+Whenever a shift left is made, bits closer to the end of the sequence than the length of the shift are first moved to the `carry flag (CF)` and then discarded.
 On the other hand, a number of new cleared bits equal to the length of the shift is added to the beginning.
 
 For instance, consider the number `23`, represented as a single byte, being shifted 3 positions to the left:
 
-```
 Before shift (Number 23):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 0 | 1 | 0 | 1 | 1 | 1 |
-+--------+---+---+---+---+---+---+---+---+
+
+| index | 7   | 6   | 5   | 4   | 3   | 2   | 1   | 0   |
+|:-----:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| bits  | 0   | 0   | 0   | 1   | 0   | 1   | 1   | 1   |
 
 After shifting 3 positions (Number 184):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 1 | 0 | 1 | 1 | 1 | 0 | 0 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-```
+
+| index | 7   | 6   | 5   | 4   | 3   | 2   | 1   | 0   |
+|:-----:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| bits  | 1   | 0   | 1   | 1   | 1   | 0   | 0   | 0   |
 
 Notice that `184` is equal to `23 * 2³`.
 Since each bit in an integer represents a power of 2, a shift to the left by n positions has the effect of multiplying the integer by 2ⁿ.
 
-## Shr/Sar
+### Shr/Sar
 
-The operation opposite to shifting left is shifting right.
+There are two instructions to move bits to the right: `shr` and `sar`.
 
-There are two instructions to move all bits in the destination operand a number of positions to the right equal to the source operand: [shr][shift] and [sar][shift].
-
-For instance, these both shift the contents of the `rax` register 2 positions to the right:
-
-```nasm
-shr rax, 2
-sar rax, 2
-```
-
-In both cases, the source operand must be a constant number (an `immediate`) or the register `cl` (the 8-bit lowest portion of `rcx`).
-
-Whenever any of the two instructions is used, bits closer to the start of the sequence than the length of the shift are first moved to the `carry flag` and then discarded.
+Whenever any of the two instructions is used, bits closer to the start of the sequence than the length of the shift are first moved to the `carry flag (CF)` and then discarded.
 On the other hand, a number of new bits equal to the length of the shift is added to the end.
 
-The difference between them is that `shr` moves cleared bits to the end, while `sar` moves `1` if the most significant was set and `0` otherwise.
+The difference between them is that `shr` moves `0` bits to the left end, while `sar` moves `1` if the most significant was set and `0` otherwise.
 This means that `sar` preserves the sign in the shift of a signed integer.
 
 For instance, consider the number `23`, represented as a single byte, being shifted 3 positions to the right:
 
-```
 Before shift (Number 23):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 0 | 1 | 0 | 1 | 1 | 1 |
-+--------+---+---+---+---+---+---+---+---+
+
+| index | 7   | 6   | 5   | 4   | 3   | 2   | 1   | 0   |
+|:-----:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| bits  | 0   | 0   | 0   | 1   | 0   | 1   | 1   | 1   |
 
 After shifting 3 positions (Number 2):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 0 | 0 | 0 | 0 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-```
+
+| index | 7   | 6   | 5   | 4   | 3   | 2   | 1   | 0   |
+|:-----:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| bits  | 0   | 0   | 0   | 0   | 0   | 0   | 1   | 0   |
 
 Since `23` is not negative, both `sar` and `shr` would give the same result in this case.
 
 On the other hand, consider the number `-42`, represented as a single byte, being shifted 3 positions to the right:
 
-```
 Before shift (Number -42):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 1 | 1 | 0 | 1 | 0 | 1 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
+
+| index | 7   | 6   | 5   | 4   | 3   | 2   | 1   | 0   |
+|:-----:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| bits  | 1   | 1   | 0   | 1   | 0   | 1   | 1   | 0   |
 
 After shifting 3 positions with shr (Number 26):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 0 | 1 | 1 | 0 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
+
+| index | 7   | 6   | 5   | 4   | 3   | 2   | 1   | 0   |
+|:-----:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| bits  | 0   | 0   | 0   | 1   | 1   | 0   | 1   | 0   |
 
 After shifting 3 positions with sar (Number -6):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 1 | 1 | 1 | 1 | 1 | 0 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-```
+
+| index | 7   | 6   | 5   | 4   | 3   | 2   | 1   | 0   |
+|:-----:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| bits  | 1   | 1   | 1   | 1   | 1   | 0   | 1   | 0   |
 
 Notice that `2` is the quotient of `23 / 2³`.
 Similarly, if the number `-42` is interpreted as unsigned, it would be `214` and `214 / 2³` is equal to `26`.
@@ -162,7 +122,6 @@ Similarly, if the number `-42` is interpreted as unsigned, it would be `214` and
 Since each bit in an integer represents a power of 2, a shift to the right by n positions using `shr` has the effect of making an *unsigned* division by 2ⁿ.
 
 Notice also that `-42 / 2³` is equal to `-6` (with a remainder of 6).
-
 So, a shift to the right by n positions using `sar` has the effect of making a *signed* division by 2ⁿ.
 
 ~~~~exercism/note
@@ -177,86 +136,56 @@ Whereas when shifting `-9` by `2` positions to the right, the result would be `-
 
 ~~~~
 
-## Rol
+## Rotation Operations
 
-The instruction [rol][rotate] moves all bits in the destination operand a number of positions to the left equal to the source operand.
+These instructions move the bits in the destination operand by a number of positions specified by the second operand.
+The second operand must be a constant number (an `immediate`) or the register `cl` (the lowest 8-bits of `rcx`).
 
-While `shl` discards bits closer to the end of the sequence than the length of the shift, `rol` moves those bits to the start of the sequence.
-So, no new bits are added, they all change places.
+The difference between a rotation and a shift is that a rotation does not discard or add any bits.
+Bits that would be discarded by a shift are instead moved to the opposite end.
+So, all bits remain, they all change places.
 
-For instance, consider the number `71`, represented as a single byte, being rotated 3 positions to the left:
+| Name    | Description               |
+|---------|---------------------------|
+|rol      |Rotates bits to the left   |
+|ror      |Rotates bits to the right  |
 
-```
-Before shift (Number 71):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 1 | 0 | 0 | 0 | 1 | 1 | 1 |
-+--------+---+---+---+---+---+---+---+---+
+There are variants for both of those instructions that use the `carry flag (CF)` as an extra bit in the rotation:
 
-After rotating 3 positions to the left (Number 58):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 1 | 1 | 1 | 0 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-```
+| Name    | Description                                   |
+|---------|-----------------------------------------------|
+|rcl      |Rotates bits to the left, including the `CF`   |
+|rcr      |Rotates bits to the right, including the `CF`  |
 
-There's a similar instruction called `rcl` that uses the `carry flag` as an extra bit in the rotation.
+This means that a bit at one end of the sequence is first moved to the flag before going to the other end of the sequence.
+At the same time, the previous value in the flag is moved to the bit that would receive the one moved to the flag.
 
-This means that a bit at the end of the sequence is first moved to the flag before going to the start of the sequence.
-At the same time, the previous value in the flag is moved to the bit at the start of the sequence.
-
-In both cases, the source operand must be a constant number (an `immediate`) or the register `cl` (the 8-bit lowest portion of `rcx`).
-
-## Ror
-
-The instruction [ror][rotate] does the opposite of `rol`, rotating bits to the right without adding or discarding bits.
-
-There's also a similar instruction called `rcr` that uses the `carry flag` as an extra bit.
-
-In both cases, the source operand must be a constant number (an `immediate`) or the register `cl` (the 8-bit lowest portion of `rcx`).
+So, the `CF` works as an extra bit to the left in the case of `rcr` and as an extra bit to the right in the case of `rcl`.
 
 ## Other bit manipulation instructions
 
+There are other useful bit manipulation instructions, some of them are listed below.
+
+These instructions all work with two 16-bits, 32-bits or 64-bits operands.
+They can not be used with 8-bits operands.
+
 ### Popcnt
 
-The instruction [popcnt][popcnt] counts the number of bits set in the source operand and stores this count in the destination operand.
-
-It can't be used with 8-bit operands, only with 16-bits, 32-bits or 64-bits.
+The instruction `popcnt` counts the number of bits set in the source operand and stores this count in the destination operand.
 
 ### Lzcnt
 
-The instruction [lzcnt][lzcnt] counts the number of leading zeros in the source operand and stores this count in the destination operand.
+The instruction `lzcnt` counts the number of leading zeros in the source operand and stores this count in the destination operand.
 A leading zero is any bit cleared before the first set bit in a sequence of bytes.
-
-It can't be used with 8-bit operands, only with 16-bits, 32-bits or 64-bits.
 
 ### BSR
 
-The instruction [bsr][bsr] stores in the destination operand the index of the most significant bit set in the source operand.
-If the source operand has no set bit (it's equivalent to the number `0`), the result is undefined.
-
-It can't be used with 8-bit operands, only with 16-bits, 32-bits or 64-bits.
+The instruction `bsr` stores in the destination operand the index of the most significant bit set in the source operand.
+If the source operand has no set bit (ie, it is `0`), the result is undefined.
 
 ### BSF
 
-The instruction [bsf][bsf] stores in the destination operand the index of the least significant bit set in the source operand.
-If the source operand has no set bit (it's equivalent to the number `0`), the result is undefined.
+The instruction `bsf` stores in the destination operand the index of the least significant bit set in the source operand.
+If the source operand has no set bit (ie, it is `0`), the result is undefined.
 
-It can't be used with 8-bit operands, only with 16-bits, 32-bits or 64-bits.
-
-[bt]: https://www.felixcloutier.com/x86/bt
-[bts]: https://www.felixcloutier.com/x86/bts
-[btr]: https://www.felixcloutier.com/x86/btr
-[btc]: https://www.felixcloutier.com/x86/btc
-[not]: https://www.felixcloutier.com/x86/not
-[and]: https://www.felixcloutier.com/x86/and
-[or]: https://www.felixcloutier.com/x86/or
-[xor]: https://www.felixcloutier.com/x86/xor
-[shift]: https://www.felixcloutier.com/x86/sal:sar:shl:shr
-[popcnt]: https://www.felixcloutier.com/x86/popcnt
-[lzcnt]: https://www.felixcloutier.com/x86/lzcnt
-[bsr]: https://www.felixcloutier.com/x86/bsr
-[bsf]: https://www.felixcloutier.com/x86/bsf
 [bitwise]: https://en.wikipedia.org/wiki/Bitwise_operation

--- a/concepts/bit-manipulation/introduction.md
+++ b/concepts/bit-manipulation/introduction.md
@@ -4,137 +4,113 @@
 
 These instructions work on single bits in a operand.
 
-### Bt
+They all take two operands, the second indicates the index of the bit being operated in the first operand.
+All of them copy the selected bit into the `carry flag (CF)`.
 
-The instruction `bt` selects the bit in the first operand at the bit-position designated by the second operand.
-This bit is then stored in the `carry flag`.
-
-### Bts
-
-The instruction `bts` selects the bit in the destination operand at the bit-position designated by the second operand, storing it in the `carry flag`.
-This bit is not only selected, but also set in the destination operand.
-
-### Btr
-
-The instruction `btr` selects the bit in the destination operand at the bit-position designated by the second operand, storing it in the `carry flag`.
-This bit is not only selected, but also cleared in the destination operand.
-
-### Btc
-
-The instruction `btc` selects the bit in the destination operand at the bit-position designated by the second operand, storing it in the `carry flag`.
-This bit is not only selected, but also complemented in the destination operand, so that if it was set before, it is now cleared, and if it was cleared, it is now set.
+| Name | Description                                                                   |
+|------|-------------------------------------------------------------------------------|
+|bt    |copies the bit into `CF` without modifying any operand                         |
+|bts   |copies the bit into `CF` and sets it in the destination operand                |
+|btr   |copies the bit into `CF` and clears it in the destination operand              |
+|btc   |copies the bit into `CF` and complements (flips) it in the destination operand |
 
 ## Bitwise operations
 
-These instructions are performed in all bits of an operand.
+Bitwise operations are performed in all bits of an operand.
 
-## Not
+They all have an instruction with the same name as the performed bitwise operation:
 
-The instruction `not` flips all the bits in the destination operand.
-Every set bit is cleared, and every cleared bit is set.
+| Name   | Description                                  |
+|--------|----------------------------------------------|
+|and     |1 if both bits are 1                          |
+|or      |1 if at least one of the bits is 1            |
+|xor     |1 if the bits differ                          |
+|not     |1 if bit was 0; 0 if bit was 1                |
 
-## Or
+Most of them take two operands, perform a bitwise operation on both and store the result in the destination operand.
+The exception is `not`, which takes just one destination operand.
 
-The instruction `or` sets in the destination operand all bits which are set in either the destination operand or the source operand.
-Any other bit is cleared.
+## Shift operations
 
-## And
+These instructions move the bits in the destination operand by a number of positions specified by the second operand.
+The second operand must be a constant number (an `immediate`) or the register `cl` (the lowest 8-bits of `rcx`).
 
-The instruction `and` sets in the destination operand all bits which are set in both the destination operand and the source operand.
-Any other bit is cleared.
+| Name    | Description             |
+|---------|-------------------------|
+|shl/sal  |Shifts bits to the left  |
+|shr/sar  |Shifts bits to the right |
 
-## Xor
+### Shl / Sal
 
-The instruction `xor` sets in the destination operand all bits which are set in only one of the destination operand or the source operand.
-If a bit is set in both or cleared in both, it is cleared.
+Both `shl` and `sal` perform the exact same operation, one is an alias of the other.
 
-## Shl
-
-The instruction `shl` moves all bits in the destination operand a number of positions to the left equal to the source operand.
-
-The source operand must be a constant number (an `immediate`) or the register `cl` (the 8-bit lowest portion of `rcx`).
-
-Whenever a shift left is made, bits closer to the end of the sequence than the length of the shift are first moved to the `carry flag` and then discarded.
+Whenever a shift left is made, bits closer to the end of the sequence than the length of the shift are first moved to the `carry flag (CF)` and then discarded.
 On the other hand, a number of new cleared bits equal to the length of the shift is added to the beginning.
 
 Since each bit in an integer represents a power of 2, a shift to the left by n positions has the effect of multiplying the integer by 2ⁿ.
 
-## Shr/Sar
+### Shr/Sar
 
-The operation opposite to shifting left is shifting right.
+There are two instructions to move bits to the right: `shr` and `sar`.
 
-There are two instructions to move all bits in the destination operand a number of positions to the right equal to the source operand: `shr` and `sar`.
-
-In both cases, the source operand must be a constant number (an `immediate`) or the register `cl` (the 8-bit lowest portion of `rcx`).
-
-Whenever any of the two instructions is used, bits closer to the start of the sequence than the length of the shift are first moved to the `carry flag` and then discarded.
+Whenever any of the two instructions is used, bits closer to the start of the sequence than the length of the shift are first moved to the `carry flag (CF)` and then discarded.
 On the other hand, a number of new bits equal to the length of the shift is added to the end.
 
-The difference between them is that `shr` moves cleared bits to the end, while `sar` moves `1` if the most significant was set and `0` otherwise.
+The difference between them is that `shr` moves `0` bits to the left end, while `sar` moves `1` if the most significant was set and `0` otherwise.
 This means that `sar` preserves the sign in the shift of a signed integer.
 
 Since each bit in an integer represents a power of 2, a shift to the right by n positions using `shr` has the effect of making an *unsigned* division by 2ⁿ.
+
 Similarly, a shift to the right by n positions using `sar` has the effect of making a *signed* division by 2ⁿ.
 
-~~~~exercism/note
+## Rotation Operations
 
-When dividing negative numbers, `idiv` and `sar` may yield different results.
-This is because `idiv` rounds towards `0`, while `sar` rounds towards `infinity`.
+These instructions move the bits in the destination operand by a number of positions specified by the second operand.
+The second operand must be a constant number (an `immediate`) or the register `cl` (the lowest 8-bits of `rcx`).
 
-In practice, this means that the `remainder` in a signed division with `idiv` may be negative.
+The difference between a rotation and a shift is that a rotation does not discard or add any bits.
+Bits that would be discarded by a shift are instead moved to the opposite end.
+So, all bits remain, they all change places.
 
-So, when dividing `-9` by `4` using `idiv`, the quotient would be `-2`.
-Whereas when shifting `-9` by `2` positions to the right, the result would be `-3`.
+| Name    | Description               |
+|---------|---------------------------|
+|rol      |Rotates bits to the left   |
+|ror      |Rotates bits to the right  |
 
-~~~~
+There are variants for both of those instructions that use the `carry flag (CF)` as an extra bit in the rotation:
 
-## Rol
+| Name    | Description                                   |
+|---------|-----------------------------------------------|
+|rcl      |Rotates bits to the left, including the `CF`   |
+|rcr      |Rotates bits to the right, including the `CF`  |
 
-The instruction [rol][rotate] moves all bits in the destination operand a number of positions to the left equal to the source operand.
+This means that a bit at one end of the sequence is first moved to the flag before going to the other end of the sequence.
+At the same time, the previous value in the flag is moved to the bit that would receive the one moved to the flag.
 
-While `shl` discards bits closer to the end of the sequence than the length of the shift, `rol` moves those bits to the start of the sequence.
-So, no new bits are added, they all change places.
-
-There's a similar instruction called `rcl` that uses the `carry flag` as an extra bit in the rotation.
-
-This means that a bit at the end of the sequence is first moved to the flag before going to the start of the sequence.
-At the same time, the previous value in the flag is moved to the bit at the start of the sequence.
-
-In both cases, the source operand must be a constant number (an `immediate`) or the register `cl` (the 8-bit lowest portion of `rcx`).
-
-## Ror
-
-The instruction [ror][rotate] does the opposite of `rol`, rotating bits to the right without adding or discarding bits.
-
-There's also a similar instruction called `rcr` that uses the `carry flag` as an extra bit.
-
-In both cases, the source operand must be a constant number (an `immediate`) or the register `cl` (the 8-bit lowest portion of `rcx`).
+So, the `CF` works as an extra bit to the left in the case of `rcr` and as an extra bit to the right in the case of `rcl`.
 
 ## Other bit manipulation instructions
+
+There are other useful bit manipulation instructions, some of them are listed below.
+
+These instructions all work with two 16-bits, 32-bits or 64-bits operands.
+They can not be used with 8-bits operands.
 
 ### Popcnt
 
 The instruction `popcnt` counts the number of bits set in the source operand and stores this count in the destination operand.
-
-It can't be used with 8-bit operands, only with 16-bits, 32-bits or 64-bits.
 
 ### Lzcnt
 
 The instruction `lzcnt` counts the number of leading zeros in the source operand and stores this count in the destination operand.
 A leading zero is any bit cleared before the first set bit in a sequence of bytes.
 
-It can't be used with 8-bit operands, only with 16-bits, 32-bits or 64-bits.
-
 ### BSR
 
 The instruction `bsr` stores in the destination operand the index of the most significant bit set in the source operand.
-If the source operand has no set bit (it's equivalent to the number `0`), the result is undefined.
-
-It can't be used with 8-bit operands, only with 16-bits, 32-bits or 64-bits.
+If the source operand has no set bit (ie, it is `0`), the result is undefined.
 
 ### BSF
 
 The instruction `bsf` stores in the destination operand the index of the least significant bit set in the source operand.
-If the source operand has no set bit (it's equivalent to the number `0`), the result is undefined.
-
-It can't be used with 8-bit operands, only with 16-bits, 32-bits or 64-bits.
+If the source operand has no set bit (ie, it is `0`), the result is undefined.

--- a/concepts/conditionals/about.md
+++ b/concepts/conditionals/about.md
@@ -7,12 +7,12 @@ Its bits act like flags for various conditions.
 
 Some of those are listed below:
 
-| name | symbol | bit |
-|:-----|:------:|:---:|
-| carry | CF | 0 |
-| zero | ZF | 6 |
-| sign | SF | 7 |
-| overflow | OF | 11 |
+| name     | symbol | bit |
+|:---------|:------:|:---:|
+| carry    | CF     | 0   |
+| zero     | ZF     | 6   |
+| sign     | SF     | 7   |
+| overflow | OF     | 11  |
 
 For a full list, refer to [Intel's Manual][manual].
 
@@ -31,11 +31,11 @@ The `cmp` instruction subtracts the second operand from the first and sets flags
 
 If A is the first operand and B, the second:
 
-| flag | set when |
-|------|----------|
-| CF   | A < B (unsigned) |
-| ZF   | A == B |
-| SF   | A < B (signed) |
+| flag | set when                       |
+|:----:|:-------------------------------|
+| CF   | A < B (unsigned)               |
+| ZF   | A == B                         |
+| SF   | A < B (signed)                 |
 | OF   | overflow in signed subtraction |
 
 ### TEST Instruction
@@ -44,12 +44,12 @@ The `test` instruction makes a logical AND between both operands and sets flags 
 
 If A is the first operand and B, the second:
 
-| flag | set when |
-|------|----------|
-| CF   | always cleared |
-| ZF   | A AND B == 0 |
+| flag | set when             |
+|:----:|:---------------------|
+| CF   | always cleared       |
+| ZF   | A AND B == 0         |
 | SF   | A AND B < 0 (signed) |
-| OF   | always cleared |
+| OF   | always cleared       |
 
 ## Branching
 
@@ -122,13 +122,13 @@ This is because, with `cmp`, `ZF` is set when the subtraction yields zero, which
 The following table shows some of the possible suffixes and their meaning.
 Consider that A is the first operand, and B the second, in a `cmp` instruction.
 
-| suffix | meaning |
-|:-------|:-------|
-| e | A == B |
-| l | A < B (signed) |
-| b | A < B (unsigned) |
-| g | A > B (signed) |
-| a | A > B (unsigned) |
+| suffix | meaning          |
+|:------:|:-----------------|
+| e      | A == B           |
+| l      | A < B (signed)   |
+| b      | A < B (unsigned) |
+| g      | A > B (signed)   |
+| a      | A > B (unsigned) |
 
 It's possible to add `e` after `l`, `b`, `g` or `a` to include the equality in the condition.
 
@@ -137,11 +137,11 @@ For instance, `jge` jumps when A >= B, when A and B are interpreted as signed in
 There are also suffixes which refer directly to the flag being tested:
 
 | suffix | flag |
-|:-------|:-----|
-| z | ZF |
-| c | CF |
-| s | SF |
-| o | OF |
+|:------:|:----:|
+| z      | ZF   |
+| c      | CF   |
+| s      | SF   |
+| o      | OF   |
 
 For all suffixes, there are variants which check the opposite behavior.
 They have the same syntax, but with a `n` before the suffix.

--- a/concepts/conditionals/about.md
+++ b/concepts/conditionals/about.md
@@ -7,19 +7,12 @@ Its bits act like flags for various conditions.
 
 Some of those are listed below:
 
-```
-+--------------+----------+-------+
-|     name     |  symbol  |  bit  |
-+--------------+----------+-------+
-|   carry      |    CF    |   0   |
-+--------------+----------+-------+
-|   zero       |    ZF    |   6   |
-+--------------+----------+-------+
-|   sign       |    SF    |   7   |
-+--------------+----------+-------+
-|   overflow   |    OF    |   11  |
-+--------------+----------+-------+
-```
+| name | symbol | bit |
+|:-----|:------:|:---:|
+| carry | CF | 0 |
+| zero | ZF | 6 |
+| sign | SF | 7 |
+| overflow | OF | 11 |
 
 For a full list, refer to [Intel's Manual][manual].
 
@@ -36,28 +29,27 @@ They both take two operands and update the flags, but **do not modify their oper
 
 The `cmp` instruction subtracts the second operand from the first and sets flags according to the result.
 
-If the first operand is less than the second, when both are interpreted as unsigned numbers, `CF` is set.
-Otherwise, it's cleared.
+If A is the first operand and B, the second:
 
-If the result is 0, `ZF` is set.
-Otherwise, it's cleared.
-
-If the result is less than 0 in a signed subtraction, ie, a negative number, `SF` is set.
-Otherwise, it's cleared.
-
-If there's an overflow in a signed division, `OF` is set.
-Otherwise, it's cleared.
+| flag | set when |
+|------|----------|
+| CF   | A < B (unsigned) |
+| ZF   | A == B |
+| SF   | A < B (signed) |
+| OF   | overflow in signed subtraction |
 
 ### TEST Instruction
 
 The `test` instruction makes a logical AND between both operands and sets flags according to the result.
-Both `OF` and `CF` are always cleared.
 
-If the result, interpreted as a signed integer, is less than 0, `SF` is set.
-Otherwise, it's cleared.
+If A is the first operand and B, the second:
 
-If the result is 0, `ZF` is set.
-Otherwise, it's cleared.
+| flag | set when |
+|------|----------|
+| CF   | always cleared |
+| ZF   | A AND B == 0 |
+| SF   | A AND B < 0 (signed) |
+| OF   | always cleared |
 
 ## Branching
 
@@ -73,6 +65,7 @@ Instead, x86-64 provides instructions that effectively transfer execution to ano
 This is called `branching`.
 
 ~~~~exercism/note
+
 We've already seen two such instructions: `call` and `ret`.
 
 When a function is called, execution is transferred from the caller to the called function.
@@ -80,6 +73,7 @@ And, on return, execution is transferred back to the caller.
 
 If no `ret` is found, execution fallthroughs from one function to the next.
 This can sometimes be used to optimize code flow.
+
 ~~~~
 
 ### Unconditional Jump
@@ -128,21 +122,13 @@ This is because, with `cmp`, `ZF` is set when the subtraction yields zero, which
 The following table shows some of the possible suffixes and their meaning.
 Consider that A is the first operand, and B the second, in a `cmp` instruction.
 
-```
-+------------+----------------------+
-|   suffix   |       meaning        |
-+------------+----------------------+
-|     e      |       A == B         |
-+------------+----------------------+
-|     l      |    A < B (signed)    |
-+------------+----------------------+
-|     b      |    A < B (unsigned)  |
-+------------+----------------------+
-|     g      |    A > B (signed)    |
-+------------+----------------------+
-|     a      |    A > B (unsigned)  |
-+------------+----------------------+
-```
+| suffix | meaning |
+|:-------|:-------|
+| e | A == B |
+| l | A < B (signed) |
+| b | A < B (unsigned) |
+| g | A > B (signed) |
+| a | A > B (unsigned) |
 
 It's possible to add `e` after `l`, `b`, `g` or `a` to include the equality in the condition.
 
@@ -150,19 +136,12 @@ For instance, `jge` jumps when A >= B, when A and B are interpreted as signed in
 
 There are also suffixes which refer directly to the flag being tested:
 
-```
-+------------+----------------------+
-|   suffix   |        flag          |
-+------------+----------------------+
-|     z      |         ZF           |
-+------------+----------------------+
-|     c      |         CF           |
-+------------+----------------------+
-|     s      |         SF           |
-+------------+----------------------+
-|     o      |         OF           |
-+------------+----------------------+
-```
+| suffix | flag |
+|:-------|:-----|
+| z | ZF |
+| c | CF |
+| s | SF |
+| o | OF |
 
 For all suffixes, there are variants which check the opposite behavior.
 They have the same syntax, but with a `n` before the suffix.

--- a/concepts/conditionals/introduction.md
+++ b/concepts/conditionals/introduction.md
@@ -7,12 +7,12 @@ Its bits act like flags for various conditions.
 
 Some of those are listed below:
 
-| name | symbol | bit |
-|:-----|:------:|:---:|
-| carry | CF | 0 |
-| zero | ZF | 6 |
-| sign | SF | 7 |
-| overflow | OF | 11 |
+| name     | symbol | bit |
+|:---------|:------:|:---:|
+| carry    | CF     | 0   |
+| zero     | ZF     | 6   |
+| sign     | SF     | 7   |
+| overflow | OF     | 11  |
 
 ## Comparison Instructions
 
@@ -27,11 +27,11 @@ The `cmp` instruction subtracts the second operand from the first and sets flags
 
 If A is the first operand and B, the second:
 
-| flag | set when |
-|------|----------|
-| CF   | A < B (unsigned) |
-| ZF   | A == B |
-| SF   | A < B (signed) |
+| flag | set when                       |
+|:----:|:-------------------------------|
+| CF   | A < B (unsigned)               |
+| ZF   | A == B                         |
+| SF   | A < B (signed)                 |
 | OF   | overflow in signed subtraction |
 
 ### TEST Instruction
@@ -40,12 +40,12 @@ The `test` instruction makes a logical AND between both operands and sets flags 
 
 If A is the first operand and B, the second:
 
-| flag | set when |
-|------|----------|
-| CF   | always cleared |
-| ZF   | A AND B == 0 |
+| flag | set when             |
+|:----:|:---------------------|
+| CF   | always cleared       |
+| ZF   | A AND B == 0         |
 | SF   | A AND B < 0 (signed) |
-| OF   | always cleared |
+| OF   | always cleared       |
 
 ## Branching
 
@@ -106,13 +106,13 @@ This is because, with `cmp`, `ZF` is set when the subtraction yields zero, which
 The following table shows some of the possible suffixes and their meaning.
 Consider that A is the first operand, and B the second, in a `cmp` instruction.
 
-| suffix | meaning |
-|:-------|:-------|
-| e | A == B |
-| l | A < B (signed) |
-| b | A < B (unsigned) |
-| g | A > B (signed) |
-| a | A > B (unsigned) |
+| suffix | meaning          |
+|:------:|:-----------------|
+| e      | A == B           |
+| l      | A < B (signed)   |
+| b      | A < B (unsigned) |
+| g      | A > B (signed)   |
+| a      | A > B (unsigned) |
 
 It's possible to add `e` after `l`, `b`, `g` or `a` to include the equality in the condition.
 
@@ -121,11 +121,11 @@ For instance, `jge` jumps when A >= B, when interpreted as signed integers.
 There are also suffixes which refer directly to the flag being tested:
 
 | suffix | flag |
-|:-------|:-----|
-| z | ZF |
-| c | CF |
-| s | SF |
-| o | OF |
+|:------:|:----:|
+| z      | ZF   |
+| c      | CF   |
+| s      | SF   |
+| o      | OF   |
 
 For all suffixes, there are variants which check the opposite behavior.
 They have the same syntax, but with a `n` before the suffix.

--- a/concepts/conditionals/introduction.md
+++ b/concepts/conditionals/introduction.md
@@ -7,19 +7,12 @@ Its bits act like flags for various conditions.
 
 Some of those are listed below:
 
-```
-+--------------+----------+-------+
-|     name     |  symbol  |  bit  |
-+--------------+----------+-------+
-|   carry      |    CF    |   0   |
-+--------------+----------+-------+
-|   zero       |    ZF    |   6   |
-+--------------+----------+-------+
-|   sign       |    SF    |   7   |
-+--------------+----------+-------+
-|   overflow   |    OF    |   11  |
-+--------------+----------+-------+
-```
+| name | symbol | bit |
+|:-----|:------:|:---:|
+| carry | CF | 0 |
+| zero | ZF | 6 |
+| sign | SF | 7 |
+| overflow | OF | 11 |
 
 ## Comparison Instructions
 
@@ -32,28 +25,27 @@ They both take two operands and update the flags, but **do not modify their oper
 
 The `cmp` instruction subtracts the second operand from the first and sets flags according to the result.
 
-If the first operand is less than the second, when both are interpreted as unsigned numbers, `CF` is set.
-Otherwise, it's cleared.
+If A is the first operand and B, the second:
 
-If the result is 0, `ZF` is set.
-Otherwise, it's cleared.
-
-If the result is less than 0 in a signed subtraction, ie, a negative number, `SF` is set.
-Otherwise, it's cleared.
-
-If there's an overflow in a signed division, `OF` is set.
-Otherwise, it's cleared.
+| flag | set when |
+|------|----------|
+| CF   | A < B (unsigned) |
+| ZF   | A == B |
+| SF   | A < B (signed) |
+| OF   | overflow in signed subtraction |
 
 ### TEST Instruction
 
 The `test` instruction makes a logical AND between both operands and sets flags according to the result.
-Both `OF` and `CF` are always cleared.
 
-If the result, interpreted as a signed integer, is less than 0, `SF` is set.
-Otherwise, it's cleared.
+If A is the first operand and B, the second:
 
-If the result is 0, `ZF` is set.
-Otherwise, it's cleared.
+| flag | set when |
+|------|----------|
+| CF   | always cleared |
+| ZF   | A AND B == 0 |
+| SF   | A AND B < 0 (signed) |
+| OF   | always cleared |
 
 ## Branching
 
@@ -114,21 +106,13 @@ This is because, with `cmp`, `ZF` is set when the subtraction yields zero, which
 The following table shows some of the possible suffixes and their meaning.
 Consider that A is the first operand, and B the second, in a `cmp` instruction.
 
-```
-+------------+----------------------+
-|   suffix   |       meaning        |
-+------------+----------------------+
-|     e      |       A == B         |
-+------------+----------------------+
-|     l      |    A < B (signed)    |
-+------------+----------------------+
-|     b      |    A < B (unsigned)  |
-+------------+----------------------+
-|     g      |    A > B (signed)    |
-+------------+----------------------+
-|     a      |    A > B (unsigned)  |
-+------------+----------------------+
-```
+| suffix | meaning |
+|:-------|:-------|
+| e | A == B |
+| l | A < B (signed) |
+| b | A < B (unsigned) |
+| g | A > B (signed) |
+| a | A > B (unsigned) |
 
 It's possible to add `e` after `l`, `b`, `g` or `a` to include the equality in the condition.
 
@@ -136,19 +120,12 @@ For instance, `jge` jumps when A >= B, when interpreted as signed integers.
 
 There are also suffixes which refer directly to the flag being tested:
 
-```
-+------------+----------------------+
-|   suffix   |        flag          |
-+------------+----------------------+
-|     z      |         ZF           |
-+------------+----------------------+
-|     c      |         CF           |
-+------------+----------------------+
-|     s      |         SF           |
-+------------+----------------------+
-|     o      |         OF           |
-+------------+----------------------+
-```
+| suffix | flag |
+|:-------|:-----|
+| z | ZF |
+| c | CF |
+| s | SF |
+| o | OF |
 
 For all suffixes, there are variants which check the opposite behavior.
 They have the same syntax, but with a `n` before the suffix.

--- a/concepts/floating-point-numbers/about.md
+++ b/concepts/floating-point-numbers/about.md
@@ -20,7 +20,7 @@ For an in-depth explanation, please refer to [Appendix D][float-guide] of Oracle
 
 In x86-64, there are 16 dedicated registers for doing floating-point arithmetic, named `xmm0` to `xmm15`.
 
-Those registers are at least 128-bit wide, but recent processors increase this to 256-bits or 512-bits
+Those registers are at least 128-bit wide, but recent processors increase this to 256-bits or 512-bits.
 
 However, in practice, floating-point numbers only use the lowest 32-bit or 64-bits, depending on the desired precision.
 
@@ -59,19 +59,12 @@ Here, `xx` is a placeholder for the type of the operands, as usual: `ss` for sin
 Those instructions take a constant number as third operand.
 This number indicates the rounding mode:
 
-```
-+--------+------------------+
-| Number |      Mode        |
-+--------+------------------+
-|    0   |     Nearest      |
-+--------+------------------+
-|    1   |   Floor (down)   |
-+--------+------------------+
-|    2   |   Ceil (up)      |
-+--------+------------------+
-|    3   |     Truncate     |
-+--------+------------------+
-```
+| Number | Mode |
+|:-------|:-----|
+| 0 | Nearest |
+| 1 | Floor (down) |
+| 2 | Ceil (up) |
+| 3 | Truncate |
 
 Those instructions can be used in preparation for a `cvtxx2si` when there's no guarantee that a floating-point number can be exactly expressed as an integer.
 
@@ -136,6 +129,14 @@ As usual, `xx` is a placeholder for either `ss` or `sd`.
 The `maxxx` instruction computes the maximum of the two operands and stores the result in the destination operand.
 
 As usual, `xx` is a placeholder for either `ss` or `sd`.
+
+### Calling Convention
+
+In `System V ABI`, the first eight floating-point arguments are passed to functions in order, from `xmm0` to `xmm7`.
+
+Floating-point values are returned from functions into `xmm0` and, if necessary, `xmm1`.
+
+All `xmm` registers are freely available to use, none of them is reserved for the caller.
 
 [ieee]: https://en.wikipedia.org/wiki/IEEE_754
 [float-guide]: https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html

--- a/concepts/floating-point-numbers/about.md
+++ b/concepts/floating-point-numbers/about.md
@@ -59,12 +59,12 @@ Here, `xx` is a placeholder for the type of the operands, as usual: `ss` for sin
 Those instructions take a constant number as third operand.
 This number indicates the rounding mode:
 
-| Number | Mode |
-|:-------|:-----|
-| 0 | Nearest |
-| 1 | Floor (down) |
-| 2 | Ceil (up) |
-| 3 | Truncate |
+| Number | Mode         |
+|:------:|:-------------|
+| 0      | Nearest      |
+| 1      | Floor (down) |
+| 2      | Ceil (up)    |
+| 3      | Truncate     |
 
 Those instructions can be used in preparation for a `cvtxx2si` when there's no guarantee that a floating-point number can be exactly expressed as an integer.
 

--- a/concepts/floating-point-numbers/introduction.md
+++ b/concepts/floating-point-numbers/introduction.md
@@ -14,7 +14,7 @@ A single-precision floating-point number is 32-bit wide, whereas a double-precis
 
 In x86-64, there are 16 dedicated registers for doing floating-point arithmetic, named `xmm0` to `xmm15`.
 
-Those registers are at least 128-bit wide, but recent processors increase this to 256-bits or 512-bits
+Those registers are at least 128-bit wide, but recent processors increase this to 256-bits or 512-bits.
 
 However, in practice, floating-point numbers only use the lowest 32-bit or 64-bits, depending on the desired precision.
 
@@ -53,19 +53,12 @@ Here, `xx` is a placeholder for the type of the operands, as usual: `ss` for sin
 Those instructions take a constant number as third operand.
 This number indicates the rounding mode:
 
-```
-+--------+------------------+
-| Number |      Mode        |
-+--------+------------------+
-|    0   |     Nearest      |
-+--------+------------------+
-|    1   |   Floor (down)   |
-+--------+------------------+
-|    2   |   Ceil (up)      |
-+--------+------------------+
-|    3   |     Truncate     |
-+--------+------------------+
-```
+| Number | Mode |
+|:-------|:-----|
+| 0 | Nearest |
+| 1 | Floor (down) |
+| 2 | Ceil (up) |
+| 3 | Truncate |
 
 Those instructions can be used in preparation for a `cvtxx2si` when there's no guarantee that a floating-point number can be exactly expressed as an integer.
 
@@ -130,3 +123,11 @@ As usual, `xx` is a placeholder for either `ss` or `sd`.
 The `maxxx` instruction computes the maximum of the two operands and stores the result in the destination operand.
 
 As usual, `xx` is a placeholder for either `ss` or `sd`.
+
+### Calling Convention
+
+In `System V ABI`, the first eight floating-point arguments are passed to functions in order, from `xmm0` to `xmm7`.
+
+Floating-point values are returned from functions into `xmm0` and, if necessary, `xmm1`.
+
+All `xmm` registers are freely available to use, none of them is reserved for the caller.

--- a/concepts/floating-point-numbers/introduction.md
+++ b/concepts/floating-point-numbers/introduction.md
@@ -53,12 +53,12 @@ Here, `xx` is a placeholder for the type of the operands, as usual: `ss` for sin
 Those instructions take a constant number as third operand.
 This number indicates the rounding mode:
 
-| Number | Mode |
-|:-------|:-----|
-| 0 | Nearest |
-| 1 | Floor (down) |
-| 2 | Ceil (up) |
-| 3 | Truncate |
+| Number | Mode         |
+|:------:|:-------------|
+| 0      | Nearest      |
+| 1      | Floor (down) |
+| 2      | Ceil (up)    |
+| 3      | Truncate     |
 
 Those instructions can be used in preparation for a `cvtxx2si` when there's no guarantee that a floating-point number can be exactly expressed as an integer.
 

--- a/concepts/integers/about.md
+++ b/concepts/integers/about.md
@@ -1,11 +1,11 @@
 # About
 
-## Binary notation
-
 In an assembly language, most abstractions common in higher-level languages are not present.
 
 Values in a register or in memory are simply a sequence of one or more [bytes][byte], each formed of eight [bits][bit].
 Most, if not all, abstractions are built on top of this.
+
+## Binary notation
 
 One of the most important and fundamental abstractions are [integers][integer].
 They represent whole numbers such as `4`, `-2`, `0` or `64532`.
@@ -15,21 +15,8 @@ In order to represent an `integer` as a sequence of bytes, the [binary notation]
 This means each bit in the sequence represents a distinct power of two.
 The sum of the powers corresponding to set bits is the number represented.
 
-In x86-64, those bits are counted in ascending order from the smallest.
+In x86-64, those bits are counted in ascending order from the smallest index.
 This means x86-64 is [little endian][endianness].
-
-For instance, consider the following byte:
-
-```
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 0 | 1 | 0 | 1 | 1 | 1 |
-+--------+---+---+---+---+---+---+---+---+
-```
-
-The bits are set in the indexes `0`, `1`, `2` and `4`.
-So the number represented is given by the sum `2⁰ + 2¹ + 2² + 2⁴`, which is equal to `23`.
 
 ## Unsigned and Signed Integers
 
@@ -41,13 +28,9 @@ Unsigned numbers are represented directly as the sum of all set bits in its sequ
 
 For instance, this represents the number `2⁰ + 2³ + 2⁵ + 2⁶ + 2⁷`, which is `233`:
 
-```
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 1 | 1 | 1 | 0 | 1 | 0 | 0 | 1 |
-+--------+---+---+---+---+---+---+---+---+
-```
+| index | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+|-------|---|---|---|---|---|---|---|---|
+| bits  | 1 | 1 | 1 | 0 | 1 | 0 | 0 | 1 |
 
 Given an arbitrary sequence of bytes, any non-negative whole number could be theoretically represented like this.
 
@@ -58,7 +41,7 @@ So, the range of representable non-negative integers in a register goes from `0`
 
 If an integer can assume positive or negative values, it's called a `signed` number.
 
-In order to represent [negative numbers][negative], it's not enough to simply sum all set bits in a sequence of bytes.
+In order to represent [negative numbers][negative], it is not enough to simply sum all set bits in a sequence of bytes.
 A different representation is needed.
 
 The most common representation for negative numbers is [two's complement][two-complement].
@@ -68,54 +51,44 @@ Flipping a bit means that the values are inverted: a bit with the value of `1` b
 
 For instance, the number `-23` can be obtained from `23` like this:
 
-```
 Original number (23):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 0 | 1 | 0 | 1 | 1 | 1 |
-+--------+---+---+---+---+---+---+---+---+
+
+| index | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+|-------|---|---|---|---|---|---|---|---|
+| bits  | 0 | 0 | 0 | 1 | 0 | 1 | 1 | 1 |
 
 Step 1 (flip all bits):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 1 | 1 | 1 | 0 | 1 | 0 | 0 | 0 |
-+--------+---+---+---+---+---+---+---+---+
+
+| index | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+|-------|---|---|---|---|---|---|---|---|
+| bits  | 1 | 1 | 1 | 0 | 1 | 0 | 0 | 0 |
 
 Step 2 (add 1):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 1 | 1 | 1 | 0 | 1 | 0 | 0 | 1 |
-+--------+---+---+---+---+---+---+---+---+
-```
+
+| index | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+|-------|---|---|---|---|---|---|---|---|
+| bits  | 1 | 1 | 1 | 0 | 1 | 0 | 0 | 1 |
 
 The steps are the same when converting from a negative number to its positive counterpart.
 So, `-23` can be changed back to `23` in the same way:
 
-```
 Original number (-23):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 1 | 1 | 1 | 0 | 1 | 0 | 0 | 1 |
-+--------+---+---+---+---+---+---+---+---+
+
+| index | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+|-------|---|---|---|---|---|---|---|---|
+| bits  | 1 | 1 | 1 | 0 | 1 | 0 | 0 | 1 |
 
 Step 1 (flip all bits):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 0 | 1 | 0 | 1 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
+
+| index | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+|-------|---|---|---|---|---|---|---|---|
+| bits  | 0 | 0 | 0 | 1 | 0 | 1 | 1 | 0 |
 
 Step 2 (add 1):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 0 | 1 | 0 | 1 | 1 | 1 |
-+--------+---+---+---+---+---+---+---+---+
-```
+
+| index | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+|-------|---|---|---|---|---|---|---|---|
+| bits  | 0 | 0 | 0 | 1 | 0 | 1 | 1 | 1 |
 
 The [neg][neg] instruction can be used to change the sign of a number.
 
@@ -147,62 +120,49 @@ If the bit in the next index is not set, the carry is "deposited" there, making 
 If, however, the bit is already set, then this bit is cleared and the carry is then added to the following bit index in the sum.
 This continues until a bit not set is found, or until the end of the number.
 
-For instance, consider the binary representation of the numbers `30` and `13`:
+For instance, consider:
 
-```
-Number 30:
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 0 | 1 | 1 | 1 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
+Number `30`:
 
-Number 13:
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 0 | 0 | 1 | 1 | 0 | 1 |
-+--------+---+---+---+---+---+---+---+---+
-```
+| index | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+|-------|---|---|---|---|---|---|---|---|
+| bits  | 0 | 0 | 0 | 1 | 1 | 1 | 1 | 0 |
+
+Number `13`:
+
+| index | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+|-------|---|---|---|---|---|---|---|---|
+| bits  | 0 | 0 | 0 | 0 | 1 | 1 | 0 | 1 |
 
 The bits in index `1` and `4` are only set in the number `30` and the bit in index `0` is only set in number `13`.
 So they are all set in the resulting sum:
 
-```
-Step 1 (set all bits present in only of the numbers)
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 0 | 1 | 0 | 0 | 1 | 1 |
-+--------+---+---+---+---+---+---+---+---+
-```
+Step 1 (set all bits present in only of the numbers):
+
+| index | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+|-------|---|---|---|---|---|---|---|---|
+| bits  | 0 | 0 | 0 | 1 | 0 | 0 | 1 | 1 |
 
 The bits in index `2` and `3`, however, are set in both numbers being added.
 So those indexes are cleared and their bits are carried over to the next index in the sum.
 
 Since the bit in index `3` is not set in the sum, the carry from index `2` is put there:
 
-```
-Step 2 (carry over bit in index 2)
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 0 | 1 | 1 | 0 | 1 | 1 |
-+--------+---+---+---+---+---+---+---+---+
-```
+Step 2 (carry over bit in index 2):
+
+| index | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+|-------|---|---|---|---|---|---|---|---|
+| bits  | 0 | 0 | 0 | 1 | 1 | 0 | 1 | 1 |
 
 However, the bit in index `4` is already set in the sum, so the carry from index `3` clears it and moves to the next bit index.
 
 Since the bit in index `5` is not set, the carry is put there:
 
-```
-Step 3 (carry over bit in index 3)
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 1 | 0 | 1 | 0 | 1 | 1 |
-+--------+---+---+---+---+---+---+---+---+
-```
+Step 3 (carry over bit in index 3):
+
+| index | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+|-------|---|---|---|---|---|---|---|---|
+| bits  | 0 | 0 | 1 | 0 | 1 | 0 | 1 | 1 |
 
 The resulting number is `2⁵ + 2³ + 2¹ + 2⁰`, which is `43`, the sum of `30` and `13`.
 
@@ -225,7 +185,7 @@ There's also a [inc][inc] instruction, that simply sums 1 to the value in the de
 inc dest ; dest = dest + 1
 ```
 
-It's important to notice that the sum of two integers operates in the same way for both unsigned and signed numbers.
+The sum of two integers operates in the same way for both unsigned and signed numbers.
 
 ## Subtraction
 
@@ -275,8 +235,8 @@ So, for instance, if two 32-bit numbers are being multiplied, `eax` and `edx` wi
 
 The exception is the multiplication between two bytes.
 
-In this case, instead of `dl:al`, `ah` will be used.
-The lower portion of `ah` (`al`) will get the lower 8-bits of the product, while the upper portion (`ah`) will get the upper 8-bits.
+In this case, instead of `dl:al`, `ax` will be used.
+The lower portion of `ax` (`al`) will get the lower 8-bits of the product, while the upper portion (`ah`) will get the upper 8-bits.
 
 ### Two-operand form
 

--- a/concepts/integers/introduction.md
+++ b/concepts/integers/introduction.md
@@ -2,10 +2,6 @@
 
 ## Binary Notation
 
-In assembly, there aren't built-in types.
-Values are a sequence of one or more `bytes`, each formed of eight `bits`.
-Most, if not all, abstractions are built on top of this.
-
 An `integer` is an abstraction that represents whole numbers, such as `4`, `-2`, `0` or `64532`.
 
 In order to represent an `integer` as a sequence of bytes, the `binary notation` is used.
@@ -13,20 +9,7 @@ In order to represent an `integer` as a sequence of bytes, the `binary notation`
 This means each bit in the sequence represents a distinct power of two.
 The sum of the powers corresponding to set bits is the number represented.
 
-In x86-64, those bits are counted in ascending order from the smallest.
-
-For instance, consider the following byte:
-
-```
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 0 | 1 | 0 | 1 | 1 | 1 |
-+--------+---+---+---+---+---+---+---+---+
-```
-
-The bits are set in the indexes `0`, `1`, `2` and `4`.
-So the number represented is given by the sum `2⁰ + 2¹ + 2² + 2⁴`, which is equal to `23`.
+In x86-64, those bits are counted in ascending order from the smallest index.
 
 ## Unsigned and Signed Integers
 
@@ -36,6 +19,10 @@ If the number is know to be non-negative, it's called an `unsigned` number.
 
 Unsigned numbers are represented directly as the sum of all set bits in its sequence.
 
+The range of representable non-negative integers in a register goes from `0` (no bit set) to `2⁶⁴ - 1` (sum of all 64 bits set).
+
+### Signed numbers
+
 If an integer can assume positive or negative values, it's called a `signed` number.
 
 In order to represent negative numbers, x86-64 uses the `two's complement` representation.
@@ -44,29 +31,6 @@ In two's complement, a negative number is represented by flipping all bits and t
 Flipping a bit means that the values are inverted: a bit with the value of `1` becomes `0` and a bit with the value of `0` becomes `1`.
 
 For instance, the number `-23` can be obtained from `23` like this:
-
-```
-Original number (23):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 0 | 0 | 0 | 1 | 0 | 1 | 1 | 1 |
-+--------+---+---+---+---+---+---+---+---+
-
-Step 1 (flip all bits):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 1 | 1 | 1 | 0 | 1 | 0 | 0 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-
-Step 2 (add 1):
-+--------+---+---+---+---+---+---+---+---+
-| index  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
-+--------+---+---+---+---+---+---+---+---+
-|  bits  | 1 | 1 | 1 | 0 | 1 | 0 | 0 | 1 |
-+--------+---+---+---+---+---+---+---+---+
-```
 
 The steps are the same when converting from a negative number to its positive counterpart.
 
@@ -107,7 +71,7 @@ There's also a `inc` instruction, that simply sums 1 to the value in the destina
 inc dest ; dest = dest + 1
 ```
 
-It's important to notice that the sum of two integers operates in the same way for both unsigned and signed numbers.
+The sum of two integers operates in the same way for both unsigned and signed numbers.
 
 ## Subtraction
 
@@ -153,8 +117,8 @@ So, for instance, if two 32-bit numbers are being multiplied, `eax` and `edx` wi
 
 The exception is the multiplication between two bytes.
 
-In this case, instead of `dl:al`, `ah` will be used.
-The lower portion of `ah` (`al`) will get the lower 8-bits of the product, while the upper portion (`ah`) will get the upper 8-bits.
+In this case, instead of `dl:al`, `ax` will be used.
+The lower portion of `ax` (`al`) will get the lower 8-bits of the product, while the upper portion (`ah`) will get the upper 8-bits.
 
 ### Two-operand form
 

--- a/concepts/integers/links.json
+++ b/concepts/integers/links.json
@@ -12,35 +12,7 @@
     "description": "Wikipedia Entry for Two's Complement"
   },
   {
-    "url": "https://www.felixcloutier.com/x86/neg",
-    "description": "Reference for the NEG instruction"
-  },
-  {
-    "url": "https://www.felixcloutier.com/x86/adc",
-    "description": "Reference for the ADC instruction"
-  },
-  {
-    "url": "https://www.felixcloutier.com/x86/inc",
-    "description": "Reference for the INC instruction"
-  },
-  {
-    "url": "https://www.felixcloutier.com/x86/dec",
-    "description": "Reference for the DEC instruction"
-  },
-  {
-    "url": "https://www.felixcloutier.com/x86/mul",
-    "description": "Reference for the MUL instruction"
-  },
-  {
-    "url": "https://www.felixcloutier.com/x86/idiv",
-    "description": "Reference for the IDIV instruction"
-  },
-  {
-    "url": "https://www.felixcloutier.com/x86/div",
-    "description": "Reference for the DIV instruction"
-  },
-  {
-    "url": "https://www.felixcloutier.com/x86/cwd:cdq:cqo",
-    "description": "Reference for the CWD, CDQ and CQO instructions"
+    "url": "https://www.felixcloutier.com/x86",
+    "description": "Reference for x86-64 instructions"
   }
 ]

--- a/concepts/memory/about.md
+++ b/concepts/memory/about.md
@@ -35,12 +35,12 @@ Each of these is separated with a space from the other and the label might optio
 
 The main directives and their related data sizes are:
 
-| directive | size |
-|:---------:|:-----|
-| db | 1 byte  |
-| dw | 2 bytes |
-| dd | 4 bytes |
-| dq | 8 bytes |
+| directive | size    |
+|:---------:|:--------|
+| db        | 1 byte  |
+| dw        | 2 bytes |
+| dd        | 4 bytes |
+| dq        | 8 bytes |
 
 For instance, this declares a byte variable named `space` with the value `10`:
 
@@ -69,12 +69,12 @@ Each of these is separated with a space from the other.
 
 The main directives and their related data sizes are:
 
-| directive | size |
-|:---------:|:-----|
-| resb | 1 byte  |
-| resw | 2 bytes |
-| resd | 4 bytes |
-| resq | 8 bytes |
+| directive | size    |
+|:---------:|:--------|
+| resb      | 1 byte  |
+| resw      | 2 bytes |
+| resd      | 4 bytes |
+| resq      | 8 bytes |
 
 For instance, this reserves uninitialized space for `3` bytes in a variable named `example`:
 
@@ -134,12 +134,12 @@ In those cases, a prefix specifying this size must be used.
 
 These are the most important prefixes and their sizes in a typical x86-64 program:
 
-| prefix | size |
-|:-------|:-----|
-| byte  | 1 byte  |
-| word  | 2 bytes |
-| dword | 4 bytes |
-| qword | 8 bytes |
+| prefix | size    |
+|:-------|:--------|
+| byte   | 1 byte  |
+| word   | 2 bytes |
+| dword  | 4 bytes |
+| qword  | 8 bytes |
 
 The last example can be rewritten with the size prefix:
 

--- a/concepts/memory/about.md
+++ b/concepts/memory/about.md
@@ -1,14 +1,30 @@
 # About
 
-## Data sections
+Memory is usually allocated for the program by the Operational System (OS) in a general layout:
 
-Although most computations in x86-64 are performed with registers, there are many programs which require additional memory.
-It is then crucial to be able to reserve and declare data variables.
+```
++------------------------+
+| high |     stack       |
+|      |      ...        |
+|      |     heap        |
+|      |   section .bss  |
+|      |   section .data |
+|      |   section .text |
+| low  |    reserved     |
++------+-----------------+
+```
 
-In order to do that, three main `sections` may be used: `.data`, `.rodata` and `.bss`.
+Other sections may be available to use, depending on the assembler and OS.
+
+The functions we have defined until now were all in `section .text`.
+This section holds read-only executable data.
+
+Other sections are used to declare data variables, that may be read-only, write-only or read-and-write.
 
 Data variables declared in any of these sections are accessible from any function in the same source file.
 They also persist across the entire duration of the program.
+
+## Sections
 
 ### Section .data
 
@@ -19,19 +35,12 @@ Each of these is separated with a space from the other and the label might optio
 
 The main directives and their related data sizes are:
 
-```
-+-----------+-----------+
-| directive |   size    |
-+-----------+-----------+
-|    db     |   1 byte  |
-+-----------+-----------+
-|    dw     |   2 bytes |
-+-----------+-----------+
-|    dd     |   4 bytes |
-+-----------+-----------+
-|    dq     |   8 bytes |
-+-----------+-----------+
-```
+| directive | size |
+|:---------:|:-----|
+| db | 1 byte  |
+| dw | 2 bytes |
+| dd | 4 bytes |
+| dq | 8 bytes |
 
 For instance, this declares a byte variable named `space` with the value `10`:
 
@@ -40,39 +49,32 @@ section .data
     space db 10
 ```
 
-Variables declared in `section .data` are mutable.
+Variables declared in `section .data` are mutable, ie, they are read-and-write.
 
 ### Section .rodata
 
 The `section .rodata` is similar to `section .data`.
 Both sections contain initialized data, which is declared in the same way.
 
-The main difference between them is that data variables in `section .rodata` are immutable (read-only).
+The main difference between them is that data variables in `section .rodata` are immutable, ie, they are read-only.
 
 ### Section .bss
 
 Uninitialized data is declared in the section [.bss][bss].
 
-On most platforms, this data is filled with zero by the Operational System (OS) at the start of the program.
+On most platforms, this data is filled with zero by the OS at the start of the program.
 
 In NASM, an uninitialized variable has a name (`label`), a directive that indicates data size and the number of elements to be reserved.
 Each of these is separated with a space from the other.
 
 The main directives and their related data sizes are:
 
-```
-+-----------+-----------+
-| directive |   size    |
-+-----------+-----------+
-|   resb    |   1 byte  |
-+-----------+-----------+
-|   resw    |   2 bytes |
-+-----------+-----------+
-|   resd    |   4 bytes |
-+-----------+-----------+
-|   resq    |   8 bytes |
-+-----------+-----------+
-```
+| directive | size |
+|:---------:|:-----|
+| resb | 1 byte  |
+| resw | 2 bytes |
+| resd | 4 bytes |
+| resq | 8 bytes |
 
 For instance, this reserves uninitialized space for `3` bytes in a variable named `example`:
 
@@ -88,7 +90,7 @@ section .bss
     arr resq 10
 ```
 
-Variables in `section .bss` are mutable.
+Variables in `section .bss` are mutable, ie, they are read-and-write.
 
 ## Accessing data
 
@@ -132,18 +134,23 @@ In those cases, a prefix specifying this size must be used.
 
 These are the most important prefixes and their sizes in a typical x86-64 program:
 
-```
-+-------------+-------------+
-|   prefix    |     size    |
-+-------------+-------------+
-|   byte      |    1 byte   |
-+-------------+-------------+
-|   word      |    2 bytes  |
-+-------------+-------------+
-|   dword     |    4 bytes  |
-+-------------+-------------+
-|   qword     |    8 bytes  |
-+-------------+-------------+
+| prefix | size |
+|:-------|:-----|
+| byte  | 1 byte  |
+| word  | 2 bytes |
+| dword | 4 bytes |
+| qword | 8 bytes |
+
+The last example can be rewritten with the size prefix:
+
+```nasm
+section .data
+    example dq 27 ; this declares a 8-byte variable initialized with 27
+
+section .text
+fn:
+    mov rax, qword [example] ; this dereferences example and access the value stored in memory (27)
+    ...
 ```
 
 It's good practice to always use a prefix when dereferencing memory.
@@ -153,7 +160,14 @@ It's good practice to always use a prefix when dereferencing memory.
 Any data in assembly is a sequence of bytes.
 This means that any data can be viewed as an [array][array] of those underlying bytes.
 
-In order to access any byte after the first, a 0-indexed offset must be added to the base address:
+In order to access any byte after the first, it is necessary to compute its effective address.
+An effective address is an expression that may consist of:
+
+- a base address, for instance, the one indicated by the label of a variable;
+- one index register scaled by `1`, `2`, `4` or `8`; and
+- a signed 32-bit displacement.
+
+Notice that this address is 0-indexed, so that a base address, without any offset, points to the first byte of a variable.
 
 ```nasm
 section .data
@@ -163,8 +177,9 @@ section .data
 
 section .text
 fn:
-    mov al, byte [example + 2] ; this accesses the third byte in example
-    mov edx, dword [example + 1] ; this accesses 4 bytes starting at byte offset 1
+    mov al, byte [example] ; this accesses the first byte
+    mov r8b, byte [example + 2] ; this accesses the third byte
+    mov edx, dword [example + 1] ; this accesses 4 bytes starting at the second
 ```
 
 An initialized variable declared with a list of values is an array of those values, each element having the size specified.
@@ -178,22 +193,15 @@ section .data
                             ; the value 4 is a qword that can be accessed at index 0 (the first byte)
                             ; the value 8 is a qword that can be accessed at index 8, since each element occupy 8 bytes
                             ; elements 15, 23 and 42 can be accessed at indexes 16, 24 and 32, respectively
-```
 
-When accessing data in memory, offsets added to the base address may include:
-
-- one index register scaled by `1`, `2`, `4`, or `8`; and
-
-- a signed 32‑bit displacement.
-
-For instance:
-
-```nasm
-mov rdx, 5
-mov rcx, qword [variable + 8*rdx + 10] ; rdx is an index register scaled by 8
-                                       ; 10 is a signed 32-bit displacement
-                                       ; rcx now holds 8-bytes stored in the 'variable' array starting at offset:
-                                       ; 8*rdx(5) + 10 = 40 + 10 = 50
+section .text
+fn:
+    mov rdx, 2
+    mov rcx, qword [arr + 8*rdx + 8]  ; rdx is an index register scaled by 8
+                                      ; 8 is a signed 32-bit displacement
+                                      ; rcx now holds 8-bytes stored in 'arr' starting at offset:
+                                      ; 8*rdx(2) + 8 = 16 + 8 = 24
+                                      ; this is the fourth element of the array, ie, the element 23
 ```
 
 ### The Lea instruction

--- a/concepts/memory/introduction.md
+++ b/concepts/memory/introduction.md
@@ -35,12 +35,12 @@ Each of these is separated with a space from the other and the label might optio
 
 The main directives and their related data sizes are:
 
-| directive | size |
-|:---------:|:-----|
-| db | 1 byte  |
-| dw | 2 bytes |
-| dd | 4 bytes |
-| dq | 8 bytes |
+| directive | size    |
+|:---------:|:--------|
+| db        | 1 byte  |
+| dw        | 2 bytes |
+| dd        | 4 bytes |
+| dq        | 8 bytes |
 
 For instance, this declares a byte variable named `space` with the value `10`:
 
@@ -69,12 +69,12 @@ Each of these is separated with a space from the other.
 
 The main directives and their related data sizes are:
 
-| directive | size |
-|:---------:|:-----|
-| resb | 1 byte  |
-| resw | 2 bytes |
-| resd | 4 bytes |
-| resq | 8 bytes |
+| directive | size    |
+|:---------:|:--------|
+| resb      | 1 byte  |
+| resw      | 2 bytes |
+| resd      | 4 bytes |
+| resq      | 8 bytes |
 
 For instance, this reserves uninitialized space for `3` bytes in a variable named `example`:
 
@@ -133,12 +133,12 @@ In those cases, a prefix specifying this size must be used.
 
 These are the most important prefixes and their sizes in a typical x86-64 program:
 
-| prefix | size |
-|:-------|:-----|
-| byte  | 1 byte  |
-| word  | 2 bytes |
-| dword | 4 bytes |
-| qword | 8 bytes |
+| prefix | size    |
+|:-------|:--------|
+| byte   | 1 byte  |
+| word   | 2 bytes |
+| dword  | 4 bytes |
+| qword  | 8 bytes |
 
 The last example can be rewritten with the size prefix:
 

--- a/concepts/memory/introduction.md
+++ b/concepts/memory/introduction.md
@@ -1,14 +1,30 @@
 # Introduction
 
-## Data sections
+Memory is usually allocated for the program by the Operational System (OS) in a general layout:
 
-Although most computations in x86-64 are performed with registers, there are many programs which require additional memory.
-It is then crucial to be able to reserve and declare data variables.
+```
++------------------------+
+| high |     stack       |
+|      |      ...        |
+|      |     heap        |
+|      |   section .bss  |
+|      |   section .data |
+|      |   section .text |
+| low  |    reserved     |
++------+-----------------+
+```
 
-In order to do that, three main `sections` may be used: `.data`, `.rodata` and `.bss`.
+Other sections may be available to use, depending on the assembler and OS.
+
+The functions we have defined until now were all in `section .text`.
+This section holds read-only executable data.
+
+Other sections are used to declare data variables, that may be read-only, write-only or read-and-write.
 
 Data variables declared in any of these sections are accessible from any function in the same source file.
 They also persist across the entire duration of the program.
+
+## Sections
 
 ### Section .data
 
@@ -19,19 +35,12 @@ Each of these is separated with a space from the other and the label might optio
 
 The main directives and their related data sizes are:
 
-```
-+-----------+-----------+
-| directive |   size    |
-+-----------+-----------+
-|    db     |   1 byte  |
-+-----------+-----------+
-|    dw     |   2 bytes |
-+-----------+-----------+
-|    dd     |   4 bytes |
-+-----------+-----------+
-|    dq     |   8 bytes |
-+-----------+-----------+
-```
+| directive | size |
+|:---------:|:-----|
+| db | 1 byte  |
+| dw | 2 bytes |
+| dd | 4 bytes |
+| dq | 8 bytes |
 
 For instance, this declares a byte variable named `space` with the value `10`:
 
@@ -40,39 +49,32 @@ section .data
     space db 10
 ```
 
-Variables declared in `section .data` are mutable.
+Variables declared in `section .data` are mutable, ie, they are read-and-write.
 
 ### Section .rodata
 
 The `section .rodata` is similar to `section .data`.
 Both sections contain initialized data, which is declared in the same way.
 
-The main difference between them is that data variables in `section .rodata` are immutable (read-only).
+The main difference between them is that data variables in `section .rodata` are immutable, ie, they are read-only.
 
 ### Section .bss
 
 Uninitialized data is declared in the `section .bss`.
 
-On most platforms, this data is filled with zero by the Operational System (OS) at the start of the program.
+On most platforms, this data is filled with zero by the OS at the start of the program.
 
 In NASM, an uninitialized variable has a name (`label`), a directive that indicates data size and the number of elements to be reserved.
 Each of these is separated with a space from the other.
 
 The main directives and their related data sizes are:
 
-```
-+-----------+-----------+
-| directive |   size    |
-+-----------+-----------+
-|   resb    |   1 byte  |
-+-----------+-----------+
-|   resw    |   2 bytes |
-+-----------+-----------+
-|   resd    |   4 bytes |
-+-----------+-----------+
-|   resq    |   8 bytes |
-+-----------+-----------+
-```
+| directive | size |
+|:---------:|:-----|
+| resb | 1 byte  |
+| resw | 2 bytes |
+| resd | 4 bytes |
+| resq | 8 bytes |
 
 For instance, this reserves uninitialized space for `3` bytes in a variable named `example`:
 
@@ -88,7 +90,7 @@ section .bss
     arr resq 10
 ```
 
-Variables in `section .bss` are mutable.
+Variables in `section .bss` are mutable, ie, they are read-and-write.
 
 ## Accessing data
 
@@ -131,18 +133,23 @@ In those cases, a prefix specifying this size must be used.
 
 These are the most important prefixes and their sizes in a typical x86-64 program:
 
-```
-+-------------+-------------+
-|   prefix    |     size    |
-+-------------+-------------+
-|   byte      |    1 byte   |
-+-------------+-------------+
-|   word      |    2 bytes  |
-+-------------+-------------+
-|   dword     |    4 bytes  |
-+-------------+-------------+
-|   qword     |    8 bytes  |
-+-------------+-------------+
+| prefix | size |
+|:-------|:-----|
+| byte  | 1 byte  |
+| word  | 2 bytes |
+| dword | 4 bytes |
+| qword | 8 bytes |
+
+The last example can be rewritten with the size prefix:
+
+```nasm
+section .data
+    example dq 27 ; this declares a 8-byte variable initialized with 27
+
+section .text
+fn:
+    mov rax, qword [example] ; this dereferences example and access the value stored in memory (27)
+    ...
 ```
 
 It's good practice to always use a prefix when dereferencing memory.
@@ -152,7 +159,14 @@ It's good practice to always use a prefix when dereferencing memory.
 Any data in assembly is a sequence of bytes.
 This means that any data can be viewed as an `array` of those underlying bytes.
 
-In order to access any byte after the first, a 0-indexed offset must be added to the base address:
+In order to access any byte after the first, it is necessary to compute its effective address.
+An effective address is an expression that may consist of:
+
+- a base address, for instance, the one indicated by the label of a variable;
+- one index register scaled by `1`, `2`, `4` or `8`; and
+- a signed 32-bit displacement.
+
+Notice that this address is 0-indexed, so that a base address, without any offset, points to the first byte of a variable.
 
 ```nasm
 section .data
@@ -162,8 +176,9 @@ section .data
 
 section .text
 fn:
-    mov al, byte [example + 2] ; this accesses the third byte in example
-    mov edx, dword [example + 1] ; this accesses 4 bytes starting at byte offset 1
+    mov al, byte [example] ; this accesses the first byte
+    mov r8b, byte [example + 2] ; this accesses the third byte
+    mov edx, dword [example + 1] ; this accesses 4 bytes starting at the second
 ```
 
 An initialized variable declared with a list of values is an array of those values, each element having the size specified.
@@ -177,22 +192,15 @@ section .data
                             ; the value 4 is a qword that can be accessed at index 0 (the first byte)
                             ; the value 8 is a qword that can be accessed at index 8, since each element occupy 8 bytes
                             ; elements 15, 23 and 42 can be accessed at indexes 16, 24 and 32, respectively
-```
 
-When accessing data in memory, offsets added to the base address may include:
-
-- one index register scaled by `1`, `2`, `4`, or `8`; and
-
-- a signed 32‑bit displacement.
-
-For instance:
-
-```nasm
-mov rdx, 5
-mov rcx, qword [variable + 8*rdx + 10] ; rdx is an index register scaled by 8
-                                       ; 10 is a signed 32-bit displacement
-                                       ; rcx now holds 8-bytes stored in the 'variable' array starting at offset:
-                                       ; 8*rdx(5) + 10 = 40 + 10 = 50
+section .text
+fn:
+    mov rdx, 2
+    mov rcx, qword [arr + 8*rdx + 8]  ; rdx is an index register scaled by 8
+                                      ; 8 is a signed 32-bit displacement
+                                      ; rcx now holds 8-bytes stored in 'arr' starting at offset:
+                                      ; 8*rdx(2) + 8 = 16 + 8 = 24
+                                      ; this is the fourth element of the array, ie, the element 23
 ```
 
 ### The Lea instruction

--- a/concepts/recursion/about.md
+++ b/concepts/recursion/about.md
@@ -76,15 +76,15 @@ It seems as if `times_three` is just a local label inside of `triple_of_square`.
 In reality, there's no essential difference between any local label and a function.
 x86-64 assembly does not give special treatment to any of them, they are just addresses in the `section .text`.
 
-In this way, a tail recursive function can be thought of being essentially a loop, while a base case is a condition that ends this loop.
+In this way, a tail recursive function can be thought of being similar to a loop, while a base case would be a condition that ends this loop.
 
 ~~~~exercism/note
+
 A `tail call` can only be used if a function does not perform any more work after calling another.
 Many recursive functions are not naturally tail recursive.
 
 However, in some situations, a tail-recursive helper may be defined, so that the main function does some work before or after this helper and the "recursion" occurs in the helper function.
 
-This is essentially equivalent to defining a loop inside the function.
 ~~~~
 
 [recursion]: https://en.wikipedia.org/wiki/Recursion_%28computer_science%29

--- a/concepts/recursion/introduction.md
+++ b/concepts/recursion/introduction.md
@@ -76,4 +76,4 @@ It seems as if `times_three` is just a local label inside of `triple_of_square`.
 In reality, there's no essential difference between any local label and a function.
 Assembly does not give special treatment to any of them, they are just addresses in the `section .text`.
 
-In this way, a tail recursive function can be thought of being essentially a loop, while a base case is a condition that ends this loop.
+In this way, a tail recursive function can be thought of being similar to a loop, while a base case would be a condition that ends this loop.

--- a/concepts/stack/about.md
+++ b/concepts/stack/about.md
@@ -1,19 +1,5 @@
 # About
 
-Memory is usually allocated for the program by the OS in a general layout:
-
-```
-+-----------------+
-| high |  stack   |
-|      |   ...    |
-|      |  heap    |
-|      |  .bss    |
-|      |  .data   |
-|      |  .text   |
-| low  | reserved |
-+------+----------+
-```
-
 The [stack][stack] is a special data structure that starts at the highest point in memory and grows downward.
 
 ## Push and Pop

--- a/concepts/stack/links.json
+++ b/concepts/stack/links.json
@@ -4,12 +4,8 @@
     "description": "Wikipedia Entry for the Stack"
   },
   {
-    "url": "https://www.felixcloutier.com/x86/push",
-    "description": "Reference for the PUSH instruction"
-  },
-  {
-    "url": "https://www.felixcloutier.com/x86/pop",
-    "description": "Reference for the POP instruction"
+    "url": "https://www.felixcloutier.com/x86",
+    "description": "Reference for x86-64 instructions"
   },
   {
     "url": "https://www.uclibc.org/docs/psABI-x86_64.pdf",

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -40,12 +40,12 @@ They usually expect the source to be a memory location in `rsi` and the destinat
 Many of those instructions are actually a family of related instructions, each operating on a different size.
 In those cases, a suffix is appended to indicate this size:
 
-| prefix | size |
-|:------:|:-----|
-| b | 1 byte  |
-| w | 2 bytes |
-| d | 4 bytes |
-| q | 8 bytes |
+| prefix | size    |
+|:------:|:--------|
+| b      | 1 byte  |
+| w      | 2 bytes |
+| d      | 4 bytes |
+| q      | 8 bytes |
 
 Those instructions modify the register(s) used according to the value of the `direction flag (DF)`.
 

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -11,6 +11,7 @@ The last bit (the most significant) is cleared.
 NASM, the assembler used by the track, also supports [UTF-8][utf8] encoding.
 
 ~~~~exercism/note
+
 In x86-64, there's no difference between a character and a number.
 
 For instance, the character '0' is a byte with the value 48.
@@ -21,6 +22,7 @@ mov al, '0' ; al has the value 48
 mov cl, 48  ; cl has the value '0'
 ; al and cl now have the same value
 ```
+
 ~~~~
 
 ## Strings
@@ -38,19 +40,12 @@ They usually expect the source to be a memory location in `rsi` and the destinat
 Many of those instructions are actually a family of related instructions, each operating on a different size.
 In those cases, a suffix is appended to indicate this size:
 
-```
-+--------+----------+
-| prefix |   size   |
-+--------+----------+
-|   b    |  1 byte  |
-+--------+----------+
-|   w    |  2 bytes |
-+--------+----------+
-|   d    |  4 bytes |
-+--------+----------+
-|   q    |  8 bytes |
-+--------+----------+
-```
+| prefix | size |
+|:------:|:-----|
+| b | 1 byte  |
+| w | 2 bytes |
+| d | 4 bytes |
+| q | 8 bytes |
 
 Those instructions modify the register(s) used according to the value of the `direction flag (DF)`.
 

--- a/concepts/strings/introduction.md
+++ b/concepts/strings/introduction.md
@@ -23,12 +23,12 @@ They usually expect the source to be a memory location in `rsi` and the destinat
 Many of those instructions are actually a family of related instructions, each operating on a different size.
 In those cases, a suffix is appended to indicate this size:
 
-| prefix | size |
-|:------:|:-----|
-| b | 1 byte  |
-| w | 2 bytes |
-| d | 4 bytes |
-| q | 8 bytes |
+| prefix | size    |
+|:------:|:--------|
+| b      | 1 byte  |
+| w      | 2 bytes |
+| d      | 4 bytes |
+| q      | 8 bytes |
 
 Those instructions modify the register(s) used according to the value of the `direction flag (DF)`.
 

--- a/concepts/strings/introduction.md
+++ b/concepts/strings/introduction.md
@@ -23,19 +23,12 @@ They usually expect the source to be a memory location in `rsi` and the destinat
 Many of those instructions are actually a family of related instructions, each operating on a different size.
 In those cases, a suffix is appended to indicate this size:
 
-```
-+--------+----------+
-| prefix |   size   |
-+--------+----------+
-|   b    |  1 byte  |
-+--------+----------+
-|   w    |  2 bytes |
-+--------+----------+
-|   d    |  4 bytes |
-+--------+----------+
-|   q    |  8 bytes |
-+--------+----------+
-```
+| prefix | size |
+|:------:|:-----|
+| b | 1 byte  |
+| w | 2 bytes |
+| d | 4 bytes |
+| q | 8 bytes |
 
 Those instructions modify the register(s) used according to the value of the `direction flag (DF)`.
 


### PR DESCRIPTION
Memory layout was moved from "stack" to "memory".

A new entry was added for calling conventions  in "floating-point numbers".

Links for instructions references were all condensed in a single one per concept.

Wherever possible and with good result, tables and table-like representations (for example, bits in integers) were formatted as markdown tables. This makes them responsive to different screen sizes and their appearance is automatically handled by the browser.

Memory layout image (in "memory") and size for registers image (in "basics") remain ASCII-like. I'll check if there's a good way to substitute them for SVG images.

Various clarifications and corrections in all concepts. 

----

Although there might be some splitting of contents in order to make them smaller, I'm satisfied with the overall scope of things already produced.

There's no mention to CMOV and SET because I'm still thinking if they should be placed in "conditionals" or moved to a standalone concept.