### PR TITLE
add array concept

### DIFF
--- a/concepts/arrays/.meta/config.json
+++ b/concepts/arrays/.meta/config.json
@@ -1,0 +1,6 @@
+{
+  "blurb": "Sequences of contiguous bytes in x86-64 assembly",
+  "authors": [
+    "oxe-i"
+  ]
+}

--- a/concepts/arrays/about.md
+++ b/concepts/arrays/about.md
@@ -1,0 +1,112 @@
+# About
+
+Any data in assembly is a sequence of bytes.
+This means that any data can be viewed as an **[array][array]** of those underlying bytes.
+
+## Accessing elements in an array
+
+In order to access any value in memory, it is necessary to compute its **effective address**.
+
+An effective address is an expression that may consist of:
+
+- a _base address_, for instance, the one indicated by the label of a variable.
+- one _index register_, possibly scaled by `1`, `2`, `4` or `8`.
+- a signed 32-bit _displacement_, which is a number to be added to (or subtracted from) the base address.
+
+Notice that this address is _0-indexed_, so that a base address, without any offset, points to the first byte of a variable.
+This is why dereferencing memory using just a label, without any offset, yields a value starting at its first byte.
+
+```nasm
+section .data
+    example dq 10 ; example is a 8-byte variable
+                  ; so it can be viewed as an array of those 8 bytes
+                  ; which can be accessed from index 0 to index 7
+
+section .text
+fn:
+    mov al, byte [example] ; this accesses the first byte
+    mov r8b, byte [example + 2] ; this accesses the third byte
+    mov edx, dword [example + 1] ; this accesses 4 bytes starting at the second
+```
+
+An initialized variable declared with a list of values is an array of those values, each element having the size specified.
+However, offsets are always for _bytes_, even when each element in the array has a greater size:
+
+```nasm
+section .data
+    arr dq 4, 8, 15, 23, 42 ; this defines an array of 5 qwords (8-byte elements)
+                            ; the first qword has value 4 and can be accessed at [arr] (offset 0)
+                            ; any subsequent qword can be accessed at offsets increasing by the size in bytes of each element (8)
+
+section .text
+fn:
+    mov rdx, 2
+    mov rcx, qword [arr + 8*rdx + 8]  ; rdx is an index register scaled by 8
+                                      ; 8 is a signed 32-bit displacement
+                                      ; rcx now holds 8-bytes stored in 'arr' starting at offset:
+                                      ; 8*rdx(2) + 8 = 16 + 8 = 24
+                                      ; this is the fourth element of the array, ie, the element 23
+```
+
+## Section .bss
+
+Uninitialized data is declared in the **[section .bss][bss]**.
+
+On most platforms, this data is filled with zero by the OS at the start of the program.
+
+In NASM, an uninitialized variable has a name, a directive that indicates data size and the number of elements to be reserved.
+Each of these is separated with a space from the other.
+
+The main directives and their related data sizes are:
+
+| directive | size    |
+|:---------:|:--------|
+| resb      | 1 byte  |
+| resw      | 2 bytes |
+| resd      | 4 bytes |
+| resq      | 8 bytes |
+
+For instance, this reserves uninitialized space for `3` bytes in a variable named `example`:
+
+```nasm
+section .bss
+    example resb 3
+```
+
+And this reserves uninitialized space for `10` times `8` bytes (so, `80` bytes) in a variable named `arr`:
+
+```nasm
+section .bss
+    arr resq 10
+```
+
+Variables in section .bss are mutable, ie, they are read-and-write.
+
+Unitialized data can be accessed in the same way as initialized data, by using its effective address.
+Similarly, they are also of static storage duration and accessible from any function in the same source file (and, if declared `global`, in other source files as well).
+
+## Accessing array addresses with the Lea instruction
+
+As it was explored in a previous concept, the `lea` instruction computes an effective memory address.
+So, it can be used to compute the address of any element in an array, following the same semantics.
+
+However, in RIP-relative addressing, when you need to form more complex addresses, it is often necessary to load the variable's address into a register first:
+
+```nasm
+lea rax, [rel variable]
+lea rdx, [rax + 8*r10 - 20]
+```
+
+~~~~exercism/note
+One of the advantages of `lea` is that it uses address-calculation arithmetic to compute a value, without actually accessing the memory in that address.
+This makes it useful to do arithmetic computations even when none of the registers holds a memory address:
+
+```nasm
+mov rcx, 3
+mov rdx, 5
+lea rax, [rcx + 8*rdx + 10] ; rax = rcx(3) + 8*rdx(5) + 10 = 3 + 40 + 10 = 53
+```
+~~~~
+
+[array]: https://en.wikipedia.org/wiki/Array_(data_structure)
+[bss]: https://en.wikipedia.org/wiki/.bss

