### PR TITLE
bin/verify-exercises-in-docker accepts image argument

### DIFF
--- a/bin/verify-exercises-in-docker
+++ b/bin/verify-exercises-in-docker
@@ -30,8 +30,8 @@ copy_example_or_examplar_to_solution() {
 }
 
 pull_docker_image() {
-    docker pull exercism/x86-64-assembly-test-runner ||
-        die $'Could not find the `exercism/x86-64-assembly-test-runner` Docker image.\nCheck the test runner docs at https://exercism.org/docs/building/tooling/test-runners for more information.'
+    docker pull "${image}" ||
+        die $'Could not find the `'${image}'` Docker image.\nCheck the test runner docs at https://exercism.org/docs/building/tooling/test-runners for more information.'
 }
 
 run_tests() {
@@ -45,7 +45,7 @@ run_tests() {
         --mount type=bind,src="${PWD}",dst=/solution \
         --mount type=bind,src="${PWD}",dst=/output \
         --mount type=tmpfs,dst=/tmp \
-        exercism/x86-64-assembly-test-runner "${slug}" /solution /output
+        "${image}" "${slug}" /solution /output
     jq -r '.message // .status' "${PWD}/results.json"
     jq -e '.status == "pass"' "${PWD}/results.json" >/dev/null 2>&1
 }
@@ -85,7 +85,20 @@ verify_exercises() {
     ((count > 0)) || die 'no matching exercises found!'
 }
 
-pull_docker_image
+
+image=''
+while getopts :i: opt; do
+    case $opt in
+        i) image=$OPTARG ;;
+        ?) echo >&2 "Unknown option: -$OPTARG"; exit 1 ;;
+    esac
+done
+shift "$((OPTIND - 1))"
+
+if [[ -z "${image}" ]]; then
+    image="exercism/x86-64-assembly-test-runner"
+    pull_docker_image
+fi
 
 exercise_slug="${1:-*}"
 verify_exercises "${exercise_slug}"


### PR DESCRIPTION
`bin/verify-exercises-in-docker` accepts an image argument with `-i`. This allows testing different test-runner images against the current exercises to ensure correctness.

Adapted from the Lean track.