### PR TITLE
fix bugs in debug.mac

### DIFF
--- a/exercises/concept/bird-watcher/debug.mac
+++ b/exercises/concept/bird-watcher/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/concept/bird-watcher/debug.mac
+++ b/exercises/concept/bird-watcher/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/concept/black-jack/debug.mac
+++ b/exercises/concept/black-jack/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/concept/black-jack/debug.mac
+++ b/exercises/concept/black-jack/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/concept/color-palette/debug.mac
+++ b/exercises/concept/color-palette/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/concept/color-palette/debug.mac
+++ b/exercises/concept/color-palette/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/concept/currency-exchange/debug.mac
+++ b/exercises/concept/currency-exchange/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/concept/currency-exchange/debug.mac
+++ b/exercises/concept/currency-exchange/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/concept/freelancer-rates/debug.mac
+++ b/exercises/concept/freelancer-rates/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/concept/freelancer-rates/debug.mac
+++ b/exercises/concept/freelancer-rates/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/concept/inventory-management/debug.mac
+++ b/exercises/concept/inventory-management/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/concept/inventory-management/debug.mac
+++ b/exercises/concept/inventory-management/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/concept/lasagna/debug.mac
+++ b/exercises/concept/lasagna/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/concept/lasagna/debug.mac
+++ b/exercises/concept/lasagna/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/concept/lost-and-found/debug.mac
+++ b/exercises/concept/lost-and-found/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/concept/lost-and-found/debug.mac
+++ b/exercises/concept/lost-and-found/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/concept/mixed-juices/debug.mac
+++ b/exercises/concept/mixed-juices/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/concept/mixed-juices/debug.mac
+++ b/exercises/concept/mixed-juices/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/concept/need-for-speed/debug.mac
+++ b/exercises/concept/need-for-speed/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/concept/need-for-speed/debug.mac
+++ b/exercises/concept/need-for-speed/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/concept/poetry-club-door-policy/debug.mac
+++ b/exercises/concept/poetry-club-door-policy/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/concept/poetry-club-door-policy/debug.mac
+++ b/exercises/concept/poetry-club-door-policy/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/concept/secrets/debug.mac
+++ b/exercises/concept/secrets/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/concept/secrets/debug.mac
+++ b/exercises/concept/secrets/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/acronym/debug.mac
+++ b/exercises/practice/acronym/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/acronym/debug.mac
+++ b/exercises/practice/acronym/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/affine-cipher/debug.mac
+++ b/exercises/practice/affine-cipher/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/affine-cipher/debug.mac
+++ b/exercises/practice/affine-cipher/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/all-your-base/debug.mac
+++ b/exercises/practice/all-your-base/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/all-your-base/debug.mac
+++ b/exercises/practice/all-your-base/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/allergies/debug.mac
+++ b/exercises/practice/allergies/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/allergies/debug.mac
+++ b/exercises/practice/allergies/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/anagram/debug.mac
+++ b/exercises/practice/anagram/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/anagram/debug.mac
+++ b/exercises/practice/anagram/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/armstrong-numbers/debug.mac
+++ b/exercises/practice/armstrong-numbers/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/armstrong-numbers/debug.mac
+++ b/exercises/practice/armstrong-numbers/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/atbash-cipher/debug.mac
+++ b/exercises/practice/atbash-cipher/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/atbash-cipher/debug.mac
+++ b/exercises/practice/atbash-cipher/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/baffling-birthdays/debug.mac
+++ b/exercises/practice/baffling-birthdays/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/baffling-birthdays/debug.mac
+++ b/exercises/practice/baffling-birthdays/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/binary-search-tree/debug.mac
+++ b/exercises/practice/binary-search-tree/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/binary-search-tree/debug.mac
+++ b/exercises/practice/binary-search-tree/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/binary-search/debug.mac
+++ b/exercises/practice/binary-search/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/binary-search/debug.mac
+++ b/exercises/practice/binary-search/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/bob/debug.mac
+++ b/exercises/practice/bob/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/bob/debug.mac
+++ b/exercises/practice/bob/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/book-store/debug.mac
+++ b/exercises/practice/book-store/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/book-store/debug.mac
+++ b/exercises/practice/book-store/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/bottle-song/debug.mac
+++ b/exercises/practice/bottle-song/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/bottle-song/debug.mac
+++ b/exercises/practice/bottle-song/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/camicia/debug.mac
+++ b/exercises/practice/camicia/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/camicia/debug.mac
+++ b/exercises/practice/camicia/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/change/debug.mac
+++ b/exercises/practice/change/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/change/debug.mac
+++ b/exercises/practice/change/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/circular-buffer/debug.mac
+++ b/exercises/practice/circular-buffer/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/circular-buffer/debug.mac
+++ b/exercises/practice/circular-buffer/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/clock/debug.mac
+++ b/exercises/practice/clock/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/clock/debug.mac
+++ b/exercises/practice/clock/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/collatz-conjecture/debug.mac
+++ b/exercises/practice/collatz-conjecture/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/collatz-conjecture/debug.mac
+++ b/exercises/practice/collatz-conjecture/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/complex-numbers/debug.mac
+++ b/exercises/practice/complex-numbers/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/complex-numbers/debug.mac
+++ b/exercises/practice/complex-numbers/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/crypto-square/debug.mac
+++ b/exercises/practice/crypto-square/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/crypto-square/debug.mac
+++ b/exercises/practice/crypto-square/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/custom-set/debug.mac
+++ b/exercises/practice/custom-set/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/custom-set/debug.mac
+++ b/exercises/practice/custom-set/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/darts/debug.mac
+++ b/exercises/practice/darts/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/darts/debug.mac
+++ b/exercises/practice/darts/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/diamond/debug.mac
+++ b/exercises/practice/diamond/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/diamond/debug.mac
+++ b/exercises/practice/diamond/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/difference-of-squares/debug.mac
+++ b/exercises/practice/difference-of-squares/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/difference-of-squares/debug.mac
+++ b/exercises/practice/difference-of-squares/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/dnd-character/debug.mac
+++ b/exercises/practice/dnd-character/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/dnd-character/debug.mac
+++ b/exercises/practice/dnd-character/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/dominoes/debug.mac
+++ b/exercises/practice/dominoes/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/dominoes/debug.mac
+++ b/exercises/practice/dominoes/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/eliuds-eggs/debug.mac
+++ b/exercises/practice/eliuds-eggs/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/eliuds-eggs/debug.mac
+++ b/exercises/practice/eliuds-eggs/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/etl/debug.mac
+++ b/exercises/practice/etl/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/etl/debug.mac
+++ b/exercises/practice/etl/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/flower-field/debug.mac
+++ b/exercises/practice/flower-field/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/flower-field/debug.mac
+++ b/exercises/practice/flower-field/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/flower-field/flower_field.asm
+++ b/exercises/practice/flower-field/flower_field.asm
@@ -2,4 +2,9 @@ section .text
 global annotate
 
 annotate:
