### PR TITLE
make `hamming` SIMD-friendly

### DIFF
--- a/exercises/practice/hamming/.meta/example.asm
+++ b/exercises/practice/hamming/.meta/example.asm
@@ -6,37 +6,28 @@
 ;   rsi - strand2
 ; Returns:
 ;   rax - the difference between two DNA strands
+;   -1 if lengths differ
 ;
+
 section .text
 global distance
 distance:
-    xor eax, eax        ; Initialize difference
-
-    cmp byte [rdi], 0   ; Check if strand1 is an empty string
-    je .loop_end        ; If empty, skip loop
-    cmp byte[rsi], 0    ; Check if strand2 is an empty string
-    je .loop_end        ; If empty, skip loop
-.loop_start:
-    mov cl, byte [rdi]  ; Read char from strand1
-    cmp cl, byte [rsi]  ; Compare with char from strand2
-    je .next            ; If equal, process next char
-    inc eax             ; Increment difference
-.next:
-    inc rdi             ; Advance strand1 to next char
-    inc rsi             ; Advance strand2 to next char
-    cmp byte [rdi], 0   ; See if we reached end of strand1
-    je .loop_end        ; If there are no more chars, exit loop
-    cmp byte [rsi], 0   ; See if we reached end of strand2
-    jne .loop_start     ; If chars remain, loop back
-
-.loop_end:
-    mov cl, byte [rdi]  ; Read char from strand1
-    cmp cl, byte [rsi]  ; Compare with char from strand2
-    je .return          ; If equal, return the difference
-
-    mov eax, -1         ; Return -1 to indicate an error
-
-.return:
+    pxor xmm0, xmm0
+    movdqu xmm1, [rdi]
+    movdqu xmm2, [rsi]
+    movdqa xmm3, xmm1
+    pcmpeqb xmm3, xmm0
+    pcmpeqb xmm0, xmm2
+    pcmpeqb xmm1, xmm2
+    pmovmskb ecx, xmm3
+    pmovmskb edx, xmm0
+    pmovmskb eax, xmm1
+    not eax
+    and eax, 0xFFFF
+    popcnt eax, eax
+    mov r8d, -1
+    cmp ecx, edx
+    cmovne eax, r8d
     ret
 
 %ifidn __OUTPUT_FORMAT__,elf64

--- a/exercises/practice/hamming/hamming_test.c
+++ b/exercises/practice/hamming/hamming_test.c
@@ -1,5 +1,7 @@
 #include "vendor/unity.h"
 
+#include <stdalign.h>
+
 #define BUFFER_SIZE 16
 
 extern int distance(const char strand1[], const char strand2[]);