--- a/concepts/arrays/introduction.md
+++ b/concepts/arrays/introduction.md
@@ -1,0 +1,110 @@
+# Introduction
+
+Any data in assembly is a sequence of bytes.
+This means that any data can be viewed as an **array** of those underlying bytes.
+
+## Accessing elements in an array
+
+In order to access any value in memory, it is necessary to compute its **effective address**.
+
+An effective address is an expression that may consist of:
+
+- a _base address_, for instance, the one indicated by the label of a variable.
+- one _index register_, possibly scaled by `1`, `2`, `4` or `8`.
+- a signed 32-bit _displacement_, which is a number to be added to (or subtracted from) the base address.
+
+Notice that this address is _0-indexed_, so that a base address, without any offset, points to the first byte of a variable.
+This is why dereferencing memory using just a label, without any offset, yields a value starting at its first byte.
+
+```nasm
+section .data
+    example dq 10 ; example is a 8-byte variable
+                  ; so it can be viewed as an array of those 8 bytes
+                  ; which can be accessed from index 0 to index 7
+
+section .text
+fn:
+    mov al, byte [example] ; this accesses the first byte
+    mov r8b, byte [example + 2] ; this accesses the third byte
+    mov edx, dword [example + 1] ; this accesses 4 bytes starting at the second
+```
+
+An initialized variable declared with a list of values is an array of those values, each element having the size specified.
+However, offsets are always for **_bytes_**, even when each element in the array has a greater size:
+
+```nasm
+section .data
+    arr dq 4, 8, 15, 23, 42 ; this defines an array of 5 qwords (8-byte elements)
+                            ; the first qword has value 4 and can be accessed at [arr] (offset 0)
+                            ; any subsequent qword can be accessed at offsets increasing by the size in bytes of each element (8)
+
+section .text
+fn:
+    mov rdx, 2
+    lea rax, [rel arr]
+    mov rcx, qword [rax + 8*rdx + 8]  ; rdx is an index register scaled by 8
+                                      ; 8 is a signed 32-bit displacement
+                                      ; rcx now holds 8-bytes stored in 'arr' starting at offset:
+                                      ; 8*rdx(2) + 8 = 16 + 8 = 24
+                                      ; this is the fourth element of the array, ie, the element 23
+```
+
+## Section .bss
+
+Uninitialized data is declared in the **section .bss**.
+
+On most platforms, this data is filled with zero by the OS at the start of the program.
+
+In NASM, an uninitialized variable has a name, a directive that indicates data size and the number of elements to be reserved.
+Each of these is separated with a space from the other.
+
+The main directives and their related data sizes are:
+
+| directive | size    |
+|:---------:|:--------|
+| resb      | 1 byte  |
+| resw      | 2 bytes |
+| resd      | 4 bytes |
+| resq      | 8 bytes |
+
+For instance, this reserves uninitialized space for `3` bytes in a variable named `example`:
+
+```nasm
+section .bss
+    example resb 3
+```
+
+And this reserves uninitialized space for `10` times `8` bytes (so, `80` bytes) in a variable named `arr`:
+
+```nasm
+section .bss
+    arr resq 10
+```
+
+Variables in section .bss are mutable, ie, they are read-and-write.
+
+Unitialized data can be accessed in the same way as initialized data, by using its effective address.
+Similarly, they are also of static storage duration and accessible from any function in the same source file (and, if declared `global`, in other source files as well).
+
+## Accessing array addresses with the Lea instruction
+
+As it was explored in a previous concept, the `lea` instruction computes an effective memory address.
+So, it can be used to compute the address of any element in an array, following the same semantics.
+
+However, in RIP-relative addressing, when you need to form more complex addresses, it is often necessary to load the variable's address into a register first:
+
+```nasm
+lea rax, [rel variable]
+lea rdx, [rax + 8*r10 - 20]
+```
+
+~~~~exercism/note
+One of the advantages of `lea` is that it uses address-calculation arithmetic to compute a value, without actually accessing the memory in that address.
+This makes it useful to do arithmetic computations even when none of the registers holds a memory address:
+
+```nasm
+mov rcx, 3
+mov rdx, 5
+lea rax, [rcx + 8*rdx + 10] ; rax = rcx(3) + 8*rdx(5) + 10 = 3 + 40 + 10 = 53
+```
+~~~~