-        ret
+    ; Provide your implementation here
+    ret
+
+%ifidn __OUTPUT_FORMAT__,elf64
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif

--- a/exercises/practice/food-chain/debug.mac
+++ b/exercises/practice/food-chain/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/food-chain/debug.mac
+++ b/exercises/practice/food-chain/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/game-of-life/debug.mac
+++ b/exercises/practice/game-of-life/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/game-of-life/debug.mac
+++ b/exercises/practice/game-of-life/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/gigasecond/debug.mac
+++ b/exercises/practice/gigasecond/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/gigasecond/debug.mac
+++ b/exercises/practice/gigasecond/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/grains/debug.mac
+++ b/exercises/practice/grains/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/grains/debug.mac
+++ b/exercises/practice/grains/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/hamming/debug.mac
+++ b/exercises/practice/hamming/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/hamming/debug.mac
+++ b/exercises/practice/hamming/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/hello-world/debug.mac
+++ b/exercises/practice/hello-world/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/hello-world/debug.mac
+++ b/exercises/practice/hello-world/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/high-scores/debug.mac
+++ b/exercises/practice/high-scores/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/high-scores/debug.mac
+++ b/exercises/practice/high-scores/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/house/debug.mac
+++ b/exercises/practice/house/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/house/debug.mac
+++ b/exercises/practice/house/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/intergalactic-transmission/debug.mac
+++ b/exercises/practice/intergalactic-transmission/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/intergalactic-transmission/debug.mac
+++ b/exercises/practice/intergalactic-transmission/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/isbn-verifier/debug.mac
+++ b/exercises/practice/isbn-verifier/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/isbn-verifier/debug.mac
+++ b/exercises/practice/isbn-verifier/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/isogram/debug.mac
+++ b/exercises/practice/isogram/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/isogram/debug.mac
+++ b/exercises/practice/isogram/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/killer-sudoku-helper/debug.mac
+++ b/exercises/practice/killer-sudoku-helper/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/killer-sudoku-helper/debug.mac
+++ b/exercises/practice/killer-sudoku-helper/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/kindergarten-garden/debug.mac
+++ b/exercises/practice/kindergarten-garden/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/kindergarten-garden/debug.mac
+++ b/exercises/practice/kindergarten-garden/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/knapsack/debug.mac
+++ b/exercises/practice/knapsack/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/knapsack/debug.mac
+++ b/exercises/practice/knapsack/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/largest-series-product/debug.mac
+++ b/exercises/practice/largest-series-product/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/largest-series-product/debug.mac
+++ b/exercises/practice/largest-series-product/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/leap/debug.mac
+++ b/exercises/practice/leap/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/leap/debug.mac
+++ b/exercises/practice/leap/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/line-up/debug.mac
+++ b/exercises/practice/line-up/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/line-up/debug.mac
+++ b/exercises/practice/line-up/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/linked-list/debug.mac
+++ b/exercises/practice/linked-list/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/linked-list/debug.mac
+++ b/exercises/practice/linked-list/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/list-ops/debug.mac
+++ b/exercises/practice/list-ops/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/list-ops/debug.mac
+++ b/exercises/practice/list-ops/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/luhn/debug.mac
+++ b/exercises/practice/luhn/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/luhn/debug.mac
+++ b/exercises/practice/luhn/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/matching-brackets/debug.mac
+++ b/exercises/practice/matching-brackets/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/matching-brackets/debug.mac
+++ b/exercises/practice/matching-brackets/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/matrix/debug.mac
+++ b/exercises/practice/matrix/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/matrix/debug.mac
+++ b/exercises/practice/matrix/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/meetup/debug.mac
+++ b/exercises/practice/meetup/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/meetup/debug.mac
+++ b/exercises/practice/meetup/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/micro-blog/debug.mac
+++ b/exercises/practice/micro-blog/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/micro-blog/debug.mac
+++ b/exercises/practice/micro-blog/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/minesweeper/debug.mac
+++ b/exercises/practice/minesweeper/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/minesweeper/debug.mac
+++ b/exercises/practice/minesweeper/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/nth-prime/debug.mac
+++ b/exercises/practice/nth-prime/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/nth-prime/debug.mac
+++ b/exercises/practice/nth-prime/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/nucleotide-count/debug.mac
+++ b/exercises/practice/nucleotide-count/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/nucleotide-count/debug.mac
+++ b/exercises/practice/nucleotide-count/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/ocr-numbers/debug.mac
+++ b/exercises/practice/ocr-numbers/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/ocr-numbers/debug.mac
+++ b/exercises/practice/ocr-numbers/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/palindrome-products/debug.mac
+++ b/exercises/practice/palindrome-products/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/palindrome-products/debug.mac
+++ b/exercises/practice/palindrome-products/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/pangram/debug.mac
+++ b/exercises/practice/pangram/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/pangram/debug.mac
+++ b/exercises/practice/pangram/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/pascals-triangle/debug.mac
+++ b/exercises/practice/pascals-triangle/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/pascals-triangle/debug.mac
+++ b/exercises/practice/pascals-triangle/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/perfect-numbers/debug.mac
+++ b/exercises/practice/perfect-numbers/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/perfect-numbers/debug.mac
+++ b/exercises/practice/perfect-numbers/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/phone-number/debug.mac
+++ b/exercises/practice/phone-number/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/phone-number/debug.mac
+++ b/exercises/practice/phone-number/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/pig-latin/debug.mac
+++ b/exercises/practice/pig-latin/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/pig-latin/debug.mac
+++ b/exercises/practice/pig-latin/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/prime-factors/debug.mac
+++ b/exercises/practice/prime-factors/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/prime-factors/debug.mac
+++ b/exercises/practice/prime-factors/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/protein-translation/debug.mac
+++ b/exercises/practice/protein-translation/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/protein-translation/debug.mac
+++ b/exercises/practice/protein-translation/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/proverb/debug.mac
+++ b/exercises/practice/proverb/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/proverb/debug.mac
+++ b/exercises/practice/proverb/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/pythagorean-triplet/debug.mac
+++ b/exercises/practice/pythagorean-triplet/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/pythagorean-triplet/debug.mac
+++ b/exercises/practice/pythagorean-triplet/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/queen-attack/debug.mac
+++ b/exercises/practice/queen-attack/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/queen-attack/debug.mac
+++ b/exercises/practice/queen-attack/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/rail-fence-cipher/debug.mac
+++ b/exercises/practice/rail-fence-cipher/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/rail-fence-cipher/debug.mac
+++ b/exercises/practice/rail-fence-cipher/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/raindrops/debug.mac
+++ b/exercises/practice/raindrops/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/raindrops/debug.mac
+++ b/exercises/practice/raindrops/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/rational-numbers/debug.mac
+++ b/exercises/practice/rational-numbers/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/rational-numbers/debug.mac
+++ b/exercises/practice/rational-numbers/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/resistor-color-duo/debug.mac
+++ b/exercises/practice/resistor-color-duo/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/resistor-color-duo/debug.mac
+++ b/exercises/practice/resistor-color-duo/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/resistor-color-trio/debug.mac
+++ b/exercises/practice/resistor-color-trio/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/resistor-color-trio/debug.mac
+++ b/exercises/practice/resistor-color-trio/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/resistor-color/debug.mac
+++ b/exercises/practice/resistor-color/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/resistor-color/debug.mac
+++ b/exercises/practice/resistor-color/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/reverse-string/debug.mac
+++ b/exercises/practice/reverse-string/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/reverse-string/debug.mac
+++ b/exercises/practice/reverse-string/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/rna-transcription/debug.mac
+++ b/exercises/practice/rna-transcription/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/rna-transcription/debug.mac
+++ b/exercises/practice/rna-transcription/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/robot-name/debug.mac
+++ b/exercises/practice/robot-name/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/robot-name/debug.mac
+++ b/exercises/practice/robot-name/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/robot-simulator/debug.mac
+++ b/exercises/practice/robot-simulator/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/robot-simulator/debug.mac
+++ b/exercises/practice/robot-simulator/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/roman-numerals/debug.mac
+++ b/exercises/practice/roman-numerals/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/roman-numerals/debug.mac
+++ b/exercises/practice/roman-numerals/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/rotational-cipher/debug.mac
+++ b/exercises/practice/rotational-cipher/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/rotational-cipher/debug.mac
+++ b/exercises/practice/rotational-cipher/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/run-length-encoding/debug.mac
+++ b/exercises/practice/run-length-encoding/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/run-length-encoding/debug.mac
+++ b/exercises/practice/run-length-encoding/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/saddle-points/debug.mac
+++ b/exercises/practice/saddle-points/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/saddle-points/debug.mac
+++ b/exercises/practice/saddle-points/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/say/debug.mac
+++ b/exercises/practice/say/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/say/debug.mac
+++ b/exercises/practice/say/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/scrabble-score/debug.mac
+++ b/exercises/practice/scrabble-score/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/scrabble-score/debug.mac
+++ b/exercises/practice/scrabble-score/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/secret-handshake/debug.mac
+++ b/exercises/practice/secret-handshake/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/secret-handshake/debug.mac
+++ b/exercises/practice/secret-handshake/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/series/debug.mac
+++ b/exercises/practice/series/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/series/debug.mac
+++ b/exercises/practice/series/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/sieve/debug.mac
+++ b/exercises/practice/sieve/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/sieve/debug.mac
+++ b/exercises/practice/sieve/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/simple-linked-list/debug.mac
+++ b/exercises/practice/simple-linked-list/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/simple-linked-list/debug.mac
+++ b/exercises/practice/simple-linked-list/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/space-age/debug.mac
+++ b/exercises/practice/space-age/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/space-age/debug.mac
+++ b/exercises/practice/space-age/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/spiral-matrix/debug.mac
+++ b/exercises/practice/spiral-matrix/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/spiral-matrix/debug.mac
+++ b/exercises/practice/spiral-matrix/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/split-second-stopwatch/debug.mac
+++ b/exercises/practice/split-second-stopwatch/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/split-second-stopwatch/debug.mac
+++ b/exercises/practice/split-second-stopwatch/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/square-root/debug.mac
+++ b/exercises/practice/square-root/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/square-root/debug.mac
+++ b/exercises/practice/square-root/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/state-of-tic-tac-toe/debug.mac
+++ b/exercises/practice/state-of-tic-tac-toe/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/state-of-tic-tac-toe/debug.mac
+++ b/exercises/practice/state-of-tic-tac-toe/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/sublist/debug.mac
+++ b/exercises/practice/sublist/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/sublist/debug.mac
+++ b/exercises/practice/sublist/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/sum-of-multiples/debug.mac
+++ b/exercises/practice/sum-of-multiples/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/sum-of-multiples/debug.mac
+++ b/exercises/practice/sum-of-multiples/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/tournament/debug.mac
+++ b/exercises/practice/tournament/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/tournament/debug.mac
+++ b/exercises/practice/tournament/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/transpose/debug.mac
+++ b/exercises/practice/transpose/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/transpose/debug.mac
+++ b/exercises/practice/transpose/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/triangle/debug.mac
+++ b/exercises/practice/triangle/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/triangle/debug.mac
+++ b/exercises/practice/triangle/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/twelve-days/debug.mac
+++ b/exercises/practice/twelve-days/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/twelve-days/debug.mac
+++ b/exercises/practice/twelve-days/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/two-bucket/debug.mac
+++ b/exercises/practice/two-bucket/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/two-bucket/debug.mac
+++ b/exercises/practice/two-bucket/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/two-fer/debug.mac
+++ b/exercises/practice/two-fer/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/two-fer/debug.mac
+++ b/exercises/practice/two-fer/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/variable-length-quantity/debug.mac
+++ b/exercises/practice/variable-length-quantity/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/variable-length-quantity/debug.mac
+++ b/exercises/practice/variable-length-quantity/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/word-count/debug.mac
+++ b/exercises/practice/word-count/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/word-count/debug.mac
+++ b/exercises/practice/word-count/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/wordy/debug.mac
+++ b/exercises/practice/wordy/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/wordy/debug.mac
+++ b/exercises/practice/wordy/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/exercises/practice/yacht/debug.mac
+++ b/exercises/practice/yacht/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/exercises/practice/yacht/debug.mac
+++ b/exercises/practice/yacht/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt

