### PR TITLE
sync `simple-linked-list` with canonical-data

### DIFF
--- a/exercises/practice/simple-linked-list/.docs/instructions.append.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.append.md
@@ -1,0 +1,3 @@
+## Instructions append
+
+You may consider that all functions will be called with valid values and that `pop_list` and `peek_list` won't be called on empty lists.

--- a/exercises/practice/simple-linked-list/.meta/example.asm
+++ b/exercises/practice/simple-linked-list/.meta/example.asm
@@ -1,7 +1,9 @@
 section .text
 
 global create_list
+global count_list
 global push_list
+global peek_list
 global pop_list
 global reverse_list
 global delete_list
@@ -27,11 +29,12 @@ create_list:
     mov qword [rsp], rdi
     mov qword [rsp + 8], rsi
 
+    mov rcx, rdi
     mov rdi, 24 ; size of a list_t
-    call qword [rsp] ; stack is 16-byte aligned:
-                     ; 1 qword for pushing rbp
-                     ; 2 qwords for subbing rsp
-                     ; 1 qword for pushing RIP (in CALL)
+    call rcx    ; stack is 16-byte aligned:
+                ; 1 qword for pushing rbp
+                ; 2 qwords for subbing rsp
+                ; 1 qword for pushing RIP (in CALL)
 
     mov qword [rax], 0 ; head is null
 
@@ -43,6 +46,16 @@ create_list:
 
     mov rsp, rbp
     pop rbp
+    ret
+
+count_list:
+    sub rdi, 8   ; head is first QWORD of list, but next is second QWORD of each node
+    mov eax, -1
+.count_loop:
+    inc eax
+    mov rdi, qword [rdi + 8] ; accesses head and next for each node
+    test rdi, rdi
+    jnz .count_loop          ; next non-null, keeps looping
     ret
 
 push_list:
@@ -77,6 +90,11 @@ push_list:
 
     mov rsp, rbp
     pop rbp
+    ret
+
+peek_list:
+    mov rdi, [rdi] ; gets head node
+    mov rax, [rdi] ; gets data in head
     ret
 
 pop_list:

--- a/exercises/practice/simple-linked-list/.meta/tests.toml
+++ b/exercises/practice/simple-linked-list/.meta/tests.toml
@@ -1,0 +1,105 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[962d998c-c203-41e2-8fbd-85a7b98b79b9]
+description = "count -> Empty list has length of zero"
+
+[9760262e-d7e4-4639-9840-87e2e2fbb115]
+description = "count -> Singleton list has length of one"
+
+[d9955c90-637c-441b-b41d-8cfb48e924a8]
+description = "count -> Non-empty list has correct length"
+
+[0c3966db-58f9-4632-b94c-8ea13e54c2c8]
+description = "pop -> Pop from empty list is an error"
+include = false
+
+[a4f9d2e1-7425-49ef-9ee8-6c0cb3407cf0]
+description = "pop -> Can pop from singleton list"
+
+[6dcbb2c9-d98a-47bc-a010-9c19703d3ea2]
+description = "pop -> Can pop from non-empty list"
+
+[e83aade9-f030-4096-aaf0-f9dc6491e6cf]
+description = "pop -> Can pop multiple items"
+
+[5c46bcf2-c0a9-4654-ae17-f3192436fcf1]
+description = "pop -> Pop updates the count"
+
+[70d747a1-2e84-4ebc-bc3f-dcbee6a05f6b]
+description = "push -> Can push to an empty list"
+
+[f3197f0a-1fea-45a5-939f-4a5ea60387ec]
+description = "push -> Can push to an empty list"
+reimplements = "70d747a1-2e84-4ebc-bc3f-dcbee6a05f6b"
+
+[391e332e-1f91-4033-b1e0-0e0c17812fa7]
+description = "push -> Can push to a non-empty list"
+
+[ed4b0e01-3bbd-4895-af25-152b5914b3da]
+description = "push -> Push updates count"
+
+[41666790-b932-4e5a-b323-e848a83d12d5]
+description = "push -> Push and pop"
+
+[930a4a5c-76f6-47ec-9be3-4e70993173a1]
+description = "peek -> Peek on empty list is an error"
+include = false
+
+[43255a50-d919-4e81-afce-e4a271eaedbd]
+description = "peek -> Can peek on singleton list"
+
+[48353020-e25d-4621-a854-e35fb1e15fa7]
+description = "peek -> Can peek on non-empty list"
+
+[96fcead9-a713-46c2-8005-3f246c873851]
+description = "peek -> Peek does not change the count"
+
+[7576ed05-7ff7-4b84-8efb-d34d62c110f5]
+description = "peek -> Can peek after a pop and push"
+
+[b97d00b6-2fab-435d-ae74-3233dcc13698]
+description = "toList LIFO -> Empty linked list to list is empty"
+
+[eedeb95f-b5cf-431d-8ad6-5854ba6b251c]
+description = "toList LIFO -> To list with multiple values"
+
+[838678de-eaf3-4c14-b34e-7e35b6d851e8]
+description = "toList LIFO -> To list after a pop"
+
+[03fc83a5-48a8-470b-a2d2-a286c5e8365f]
+description = "toList FIFO -> Empty linked list to list is empty"
+include = false
+
+[1282484e-a58c-426a-972e-90746bda61fc]
+description = "toList FIFO -> To list with multiple values"
+include = false
+
+[05ca3109-1249-4c0c-a567-a3b2f8352a7c]
+description = "toList FIFO -> To list after a pop"
+include = false
+
+[5e6c1a3d-e34b-46d3-be59-3f132a820ed5]
+description = "reverse -> Reversed empty list has same values"
+
+[93c87ed3-862a-474f-820b-ba3fd6b6daf6]
+description = "reverse -> Reversed singleton list is same list"
+
+[92851ebe-9f52-4406-b92e-0718c441a2ab]
+description = "reverse -> Reversed non-empty list is reversed"
+include = false
+
+[1210eeda-b23f-4790-930c-7ac6d0c8e723]
+description = "reverse -> Reversed non-empty list is reversed"
+reimplements = "92851ebe-9f52-4406-b92e-0718c441a2ab"
+
+[9b53af96-7494-4cfa-9b77-b7366fed5c4c]
+description = "reverse -> Double reverse"

--- a/exercises/practice/simple-linked-list/simple_linked_list.asm
+++ b/exercises/practice/simple-linked-list/simple_linked_list.asm
@@ -1,7 +1,9 @@
 section .text
 
 global create_list
+global count_list
 global push_list
+global peek_list
 global pop_list
 global reverse_list
 global delete_list
@@ -10,7 +12,15 @@ create_list:
     ; Provide your implementation here
     ret
 
+count_list:
+    ; Provide your implementation here
+    ret
+
 push_list:
+    ; Provide your implementation here
+    ret
+
+peek_list:
     ; Provide your implementation here
     ret
 

--- a/exercises/practice/simple-linked-list/simple_linked_list_test.c
+++ b/exercises/practice/simple-linked-list/simple_linked_list_test.c
@@ -19,7 +19,9 @@ typedef struct {
 } list_t;
 
 extern list_t *create_list(allocator_t alloc, deallocator_t dealloc);
+extern size_t count_list(const list_t *list);
 extern void push_list(list_t *list, int64_t data);
+extern int64_t peek_list(const list_t *list);
 extern int64_t pop_list(list_t *list);
 extern void reverse_list(list_t *list);
 extern void delete_list(list_t *list);