--- a/concepts/arrays/links.json
+++ b/concepts/arrays/links.json
@@ -1,0 +1,14 @@
+[
+  {
+    "url": "https://en.wikipedia.org/wiki/Array_(data_structure)",
+    "description": "Wikipedia Entry for Arrays"
+  },
+  {
+    "url": "https://en.wikipedia.org/wiki/.bss",
+    "description": "Wikipedia Entry for section .bss"
+  },
+  {
+    "url": "https://www.felixcloutier.com/x86/lea",
+    "description": "Reference for the LEA instruction"
+  }
+]

--- a/concepts/memory/about.md
+++ b/concepts/memory/about.md
@@ -20,11 +20,7 @@ Other sections are used to declare data variables, that may be read-only or read
 Data variables and labels placed in these sections have _static_ storage duration, which means they exist for the entire program runtime.
 They are accessible from any function in the same source file and, if declared `global`, they are accessible from other source files as well.
 
-The stack and the heap will be explored in further concepts.
-
-## Sections
-
-### Section .data
+## Section .data
 
 The initialized data is declared in the **[section .data][data]**.
 
@@ -49,46 +45,12 @@ section .data
 
 Variables declared in section .data are mutable, ie, they are read-and-write.
 
-### Section .rodata
+## Section .rodata
 
 The **section .rodata** is similar to section .data.
 Both sections contain initialized data, which is declared in the same way.
 
 The main difference between them is that data variables in section .rodata are immutable, ie, they are read-only.
-
-### Section .bss
-
-Uninitialized data is declared in the **[section .bss][bss]**.
-
-On most platforms, this data is filled with zero by the OS at the start of the program.
-
-In NASM, an uninitialized variable has a name, a directive that indicates data size and the number of elements to be reserved.
-Each of these is separated with a space from the other.
-
-The main directives and their related data sizes are:
-
-| directive | size    |
-|:---------:|:--------|
-| resb      | 1 byte  |
-| resw      | 2 bytes |
-| resd      | 4 bytes |
-| resq      | 8 bytes |
-
-For instance, this reserves uninitialized space for `3` bytes in a variable named `example`:
-
-```nasm
-section .bss
-    example resb 3
-```
-
-And this reserves uninitialized space for `10` times `8` bytes (so, `80` bytes) in a variable named `arr`:
-
-```nasm
-section .bss
-    arr resq 10
-```
-
-Variables in section .bss are mutable, ie, they are read-and-write.
 
 ## Accessing data
 
@@ -151,74 +113,22 @@ fn:
     ...
 ```
 
-It's good practice to always use a prefix when dereferencing memory.
+It is good practice to always use a prefix when dereferencing memory.
 
-### Arrays
+### The LEA instruction
 
-Any data in assembly is a sequence of bytes.
-This means that any data can be viewed as an **[array][array]** of those underlying bytes.
-
-In order to access any byte after the first, it is necessary to compute its effective address.
-An effective address is an expression that may consist of:
-
-- a base address, for instance, the one indicated by the label of a variable;
-- one index register scaled by `1`, `2`, `4` or `8`; and
-- a signed 32-bit displacement.
-
-Notice that this address is 0-indexed, so that a base address, without any offset, points to the first byte of a variable.
-
-```nasm
-section .data
-    example dq 10 ; example is a 8-byte variable
-                  ; so it can be viewed as an array of those 8 bytes
-                  ; which can be accessed from index 0 to index 7
-
-section .text
-fn:
-    mov al, byte [example] ; this accesses the first byte
-    mov r8b, byte [example + 2] ; this accesses the third byte
-    mov edx, dword [example + 1] ; this accesses 4 bytes starting at the second
-```
-
-An initialized variable declared with a list of values is an array of those values, each element having the size specified.
-The same can be said for uninitialized variables which reserve more than 1 element.
-
-However, offsets are always for *bytes*, even when each element in the array has a greater size:
-
-```nasm
-section .data
-    arr dq 4, 8, 15, 23, 42 ; this declares an array with 5 qwords (8-bytes values), so 40 bytes in total
-                            ; the value 4 is a qword that can be accessed at index 0 (the first byte)
-                            ; the value 8 is a qword that can be accessed at index 8, since each element occupy 8 bytes
-                            ; elements 15, 23 and 42 can be accessed at indexes 16, 24 and 32, respectively
-
-section .text
-fn:
-    mov rdx, 2
-    mov rcx, qword [arr + 8*rdx + 8]  ; rdx is an index register scaled by 8
-                                      ; 8 is a signed 32-bit displacement
-                                      ; rcx now holds 8-bytes stored in 'arr' starting at offset:
-                                      ; 8*rdx(2) + 8 = 16 + 8 = 24
-                                      ; this is the fourth element of the array, ie, the element 23
-```
-
-### The Lea instruction
-
-There's an instruction called **[lea][lea]** which computes an effective memory address and stores that address in the destination register.
+Although a `mov` can be used to store the address of a variable in a register, there is an instruction with this specific purpose: **[lea][lea]**.
 
 This instruction uses a memory-form operand, but it does _not_ read memory.
-Instead, it computes the effective address expression and writes the result in the destination operand.
-
-One of the advantages of `lea` is that it uses address-calculation arithmetic to compute a value.
-This makes it useful to do arithmetic computations even when none of the registers holds a memory address:
+Instead, it computes the effective address expression and writes the result in the destination operand:
 
 ```nasm