--- a/templates/debug.mac
+++ b/templates/debug.mac
@@ -25,7 +25,7 @@ fmtf: db "debug floating-point... %f", 0xA, 0x0
 fmtc: db "debug character... %c", 0xA, 0x0
 
 ; formatting string for strings
-fmts: db "debug string... %s", 0xA, 0x0
+fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES

--- a/templates/debug.mac
+++ b/templates/debug.mac
@@ -226,8 +226,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         movsx rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -248,7 +248,18 @@ _fmt_xmm_is zx, "%zX"
 ; prints the value of a 32-bit signed integer
 %macro debugd32 1-*
 
-    debugd8 %{1:-1}
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
 
 %endmacro
 
@@ -258,8 +269,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzd]
         mov rsi, %1
+        lea rdi, [rel fmtzd]
         xor eax, eax
 
         call printf wrt ..plt
@@ -276,8 +287,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         movzx rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -301,8 +312,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov esi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -319,8 +330,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzu]
         mov rsi, %1
+        lea rdi, [rel fmtzu]
         xor eax, eax
 
         call printf wrt ..plt
@@ -337,8 +348,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         movzx rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -362,8 +373,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov esi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -380,8 +391,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtzx]
         mov rsi, %1
+        lea rdi, [rel fmtzx]
         xor eax, eax
 
         call printf wrt ..plt