@@ -11,78 +13,78 @@ void tearDown(void) {
 }
 
 void test_empty_strands(void) {
-    const char strand1[BUFFER_SIZE] = "";
-    const char strand2[BUFFER_SIZE] = "";
+    alignas(16) const char strand1[BUFFER_SIZE] = "";
+    alignas(16) const char strand2[BUFFER_SIZE] = "";
     TEST_ASSERT_EQUAL_INT(0, distance(strand1, strand2));
 }
 
 void test_single_letter_identical_strands(void) {
     TEST_IGNORE();
-    const char strand1[BUFFER_SIZE] = "A";
-    const char strand2[BUFFER_SIZE] = "A";
+    alignas(16) const char strand1[BUFFER_SIZE] = "A";
+    alignas(16) const char strand2[BUFFER_SIZE] = "A";
     TEST_ASSERT_EQUAL_INT(0, distance(strand1, strand2));
 }
 
 void test_single_letter_different_strands(void) {
     TEST_IGNORE();
-    const char strand1[BUFFER_SIZE] = "G";
-    const char strand2[BUFFER_SIZE] = "T";
+    alignas(16) const char strand1[BUFFER_SIZE] = "G";
+    alignas(16) const char strand2[BUFFER_SIZE] = "T";
     TEST_ASSERT_EQUAL_INT(1, distance(strand1, strand2));
 }
 
 void test_long_identical_strands(void) {
     TEST_IGNORE();
-    const char strand1[BUFFER_SIZE] = "GGACTGAAATCTG";
-    const char strand2[BUFFER_SIZE] = "GGACTGAAATCTG";
+    alignas(16) const char strand1[BUFFER_SIZE] = "GGACTGAAATCTG";
+    alignas(16) const char strand2[BUFFER_SIZE] = "GGACTGAAATCTG";
     TEST_ASSERT_EQUAL_INT(0, distance(strand1, strand2));
 }
 
 void test_long_different_strands(void) {
     TEST_IGNORE();
-    const char strand1[BUFFER_SIZE] = "GGACGGATTCTG";
-    const char strand2[BUFFER_SIZE] = "AGGACGGATTCT";
+    alignas(16) const char strand1[BUFFER_SIZE] = "GGACGGATTCTG";
+    alignas(16) const char strand2[BUFFER_SIZE] = "AGGACGGATTCT";
     TEST_ASSERT_EQUAL_INT(9, distance(strand1, strand2));
 }
 
 void test_disallow_first_strand_longer(void) {
     TEST_IGNORE();
-    const char strand1[BUFFER_SIZE] = "AATG";
-    const char strand2[BUFFER_SIZE] = "AAA";
+    alignas(16) const char strand1[BUFFER_SIZE] = "AATG";
+    alignas(16) const char strand2[BUFFER_SIZE] = "AAA";
     TEST_ASSERT_EQUAL_INT(-1, distance(strand1, strand2));
 }
 
 void test_disallow_second_strand_longer(void) {
     TEST_IGNORE();
-    const char strand1[BUFFER_SIZE] = "ATA";
-    const char strand2[BUFFER_SIZE] = "AGTG";
+    alignas(16) const char strand1[BUFFER_SIZE] = "ATA";
+    alignas(16) const char strand2[BUFFER_SIZE] = "AGTG";
     TEST_ASSERT_EQUAL_INT(-1, distance(strand1, strand2));
 }
 
 void test_disallow_left_empty_strand(void) {
     TEST_IGNORE();
-    const char strand1[BUFFER_SIZE] = "";
-    const char strand2[BUFFER_SIZE] = "G";
+    alignas(16) const char strand1[BUFFER_SIZE] = "";
+    alignas(16) const char strand2[BUFFER_SIZE] = "G";
     TEST_ASSERT_EQUAL_INT(-1, distance(strand1, strand2));
 }
 
 void test_disallow_empty_first_strand(void) {
     TEST_IGNORE();
-    const char strand1[BUFFER_SIZE] = "";
-    const char strand2[BUFFER_SIZE] = "G";
+    alignas(16) const char strand1[BUFFER_SIZE] = "";
+    alignas(16) const char strand2[BUFFER_SIZE] = "G";
     TEST_ASSERT_EQUAL_INT(-1, distance(strand1, strand2));
 }
 
 void test_disallow_right_empty_strand(void) {
     TEST_IGNORE();
-    const char strand1[BUFFER_SIZE] = "G";
-    const char strand2[BUFFER_SIZE] = "";
+    alignas(16) const char strand1[BUFFER_SIZE] = "G";
+    alignas(16) const char strand2[BUFFER_SIZE] = "";
     TEST_ASSERT_EQUAL_INT(-1, distance(strand1, strand2));
 }
 
 void test_disallow_empty_second_strand(void) {
     TEST_IGNORE();
-    const char strand1[BUFFER_SIZE] = "G";
-    const char strand2[BUFFER_SIZE] = "";
+    alignas(16) const char strand1[BUFFER_SIZE] = "G";
+    alignas(16) const char strand2[BUFFER_SIZE] = "";
     TEST_ASSERT_EQUAL_INT(-1, distance(strand1, strand2));
 }
 

--- a/exercises/practice/hamming/hamming_test.c
+++ b/exercises/practice/hamming/hamming_test.c
@@ -1,6 +1,8 @@
 #include "vendor/unity.h"
 
-extern int distance(const char *strand1, const char *strand2);
+#define BUFFER_SIZE 16
+
+extern int distance(const char strand1[], const char strand2[]);
 
 void setUp(void) {
 }