-mov rcx, 3
-mov rdx, 5
-lea rax, [rcx + 8*rdx + 10] ; rax = rcx(3) + 8*rdx(5) + 10 = 3 + 40 + 10 = 53
+lea rax, [example] ; this stores the address of 'example' in rax
 ```
 
-### Relative Addressing
+It is more idiomatic to use `lea` to compute and store memory addresses in registers.
+
+## Relative Addressing
 
 When accessing memory locations, the default behavior in NASM is to generate **absolute addresses**.
 This means that the assembler usually produces a fixed memory address.
@@ -241,18 +151,9 @@ mov rax, qword [rel variable]
 
 Relative addressing can also be made the default for a source file with `default rel` at the top.
 
-When you need to form more complex addresses, it's often necessary to load the variable's address into a register first:
-
-```nasm
-lea rax, [rel variable]
-mov rcx, qword [rax + 8*r8 + 4]
-```
-
 All exercises in this track are compiled and linked as PIE, so `rel` should be used to generate RIP-relative addresses.
 
 [pointer]: https://en.wikipedia.org/wiki/Pointer_(computer_programming)
-[array]: https://en.wikipedia.org/wiki/Array_(data_structure)
 [lea]: https://www.felixcloutier.com/x86/lea
 [rel]: https://www.nasm.us/xdoc/2.16.03/html/nasmdoc3.html#section-3.3
-[bss]: https://en.wikipedia.org/wiki/.bss
 [data]: https://en.wikipedia.org/wiki/Data_segment

--- a/concepts/memory/introduction.md
+++ b/concepts/memory/introduction.md
@@ -20,8 +20,6 @@ Other sections are used to declare data variables, that may be read-only or read
 Data variables and labels placed in these sections have _static_ storage duration, which means they exist for the entire program runtime.
 They are accessible from any function in the same source file and, if declared `global`, they are accessible from other source files as well.
 
-The stack and the heap will be explored in further concepts.
-
 ## Sections
 
 ### Section .data
@@ -55,40 +53,6 @@ The **section .rodata** is similar to section .data.
 Both sections contain initialized data, which is declared in the same way.
 
 The main difference between them is that data variables in section .rodata are immutable, ie, they are read-only.
-
-### Section .bss
-
-Uninitialized data is declared in the **section .bss**.
-
-On most platforms, this data is filled with zero by the OS at the start of the program.
-
-In NASM, an uninitialized variable has a name, a directive that indicates data size and the number of elements to be reserved.
-Each of these is separated with a space from the other.
-
-The main directives and their related data sizes are:
-
-| directive | size    |
-|:---------:|:--------|
-| resb      | 1 byte  |
-| resw      | 2 bytes |
-| resd      | 4 bytes |
-| resq      | 8 bytes |
-
-For instance, this reserves uninitialized space for `3` bytes in a variable named `example`:
-
-```nasm
-section .bss
-    example resb 3
-```
-
-And this reserves uninitialized space for `10` times `8` bytes (so, `80` bytes) in a variable named `arr`:
-
-```nasm
-section .bss
-    arr resq 10
-```
-
-Variables in section .bss are mutable, ie, they are read-and-write.
 
 ## Accessing data
 
@@ -152,70 +116,18 @@ fn:
 
 It's good practice to always use a prefix when dereferencing memory.
 
-### Arrays
+### The LEA instruction
 
-Any data in assembly is a sequence of bytes.
-This means that any data can be viewed as an **array** of those underlying bytes.
-
-In order to access any byte after the first, it is necessary to compute its effective address.
-An effective address is an expression that may consist of:
-
-- a base address, for instance, the one indicated by the label of a variable;
-- one index register scaled by `1`, `2`, `4` or `8`; and
-- a signed 32-bit displacement.
-
-Notice that this address is 0-indexed, so that a base address, without any offset, points to the first byte of a variable.
-
-```nasm
-section .data
-    example dq 10 ; example is a 8-byte variable
-                  ; so it can be viewed as an array of those 8 bytes
-                  ; which can be accessed from index 0 to index 7
-
-section .text
-fn:
-    mov al, byte [example] ; this accesses the first byte
-    mov r8b, byte [example + 2] ; this accesses the third byte
-    mov edx, dword [example + 1] ; this accesses 4 bytes starting at the second
-```
-
-An initialized variable declared with a list of values is an array of those values, each element having the size specified.
-The same can be said for uninitialized variables which reserve more than 1 element.
-
-However, offsets are always for *bytes*, even when each element in the array has a greater size:
-
-```nasm
-section .data
-    arr dq 4, 8, 15, 23, 42 ; this declares an array with 5 qwords (8-bytes values), so 40 bytes in total
-                            ; the value 4 is a qword that can be accessed at index 0 (the first byte)
-                            ; the value 8 is a qword that can be accessed at index 8, since each element occupy 8 bytes
-                            ; elements 15, 23 and 42 can be accessed at indexes 16, 24 and 32, respectively
-
-section .text
-fn:
-    mov rdx, 2
-    mov rcx, qword [arr + 8*rdx + 8]  ; rdx is an index register scaled by 8
-                                      ; 8 is a signed 32-bit displacement
-                                      ; rcx now holds 8-bytes stored in 'arr' starting at offset:
-                                      ; 8*rdx(2) + 8 = 16 + 8 = 24
-                                      ; this is the fourth element of the array, ie, the element 23
-```
-
-### The Lea instruction
-
-There's an instruction called `lea` which computes an effective memory address and stores that address in the destination register.
+Although a `mov` can be used to store the address of a variable in a register, there is an instruction with this specific purpose: **[lea][lea]**.
 
 This instruction uses a memory-form operand, but it does _not_ read memory.
-Instead, it computes the effective address expression and writes the result in the destination operand.
-
-One of the advantages of `lea` is that it uses address-calculation arithmetic to compute a value.
-This makes it useful to do arithmetic computations even when none of the registers holds a memory address:
+Instead, it computes the effective address expression and writes the result in the destination operand:
 
 ```nasm