@@ -398,8 +409,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -416,8 +427,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtf]
         movsd xmm0, %1
+        lea rdi, [rel fmtf]
         mov eax, 1
 
         call printf wrt ..plt
@@ -434,8 +445,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmtc]
         movzx rsi, %1
+        lea rdi, [rel fmtc]
         xor eax, eax
 
         call printf wrt ..plt
@@ -452,8 +463,8 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmts]
         lea rsi, [%1]
+        lea rdi, [rel fmts]
         xor eax, eax
 
         call printf wrt ..plt
@@ -470,7 +481,6 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f32]
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
@@ -479,6 +489,7 @@ _fmt_xmm_is zx, "%zX"
         cvtss2sd xmm1, [rsp + 4]
         cvtss2sd xmm2, [rsp + 8]
         cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
         call printf wrt ..plt
@@ -495,14 +506,13 @@ _fmt_xmm_is zx, "%zX"
     %rep %0
         prologue
 
-        lea rdi, [rel fmt_xmm_f64]
-
         sub rsp, 16
         movdqu xmm0, %1
         movdqa [rsp], xmm0
 
         movsd xmm0, [rsp]
         movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
         call printf wrt ..plt
@@ -525,8 +535,6 @@ _fmt_xmm_is zx, "%zX"
     prologue
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
-
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
 
     sub rsp, 96
     movdqu xmm0, %1