@@ -9,57 +11,79 @@ void tearDown(void) {
 }
 
 void test_empty_strands(void) {
-    TEST_ASSERT_EQUAL_INT(0, distance("", ""));
+    const char strand1[BUFFER_SIZE] = "";
+    const char strand2[BUFFER_SIZE] = "";
+    TEST_ASSERT_EQUAL_INT(0, distance(strand1, strand2));
 }
 
 void test_single_letter_identical_strands(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(0, distance("A", "A"));
+    const char strand1[BUFFER_SIZE] = "A";
+    const char strand2[BUFFER_SIZE] = "A";
+    TEST_ASSERT_EQUAL_INT(0, distance(strand1, strand2));
 }
 
 void test_single_letter_different_strands(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(1, distance("G", "T"));
+    const char strand1[BUFFER_SIZE] = "G";
+    const char strand2[BUFFER_SIZE] = "T";
+    TEST_ASSERT_EQUAL_INT(1, distance(strand1, strand2));
 }
 
 void test_long_identical_strands(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(0, distance("GGACTGAAATCTG", "GGACTGAAATCTG"));
+    const char strand1[BUFFER_SIZE] = "GGACTGAAATCTG";
+    const char strand2[BUFFER_SIZE] = "GGACTGAAATCTG";
+    TEST_ASSERT_EQUAL_INT(0, distance(strand1, strand2));
 }
 
 void test_long_different_strands(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(9, distance("GGACGGATTCTG", "AGGACGGATTCT"));
+    const char strand1[BUFFER_SIZE] = "GGACGGATTCTG";
+    const char strand2[BUFFER_SIZE] = "AGGACGGATTCT";
+    TEST_ASSERT_EQUAL_INT(9, distance(strand1, strand2));
 }
 
 void test_disallow_first_strand_longer(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(-1, distance("AATG", "AAA"));
+    const char strand1[BUFFER_SIZE] = "AATG";
+    const char strand2[BUFFER_SIZE] = "AAA";
+    TEST_ASSERT_EQUAL_INT(-1, distance(strand1, strand2));
 }
 
 void test_disallow_second_strand_longer(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(-1, distance("ATA", "AGTG"));
+    const char strand1[BUFFER_SIZE] = "ATA";
+    const char strand2[BUFFER_SIZE] = "AGTG";
+    TEST_ASSERT_EQUAL_INT(-1, distance(strand1, strand2));
 }
 
 void test_disallow_left_empty_strand(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(-1, distance("", "G"));
+    const char strand1[BUFFER_SIZE] = "";
+    const char strand2[BUFFER_SIZE] = "G";
+    TEST_ASSERT_EQUAL_INT(-1, distance(strand1, strand2));
 }
 
 void test_disallow_empty_first_strand(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(-1, distance("", "G"));
+    const char strand1[BUFFER_SIZE] = "";
+    const char strand2[BUFFER_SIZE] = "G";
+    TEST_ASSERT_EQUAL_INT(-1, distance(strand1, strand2));
 }
 
 void test_disallow_right_empty_strand(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(-1, distance("G", ""));
+    const char strand1[BUFFER_SIZE] = "G";
+    const char strand2[BUFFER_SIZE] = "";
+    TEST_ASSERT_EQUAL_INT(-1, distance(strand1, strand2));
 }
 
 void test_disallow_empty_second_strand(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(-1, distance("G", ""));
+    const char strand1[BUFFER_SIZE] = "G";
+    const char strand2[BUFFER_SIZE] = "";
+    TEST_ASSERT_EQUAL_INT(-1, distance(strand1, strand2));
 }
 
 int main(void) {

--- a/generators/exercises/hamming.py
+++ b/generators/exercises/hamming.py
@@ -1,6 +1,8 @@
 FUNC_PROTO = """\
 #include "vendor/unity.h"
 
+#include <stdalign.h>
+
 #define BUFFER_SIZE 16
 
 extern int distance(const char strand1[], const char strand2[]);
@@ -10,10 +12,12 @@ extern int distance(const char strand1[], const char strand2[]);
 def gen_func_body(prop, inp, expected):
     strand1 = inp["strand1"]
     strand2 = inp["strand2"]
+    if len(strand1) >= 16 or len(strand2) >= 16:
+        return ""
     if type(expected) is not int:
         expected = -1
     str_list = []
-    str_list.append(f'const char strand1[BUFFER_SIZE] = "{strand1}";')
-    str_list.append(f'const char strand2[BUFFER_SIZE] = "{strand2}";')
+    str_list.append(f'alignas(16) const char strand1[BUFFER_SIZE] = "{strand1}";')
+    str_list.append(f'alignas(16) const char strand2[BUFFER_SIZE] = "{strand2}";')
     str_list.append(f"TEST_ASSERT_EQUAL_INT({expected}, {prop}(strand1, strand2));")
     return "\n".join(str_list)

--- a/generators/exercises/hamming.py
+++ b/generators/exercises/hamming.py
@@ -1,7 +1,9 @@
 FUNC_PROTO = """\
 #include "vendor/unity.h"
 
-extern int distance(const char *strand1, const char *strand2);
+#define BUFFER_SIZE 16
+
+extern int distance(const char strand1[], const char strand2[]);
 """
 
 
@@ -10,4 +12,8 @@ def gen_func_body(prop, inp, expected):
     strand2 = inp["strand2"]
     if type(expected) is not int:
         expected = -1
-    return f'TEST_ASSERT_EQUAL_INT({expected}, {prop}("{strand1}", "{strand2}"));\n'
+    str_list = []
+    str_list.append(f'const char strand1[BUFFER_SIZE] = "{strand1}";')
+    str_list.append(f'const char strand2[BUFFER_SIZE] = "{strand2}";')
+    str_list.append(f"TEST_ASSERT_EQUAL_INT({expected}, {prop}(strand1, strand2));")
+    return "\n".join(str_list)


### PR DESCRIPTION
This makes a small change to `hamming` in order to make the exercise more SIMD-friendly. Instead of passing the strings as `const char *`, they are passed as `const char[16]`, with the guarantee that the buffer is exactly 16 bytes wide. This both ensures a defined value for past-the-end bytes and avoids loads that cross a page boundary.

This change does not break any correct solution because it only adds a few extra NUL bytes after each string. A solution could only break if it somehow depends on one string spilling into another, but that would already be undefined behavior and so such a solution _should_ break.