-mov rcx, 3
-mov rdx, 5
-lea rax, [rcx + 8*rdx + 10] ; rax = rcx(3) + 8*rdx(5) + 10 = 3 + 40 + 10 = 53
+lea rax, [example] ; this stores the address of 'example' in rax
 ```
+
+It is more idiomatic to use `lea` to compute and store memory addresses in registers.
 
 ### Relative Addressing
 
@@ -239,12 +151,5 @@ mov rax, qword [rel variable]
 ```
 
 Relative addressing can also be made the default for a source file with `default rel` at the top.
-
-When you need to form more complex addresses, it's often necessary to load the variable's address into a register first:
-
-```nasm
-lea rax, [rel variable]
-mov rcx, qword [rax + 8*r8 + 4]
-```
 
 All exercises in this track are compiled and linked as PIE, so `rel` should be used to generate RIP-relative addresses.

--- a/concepts/memory/links.json
+++ b/concepts/memory/links.json
@@ -4,16 +4,8 @@
     "description": "Wikipedia Entry for section .data"
   },
   {
-    "url": "https://en.wikipedia.org/wiki/.bss",
-    "description": "Wikipedia Entry for section .bss"
-  },
-  {
     "url": "https://en.wikipedia.org/wiki/Pointer_(computer_programming)",
     "description": "Wikipedia Entry for Pointers"
-  },
-  {
-    "url": "https://en.wikipedia.org/wiki/Array_(data_structure)",
-    "description": "Wikipedia Entry for Arrays"
   },
   {
     "url": "https://www.felixcloutier.com/x86/lea",

--- a/config.json
+++ b/config.json
@@ -1071,6 +1071,11 @@
       "uuid": "31e1bb65-3220-41ae-a37c-c95ccec02dfd",
       "slug": "floating-point-numbers",
       "name": "Floating-Point Numbers"
+    },
+    {
+      "uuid": "82534a88-9404-4024-8d9b-9a5d6d23dae4",
+      "slug": "arrays",
+      "name": "Arrays"
     }
   ],
   "key_features": [


### PR DESCRIPTION
Splits the memory concept in two, creating an “array” concept. This reduces the overall length of each (the previous “memory” concept was around 250 lines) and makes corresponding concept exercises (to be implemented next) more focused on a core idea.

Also includes many stylistic changes and some clarity improvements.

It's possible that the array concept exercise will be shared with the loop concept.