@@ -569,6 +577,7 @@ _fmt_xmm_is zx, "%zX"
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
     call printf wrt ..plt
 
@@ -619,8 +628,6 @@ _fmt_xmm_is zx, "%zX"
 
     %defalias _mov_xmm %[mov %+ %2 %+ x]
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
-
     sub rsp, 32
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -653,6 +660,7 @@ _fmt_xmm_is zx, "%zX"
     _mov_xmm r10, ax
     mov [rsp + 16], r10
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
     call printf wrt ..plt
 
@@ -701,8 +709,6 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
@@ -713,12 +719,13 @@ _fmt_xmm_is zx, "%zX"
     mov r8d, dword [rsp + 12]
 
     %ifidn %2, s
-        movsx rsi, esi
-        movsx rdx, edx
-        movsx rcx, ecx
-        movsx r8, r8d
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
     %endif
 
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
     call printf wrt ..plt
 
@@ -766,14 +773,13 @@ _fmt_xmm_is zx, "%zX"
 
     prologue
 
-    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
-
     sub rsp, 16
     movdqu xmm0, %1
     movdqa [rsp], xmm0
 
     mov rsi, [rsp]
     mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
     call printf wrt ..plt


### PR DESCRIPTION
Fix two bugs:

1. Loading the formatting string into `rdi` before passing the macro argument to `rsi` was yielding wrong results when the macro argument was passed in `rdi`.
2. `movsx` is only defined for sign-extension of 8-bit and 16-bit arguments, for 32-bit arguments the correct is `movsxd`. Debugging 32-bit negative numbers was yielding unexpected results.

EDIT:

3. Add quotes for printed strings, to help visualize whitespaces.
4. Completely unrelated to the debugging file, add correct section annotation in `flower_field.asm`.