@@ -42,265 +44,421 @@ void setUp(void) {
 void tearDown(void) {
 }
 
-void test_can_create_list(void) {
+void test_empty_list_has_length_of_zero(void) {
     list_t *list = create_list(allocator, deallocator);
     TEST_ASSERT_NOT_NULL(list);
     TEST_ASSERT_EQUAL(1, alloc_count);
-    node_t *node = list->head;
-    TEST_ASSERT_NULL(node);
+    TEST_ASSERT_EQUAL(0, count_list(list));
+    TEST_ASSERT_EQUAL(1, alloc_count);
     delete_list(list);
     TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
 }
 
-void test_can_push(void) {
+void test_singleton_list_has_length_of_one(void) {
     TEST_IGNORE();
     list_t *list = create_list(allocator, deallocator);
     TEST_ASSERT_NOT_NULL(list);
     TEST_ASSERT_EQUAL(1, alloc_count);
-    push_list(list, 16);
-    TEST_ASSERT_EQUAL(2, alloc_count);
-    node_t *node = list->head;
-    TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(16, node->data);
-    node = node->next;
-    TEST_ASSERT_NULL(node);
-    delete_list(list);
-    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
-}
-
-void test_push_updates_head(void) {
-    TEST_IGNORE();
-    list_t *list = create_list(allocator, deallocator);
-    TEST_ASSERT_NOT_NULL(list);
-    TEST_ASSERT_EQUAL(1, alloc_count);
-    push_list(list, 99);
-    TEST_ASSERT_EQUAL(2, alloc_count);
-    push_list(list, -123);
-    TEST_ASSERT_EQUAL(3, alloc_count);
-    node_t *node = list->head;
-    TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(-123, node->data);
-    node = node->next;
-    TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(99, node->data);
-    node = node->next;
-    TEST_ASSERT_NULL(node);
-    delete_list(list);
-    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
-}
-
-void test_can_pop(void) {
-    TEST_IGNORE();
-    list_t *list = create_list(allocator, deallocator);
-    TEST_ASSERT_NOT_NULL(list);
-    TEST_ASSERT_EQUAL(1, alloc_count);
-    push_list(list, -123);
-    TEST_ASSERT_EQUAL(2, alloc_count);
-    TEST_ASSERT_EQUAL(-123, pop_list(list));
-    TEST_ASSERT_EQUAL(1, alloc_count);
-    node_t *node = list->head;
-    TEST_ASSERT_NULL(node);
-    delete_list(list);
-    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
-}
-
-void test_pop_multiple_values(void) {
-    TEST_IGNORE();
-    list_t *list = create_list(allocator, deallocator);
-    TEST_ASSERT_NOT_NULL(list);
-    TEST_ASSERT_EQUAL(1, alloc_count);
-    push_list(list, -123);
-    TEST_ASSERT_EQUAL(2, alloc_count);
-    push_list(list, 234);
-    TEST_ASSERT_EQUAL(3, alloc_count);
-    push_list(list, 456);
-    TEST_ASSERT_EQUAL(4, alloc_count);
-    push_list(list, 789);
-    TEST_ASSERT_EQUAL(5, alloc_count);
-    TEST_ASSERT_EQUAL(789, pop_list(list));
-    TEST_ASSERT_EQUAL(4, alloc_count);
-    TEST_ASSERT_EQUAL(456, pop_list(list));
-    TEST_ASSERT_EQUAL(3, alloc_count);
-    TEST_ASSERT_EQUAL(234, pop_list(list));
-    TEST_ASSERT_EQUAL(2, alloc_count);
-    node_t *node = list->head;
-    TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(-123, node->data);
-    node = node->next;
-    TEST_ASSERT_NULL(node);
-    delete_list(list);
-    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
-}
-
-void test_multiple_operations(void) {
-    TEST_IGNORE();
-    list_t *list = create_list(allocator, deallocator);
-    TEST_ASSERT_NOT_NULL(list);
-    TEST_ASSERT_EQUAL(1, alloc_count);
-    push_list(list, 24);
-    TEST_ASSERT_EQUAL(2, alloc_count);
-    push_list(list, -15);
-    TEST_ASSERT_EQUAL(3, alloc_count);
-    push_list(list, 28);
-    TEST_ASSERT_EQUAL(4, alloc_count);
-    push_list(list, 576);
-    TEST_ASSERT_EQUAL(5, alloc_count);
-    TEST_ASSERT_EQUAL(576, pop_list(list));
-    TEST_ASSERT_EQUAL(4, alloc_count);
-    TEST_ASSERT_EQUAL(28, pop_list(list));
-    TEST_ASSERT_EQUAL(3, alloc_count);
-    push_list(list, 1245);
-    TEST_ASSERT_EQUAL(4, alloc_count);
-    push_list(list, 9829);
-    TEST_ASSERT_EQUAL(5, alloc_count);
-    push_list(list, -65555);
-    TEST_ASSERT_EQUAL(6, alloc_count);
-    push_list(list, 234);
-    TEST_ASSERT_EQUAL(7, alloc_count);
-    TEST_ASSERT_EQUAL(234, pop_list(list));
-    TEST_ASSERT_EQUAL(6, alloc_count);
-    TEST_ASSERT_EQUAL(-65555, pop_list(list));
-    TEST_ASSERT_EQUAL(5, alloc_count);
-    TEST_ASSERT_EQUAL(9829, pop_list(list));
-    TEST_ASSERT_EQUAL(4, alloc_count);
-    push_list(list, -777);
-    TEST_ASSERT_EQUAL(5, alloc_count);
-    push_list(list, 0);
-    TEST_ASSERT_EQUAL(6, alloc_count);
-    push_list(list, 19);
-    TEST_ASSERT_EQUAL(7, alloc_count);
-    TEST_ASSERT_EQUAL(19, pop_list(list));
-    TEST_ASSERT_EQUAL(6, alloc_count);
-    TEST_ASSERT_EQUAL(0, pop_list(list));
-    TEST_ASSERT_EQUAL(5, alloc_count);
     push_list(list, 1);
-    TEST_ASSERT_EQUAL(6, alloc_count);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    TEST_ASSERT_EQUAL(1, count_list(list));
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_nonempty_list_has_correct_length(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    push_list(list, 2);
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    push_list(list, 3);
+    TEST_ASSERT_EQUAL(4, alloc_count);
+    TEST_ASSERT_EQUAL(3, count_list(list));
+    TEST_ASSERT_EQUAL(4, alloc_count);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_can_pop_from_singleton_list(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
     TEST_ASSERT_EQUAL(1, pop_list(list));
-    TEST_ASSERT_EQUAL(5, alloc_count);
-    TEST_ASSERT_EQUAL(-777, pop_list(list));
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_can_pop_from_nonempty_list(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    push_list(list, 2);
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    TEST_ASSERT_EQUAL(2, pop_list(list));
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_can_pop_multiple_items(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    push_list(list, 2);
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    TEST_ASSERT_EQUAL(2, pop_list(list));
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    TEST_ASSERT_EQUAL(1, pop_list(list));
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_pop_updates_the_count(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    push_list(list, 2);
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    TEST_ASSERT_EQUAL(2, count_list(list));
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    TEST_ASSERT_EQUAL(2, pop_list(list));
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    TEST_ASSERT_EQUAL(1, count_list(list));
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    TEST_ASSERT_EQUAL(1, pop_list(list));
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    TEST_ASSERT_EQUAL(0, count_list(list));
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_can_push_to_an_empty_list(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_can_push_to_a_nonempty_list(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    push_list(list, 2);
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    push_list(list, 3);
+    TEST_ASSERT_EQUAL(4, alloc_count);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_push_updates_count(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    push_list(list, 2);
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    push_list(list, 3);
+    TEST_ASSERT_EQUAL(4, alloc_count);
+    TEST_ASSERT_EQUAL(3, count_list(list));
+    TEST_ASSERT_EQUAL(4, alloc_count);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_push_and_pop(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    push_list(list, 2);
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    TEST_ASSERT_EQUAL(2, pop_list(list));
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    push_list(list, 3);
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    TEST_ASSERT_EQUAL(2, count_list(list));
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    TEST_ASSERT_EQUAL(3, pop_list(list));
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    TEST_ASSERT_EQUAL(1, pop_list(list));
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    TEST_ASSERT_EQUAL(0, count_list(list));
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_can_peek_on_singleton_list(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    TEST_ASSERT_EQUAL(1, peek_list(list));
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_can_peek_on_nonempty_list(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    push_list(list, 2);
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    TEST_ASSERT_EQUAL(2, peek_list(list));
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_peek_does_not_change_the_count(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    push_list(list, 2);
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    TEST_ASSERT_EQUAL(2, peek_list(list));
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    TEST_ASSERT_EQUAL(2, count_list(list));
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_can_peek_after_a_pop_and_push(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    push_list(list, 2);
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    TEST_ASSERT_EQUAL(2, peek_list(list));
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    TEST_ASSERT_EQUAL(2, pop_list(list));
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    TEST_ASSERT_EQUAL(1, peek_list(list));
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    push_list(list, 3);
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    TEST_ASSERT_EQUAL(3, peek_list(list));
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_empty_linked_list_to_list_is_empty(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    node_t *node = list->head;
+    TEST_ASSERT_NULL(node);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_to_list_with_multiple_values(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    push_list(list, 2);
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    push_list(list, 3);
     TEST_ASSERT_EQUAL(4, alloc_count);
     node_t *node = list->head;
     TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(1245, node->data);
+    TEST_ASSERT_EQUAL(3, node->data);
     node = node->next;
     TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(-15, node->data);
+    TEST_ASSERT_EQUAL(2, node->data);
     node = node->next;
     TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(24, node->data);
+    TEST_ASSERT_EQUAL(1, node->data);
     node = node->next;
     TEST_ASSERT_NULL(node);
     delete_list(list);
     TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
 }
 
-void test_reverse_list(void) {
+void test_to_list_after_a_pop(void) {
     TEST_IGNORE();
     list_t *list = create_list(allocator, deallocator);
     TEST_ASSERT_NOT_NULL(list);
     TEST_ASSERT_EQUAL(1, alloc_count);
-    push_list(list, 0);
+    push_list(list, 1);
     TEST_ASSERT_EQUAL(2, alloc_count);
-    push_list(list, 45);
+    push_list(list, 2);
     TEST_ASSERT_EQUAL(3, alloc_count);
-    push_list(list, -71);
+    push_list(list, 3);
     TEST_ASSERT_EQUAL(4, alloc_count);
-    push_list(list, 4567890);
-    TEST_ASSERT_EQUAL(5, alloc_count);
-    push_list(list, 8000);
-    TEST_ASSERT_EQUAL(6, alloc_count);
-    push_list(list, 27);
-    TEST_ASSERT_EQUAL(7, alloc_count);
-    reverse_list(list);
-    TEST_ASSERT_EQUAL(7, alloc_count);
+    TEST_ASSERT_EQUAL(3, pop_list(list));
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    push_list(list, 4);
+    TEST_ASSERT_EQUAL(4, alloc_count);
     node_t *node = list->head;
     TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(0, node->data);
+    TEST_ASSERT_EQUAL(4, node->data);
     node = node->next;
     TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(45, node->data);
+    TEST_ASSERT_EQUAL(2, node->data);
     node = node->next;
     TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(-71, node->data);
-    node = node->next;
-    TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(4567890, node->data);
-    node = node->next;
-    TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(8000, node->data);
-    node = node->next;
-    TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(27, node->data);
+    TEST_ASSERT_EQUAL(1, node->data);
     node = node->next;
     TEST_ASSERT_NULL(node);
     delete_list(list);
     TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
 }
 
-void test_reverse_of_a_reverse_is_original_list(void) {
+void test_reversed_empty_list_has_same_values(void) {
     TEST_IGNORE();
     list_t *list = create_list(allocator, deallocator);
     TEST_ASSERT_NOT_NULL(list);
     TEST_ASSERT_EQUAL(1, alloc_count);
-    push_list(list, 8);
+    reverse_list(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    node_t *node = list->head;
+    TEST_ASSERT_NULL(node);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_reversed_singleton_list_is_same_list(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
     TEST_ASSERT_EQUAL(2, alloc_count);
-    push_list(list, 2198);
-    TEST_ASSERT_EQUAL(3, alloc_count);
-    push_list(list, -33);
-    TEST_ASSERT_EQUAL(4, alloc_count);
-    push_list(list, 24);
-    TEST_ASSERT_EQUAL(5, alloc_count);
-    push_list(list, 10);
-    TEST_ASSERT_EQUAL(6, alloc_count);
-    push_list(list, 175532);
-    TEST_ASSERT_EQUAL(7, alloc_count);
-    push_list(list, -6534);
-    TEST_ASSERT_EQUAL(8, alloc_count);
-    push_list(list, 892838);
-    TEST_ASSERT_EQUAL(9, alloc_count);
     reverse_list(list);
-    TEST_ASSERT_EQUAL(9, alloc_count);
-    reverse_list(list);
-    TEST_ASSERT_EQUAL(9, alloc_count);
+    TEST_ASSERT_EQUAL(2, alloc_count);
     node_t *node = list->head;
     TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(892838, node->data);
-    node = node->next;
-    TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(-6534, node->data);
-    node = node->next;
-    TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(175532, node->data);
-    node = node->next;
-    TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(10, node->data);
-    node = node->next;
-    TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(24, node->data);
-    node = node->next;
-    TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(-33, node->data);
-    node = node->next;
-    TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(2198, node->data);
-    node = node->next;
-    TEST_ASSERT_NOT_NULL(node);
-    TEST_ASSERT_EQUAL(8, node->data);
+    TEST_ASSERT_EQUAL(1, node->data);
     node = node->next;
     TEST_ASSERT_NULL(node);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_reversed_nonempty_list_is_reversed(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    push_list(list, 2);
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    push_list(list, 3);
+    TEST_ASSERT_EQUAL(4, alloc_count);
+    reverse_list(list);
+    TEST_ASSERT_EQUAL(4, alloc_count);
+    TEST_ASSERT_EQUAL(3, count_list(list));
+    TEST_ASSERT_EQUAL(4, alloc_count);
+    TEST_ASSERT_EQUAL(1, pop_list(list));
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    TEST_ASSERT_EQUAL(2, pop_list(list));
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    TEST_ASSERT_EQUAL(3, pop_list(list));
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    delete_list(list);
+    TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
+}
+
+void test_double_reverse(void) {
+    TEST_IGNORE();
+    list_t *list = create_list(allocator, deallocator);
+    TEST_ASSERT_NOT_NULL(list);
+    TEST_ASSERT_EQUAL(1, alloc_count);
+    push_list(list, 1);
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    push_list(list, 2);
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    push_list(list, 3);
+    TEST_ASSERT_EQUAL(4, alloc_count);
+    reverse_list(list);
+    TEST_ASSERT_EQUAL(4, alloc_count);
+    reverse_list(list);
+    TEST_ASSERT_EQUAL(4, alloc_count);
+    TEST_ASSERT_EQUAL(3, pop_list(list));
+    TEST_ASSERT_EQUAL(3, alloc_count);
+    TEST_ASSERT_EQUAL(2, pop_list(list));
+    TEST_ASSERT_EQUAL(2, alloc_count);
+    TEST_ASSERT_EQUAL(1, pop_list(list));
+    TEST_ASSERT_EQUAL(1, alloc_count);
     delete_list(list);
     TEST_ASSERT_EQUAL_UINT64(0, alloc_count);
 }
 
 int main(void) {
     UNITY_BEGIN();
-    RUN_TEST(test_can_create_list);
-    RUN_TEST(test_can_push);
-    RUN_TEST(test_push_updates_head);
-    RUN_TEST(test_can_pop);
-    RUN_TEST(test_pop_multiple_values);
-    RUN_TEST(test_multiple_operations);
-    RUN_TEST(test_reverse_list);
-    RUN_TEST(test_reverse_of_a_reverse_is_original_list);
+    RUN_TEST(test_empty_list_has_length_of_zero);
+    RUN_TEST(test_singleton_list_has_length_of_one);
+    RUN_TEST(test_nonempty_list_has_correct_length);
+    RUN_TEST(test_can_pop_from_singleton_list);
+    RUN_TEST(test_can_pop_from_nonempty_list);
+    RUN_TEST(test_can_pop_multiple_items);
+    RUN_TEST(test_pop_updates_the_count);
+    RUN_TEST(test_can_push_to_an_empty_list);
+    RUN_TEST(test_can_push_to_a_nonempty_list);
+    RUN_TEST(test_push_updates_count);
+    RUN_TEST(test_push_and_pop);
+    RUN_TEST(test_can_peek_on_singleton_list);
+    RUN_TEST(test_can_peek_on_nonempty_list);
+    RUN_TEST(test_peek_does_not_change_the_count);
+    RUN_TEST(test_can_peek_after_a_pop_and_push);
+    RUN_TEST(test_empty_linked_list_to_list_is_empty);
+    RUN_TEST(test_to_list_with_multiple_values);
+    RUN_TEST(test_to_list_after_a_pop);
+    RUN_TEST(test_reversed_empty_list_has_same_values);
+    RUN_TEST(test_reversed_singleton_list_is_same_list);
+    RUN_TEST(test_reversed_nonempty_list_is_reversed);
+    RUN_TEST(test_double_reverse);
     return UNITY_END();
 }

--- a/generators/exercises/simple_linked_list.py
+++ b/generators/exercises/simple_linked_list.py
@@ -20,7 +20,9 @@ typedef struct {
 } list_t;
 
 extern list_t *create_list(allocator_t alloc, deallocator_t dealloc);
+extern size_t count_list(const list_t *list);
 extern void push_list(list_t *list, int64_t data);
+extern int64_t peek_list(const list_t *list);
 extern int64_t pop_list(list_t *list);
 extern void reverse_list(list_t *list);
 extern void delete_list(list_t *list);
@@ -39,86 +41,7 @@ static void deallocator(void *ptr) {
 """
 
 
-def extra_cases():
-    return [
-        {
-            "description": "can_create_list",
-            "property": "run",
-            "input": {},
-            "expected": [],
-        },
-        {
-            "description": "can_push",
-            "property": "run",
-            "input": [{"operation": "push", "values": [16]}],
-            "expected": [16],
-        },
-        {
-            "description": "push_updates_head",
-            "property": "run",
-            "input": [{"operation": "push", "values": [99, -123]}],
-            "expected": [-123, 99],
-        },
-        {
-            "description": "can_pop",
-            "property": "run",
-            "input": [
-                {"operation": "push", "values": [-123]},
-                {"operation": "pop", "ops": 1, "expected": [-123]},
-            ],
-            "expected": [],
-        },
-        {
-            "description": "pop_multiple_values",
-            "property": "run",
-            "input": [
-                {"operation": "push", "values": [-123, 234, 456, 789]},
-                {"operation": "pop", "ops": 3, "expected": [789, 456, 234]},
-            ],
-            "expected": [-123],
-        },
-        {
-            "description": "multiple_operations",
-            "property": "run",
-            "input": [
-                {"operation": "push", "values": [24, -15, 28, 576]},
-                {"operation": "pop", "ops": 2, "expected": [576, 28]},
-                {"operation": "push", "values": [1245, 9829, -65555, 234]},
-                {"operation": "pop", "ops": 3, "expected": [234, -65555, 9829]},
-                {"operation": "push", "values": [-777, 0, 19]},
-                {"operation": "pop", "ops": 1, "expected": [19]},
-                {"operation": "pop", "ops": 1, "expected": [0]},
-                {"operation": "push", "values": [1]},
-                {"operation": "pop", "ops": 2, "expected": [1, -777]},
-            ],
-            "expected": [1245, -15, 24],
-        },
-        {
-            "description": "reverse_list",
-            "property": "run",
-            "input": [
-                {"operation": "push", "values": [0, 45, -71, 4567890, 8000, 27]},
-                {"operation": "reverse"},
-            ],
-            "expected": [0, 45, -71, 4567890, 8000, 27],
-        },
-        {
-            "description": "reverse_of_a_reverse_is_original_list",
-            "property": "run",
-            "input": [
-                {
-                    "operation": "push",
-                    "values": [8, 2198, -33, 24, 10, 175532, -6534, 892838],
-                },
-                {"operation": "reverse"},
-                {"operation": "reverse"},
-            ],
-            "expected": [892838, -6534, 175532, 10, 24, -33, 2198, 8],
-        },
-    ]
-
-
-def push_values(numbers, size):
+def push_initialValues(numbers, size):
     str_list = []
     for num in numbers:
         str_list.append(f"push_list(list, {num});")
@@ -127,11 +50,14 @@ def push_values(numbers, size):
     return "\n".join(str_list)
 
 
-def pop_values(ops, expected, size):
+def pop_initialValues(ops, expected, size, op):
     str_list = []
+    decrement = 0
+    if op == "pop":
+        decrement = 1
     for num in expected[:ops]:
-        str_list.append(f"TEST_ASSERT_EQUAL({num}, pop_list(list));")
-        size -= 1
+        str_list.append(f"TEST_ASSERT_EQUAL({num}, {op}_list(list));")
+        size -= decrement
         str_list.append(f"TEST_ASSERT_EQUAL({size}, alloc_count);")
     return "\n".join(str_list)
 
@@ -153,17 +79,26 @@ def gen_func_body(_, inp, expected):
     str_list.append("TEST_ASSERT_NOT_NULL(list);")
     size = 1
     str_list.append(f"TEST_ASSERT_EQUAL({size}, alloc_count);")
-    for op in inp:
+    if len(inp["initialValues"]) > 0:
+        str_list.append(push_initialValues(inp["initialValues"], size))
+        size += len(inp["initialValues"])
+    for op in inp["operations"]:
         if op["operation"] == "push":
-            str_list.append(push_values(op["values"], size))
-            size += len(op["values"])
+            str_list.append(push_initialValues([op["value"]], size))
+            size += 1
         elif op["operation"] == "pop":
-            str_list.append(pop_values(op["ops"], op["expected"], size))
-            size -= op["ops"]
-        else:
+            str_list.append(pop_initialValues(1, [op["expected"]], size, "pop"))
+            size -= 1
+        elif op["operation"] == "peek":
+            str_list.append(pop_initialValues(1, [op["expected"]], size, "peek"))
+        elif op["operation"] == "reverse":
             str_list.append("reverse_list(list);")
             str_list.append(f"TEST_ASSERT_EQUAL({size}, alloc_count);")
-    str_list.append(check_resulting_list(expected, size))
+        elif op["operation"] == "count":
+            str_list.append(f"TEST_ASSERT_EQUAL({size - 1}, count_list(list));")
+            str_list.append(f"TEST_ASSERT_EQUAL({size}, alloc_count);")
+        elif op["operation"] == "toList":
+            str_list.append(check_resulting_list(op["expected"], size))
     str_list.append("delete_list(list);")
     str_list.append("TEST_ASSERT_EQUAL_UINT64(0, alloc_count);")
     return "\n".join(str_list)


### PR DESCRIPTION
Canonical data for `simple-linked-list` was recently added, and some changes were needed to sync the track's exercise with upstream:

1. Add two new functions: `count_list` and `peek_list`.
2. The canonical data has a slightly different format than the generator script expected, so I adjusted the generator script according to the new format.

The extra cases in the track's version only existed because there was no canonical data at the time, and they didn't add much on top of it, so I removed them.