### PR TITLE
improve clarity of `integers` concept and exercise

### DIFF
--- a/concepts/integers/about.md
+++ b/concepts/integers/about.md
@@ -7,19 +7,19 @@ Most, if not all, abstractions are built on top of this.
 
 ## Binary notation
 
-One of the most important and fundamental abstractions are [integers][integer].
+[Integers][integer] are one of the most important and fundamental abstractions.
 They represent whole numbers such as `4`, `-2`, `0` or `64532`.
 
-In order to represent an integer as a sequence of bytes, the [binary notation][binary] is used.
+To represent an integer as a sequence of bytes, the [binary notation][binary] is used.
 In this system, each bit in the sequence represents a distinct power of two, with the value increasing as the index of the bit increases from right to left.
 
 ## Unsigned and Signed Integers
 
 ### Unsigned numbers
 
-If the number is know to be non-negative, it's called an **unsigned** number.
+If the number is known to be non-negative, it's called an **unsigned** number.
 
-Unsigned numbers are represented directly as the sum of all set bits in its sequence.
+Unsigned numbers are represented directly as the sum of all set bits in their sequence.
 
 For instance, this represents the number `2⁰ + 2³ + 2⁵ + 2⁶ + 2⁷`, which is `233`:
 
@@ -36,7 +36,7 @@ So, the range of representable non-negative integers in a register goes from `0`
 
 If an integer can assume positive or negative values, it's called a **signed** number.
 
-In order to represent [negative numbers][negative], x86-64 uses the [two's complement][two-complement] representation.
+To represent [negative numbers][negative], x86-64 uses the [two's complement][two-complement] representation.
 
 In two's complement, a negative number is represented by flipping all bits and then adding `1` to the result.
 Flipping a bit means that the values are inverted: a bit with the value of `1` becomes `0` and a bit with the value of `0` becomes `1`.
@@ -84,9 +84,12 @@ Step 2 (add 1):
 
 The [neg][neg] instruction can be used to change the sign of a number.
 
-Notice that the binary representation of `-23` and the binary representation of `233` are equal.
+Note that the binary representation of `-23` and the binary representation of `233` are equal.
 
-In order to provide disambiguation, in a signed integer, the most significant bit is not summed up to the others, but indicates whether the number is negative.
+To provide disambiguation, in a signed integer, the most significant bit is not summed up to the others.
+Instead, its value is subtracted.
+
+Since this bit corresponds to a higher value than the sum of all the others, a number with this bit set is always negative.
 This bit is called the **sign bit**.
 
 ~~~~exercism/caution
@@ -110,10 +113,10 @@ The exception to this rule is `mov`, which accepts a _64-bit signed integer_ as 
 It is possible to use a signed negative integer as immediate in place of an unsigned integer with the same bit representation:
 
 ```x86asm
-add eax, -1          ; this is 4294967295 in unsigned representation
-                     ; an attempt to use 4294967295 directly wouldn't work because immediates are usually 32-bit signed integers
+add rax, -1  ; this is 18446744073709551615 in unsigned representation
+             ; an attempt to use 18446744073709551615 directly wouldn't work because immediates are usually 32-bit signed integers
 
-mov eax, 4294967295  ; this works because mov can take a 64-bit immediate as source operand
+mov rax, 18446744073709551615  ; this works because mov can take a 64-bit immediate as source operand
 ```
 
 ## Arithmetic
@@ -185,7 +188,7 @@ The `CF` can also be set by other instructions, performing other operations.
 The instruction [adc][adc] can be used to sum two numbers and also the value in the carry flag.
 It is a two-operand instruction, with the same syntax as `add`.
 
-There's also a [inc][inc] instruction, that simply sums 1 to the value in the destination operand:
+There's also an [inc][inc] one-operand instruction, that sums 1 to the value in its operand:
 
 ```x86asm
 inc dest ; dest = dest + 1
@@ -197,7 +200,7 @@ The sum of two integers operates in the same way for both unsigned and signed nu
 
 The subtraction of two integers is performed using the `sub` instruction.
 
-There's also a [dec][dec] instruction, that simply subtracts 1 from the value in the destination operand:
+There's also a [dec][dec] one-operand instruction, that subtracts 1 from the value in its operand:
 
 ```x86asm
 dec dest ; dest = dest - 1
@@ -266,14 +269,14 @@ This product is also truncated to fit into the destination operand.
 
 In case of a possible overflow, it is sometimes useful to move operands to a larger register size.
 
-A [movzx][movzx] instruction can be used to convert a value in a 8-bit or 16-bit source operand to a larger destination operand, clearing all remaining bits.
+A [movzx][movzx] instruction can be used to convert a value in an 8-bit or 16-bit source operand to a larger destination operand, clearing all remaining bits.
 This is called **zero extension**:
 
 ```x86asm
 mov ax, 1000 ; lower 16 bits of eax are 1000, upper bits are undefined
 mov cx, 200 ; lower 16 bits of ecx are 200, upper bits are undefined
 
-; 200 * 1000 does not fit in 16 bits, so a 32 bits multiplication is necessary
+; 200 * 1000 does not fit in 16 bits, so a 32-bit multiplication is necessary
 ; however, multiplying eax by ecx may produce an incorrect result due to undefined bits
 
 movzx eax, ax ; lower 16 bits of eax remain 1000, upper bits are cleared
@@ -305,23 +308,30 @@ idiv src
 In both cases, the value in `rdx:rax` is divided by the value in the source operand.
 The quotient is written to the `rax` register and the remainder is written to the `rdx` register.
 
-Notice that as `rdx:rax` is the dividend, both registers must have the appropriate bits set.
+Note that as `rdx:rax` is the dividend, both registers must have the appropriate bits set.
 
-So, whenever working with 64-bit integers, all bits in the `rdx` register must be cleared for a non-negative number in `rax` and set for a negative number.
+So, whenever working with 64-bit integers, the `rdx` register must be set up before the division.
+
+For unsigned division, all bits in `rdx` must be cleared.
+This is called **zero extension**.
+
+For signed division, all bits in `rdx` must be cleared for a non-negative number in `rax`, and set for a negative number.
 This is called **sign extension**.
 
-Failing to perform sign extension can cause a wrong result for the division or, if the quotient is too large to fit in `rax`, an error.
+Failing to do this can cause a wrong result for the division or, if the quotient is too large to fit in `rax`, an error.
 
-There are three instructions that automate this process: [cwd][sign-extension], [cdq][sign-extension] and [cqo][sign-extension].
+There are three instructions that automate the sign extension: [cwd][sign-extension], [cdq][sign-extension] and [cqo][sign-extension].
 They perform sign extension from `ax` to `dx`, from `eax` to `edx` and from `rax` to `rdx`, respectively.
 
-There's no equivalent instruction for sign extending `al` to `dl` because division between two bytes operate differently.
+There's no equivalent instruction for sign extending `al` to `dl` because division between two bytes operates differently.
 Instead of using `dl:al`, `ax` is used.
 
 So, the lower 8 bits of `ax` (`al`) will get the quotient of the operation and the higher 8 bits (`ah`) will get the remainder.
 
 There is also the instruction [movsx][movsx] that works similarly to `movzx`, extending from any 8-bit or 16-bit source operand to a larger destination operand.
-While `movzx` performs zero-extension, however, `movsx` performs sign-extension.
+While `movzx` performs zero-extension, `movsx` performs sign-extension.
+
+A variant of `movsx` called `movsxd` can sign-extend from a 32-bit source operand to a 64-bit destination operand.
 
 ~~~~exercism/caution
 The `rdx` register is implicitly used in an integer division.

--- a/concepts/integers/introduction.md
+++ b/concepts/integers/introduction.md
@@ -4,7 +4,7 @@
 
 An **integer** is an abstraction that represents whole numbers, such as `4`, `-2`, `0` or `64532`.
 
-In order to represent an integer as a sequence of bytes, the **binary notation** is used.
+To represent an integer as a sequence of bytes, the **binary notation** is used.
 In this system, each bit in the sequence represents a distinct power of two, with the value increasing as the index of the bit increases from right to left.
 
 ## Unsigned and Signed Integers
@@ -13,7 +13,7 @@ In this system, each bit in the sequence represents a distinct power of two, wit
 
 If the number can only be non-negative, it's called an **unsigned** number.
 
-Unsigned numbers are represented directly as the sum of all set bits in its sequence.
+Unsigned numbers are represented directly as the sum of all set bits in their sequence.
 
 The range of representable non-negative integers in a register goes from `0` (no bit set) to `2⁶⁴ - 1` (sum of all 64 bits set).
 
@@ -21,7 +21,7 @@ The range of representable non-negative integers in a register goes from `0` (no
 
 If an integer can assume positive or negative values, it's called a **signed** number.
 
-In order to represent negative numbers, x86-64 uses the **two's complement** representation.
+To represent negative numbers, x86-64 uses the **two's complement** representation.
 
 The `neg` instruction can be used to change the sign of a number.
 
@@ -46,10 +46,10 @@ The exception to this rule is `mov`, which accepts a _64-bit signed integer_ as 
 It is possible to use a signed negative integer as immediate in place of an unsigned integer with the same bit representation:
 
 ```x86asm
-add eax, -1          ; this is 4294967295 in unsigned representation
-                     ; an attempt to use 4294967295 directly wouldn't work because immediates are usually 32-bit signed integers
+add rax, -1  ; this is 18446744073709551615 in unsigned representation
+             ; an attempt to use 18446744073709551615 directly wouldn't work because immediates are usually 32-bit signed integers
 
-mov eax, 4294967295  ; this works because mov can take a 64-bit immediate as source operand
+mov rax, 18446744073709551615  ; this works because mov can take a 64-bit immediate as source operand
 ```
 
 ## Arithmetic
@@ -65,7 +65,7 @@ The `CF` can also be set by other instructions, performing other operations.
 The instruction `adc` can be used to sum two numbers and also the value in the carry flag.
 It is a two-operand instruction, with the same syntax as `add`.
 
-There's also a `inc` one-operand instruction, that sums 1 to the value in its operand.
+There's also an `inc` one-operand instruction, that sums 1 to the value in its operand.
 
 The sum of two integers operates in the same way for both unsigned and signed numbers.
 
@@ -73,7 +73,7 @@ The sum of two integers operates in the same way for both unsigned and signed nu
 
 The subtraction of two integers is performed using the `sub` instruction.
 
-There's also a `dec` one-operand instruction, that subtracts 1 from the value in its operand:
+There's also a `dec` one-operand instruction, that subtracts 1 from the value in its operand.
 
 The subtraction of two integers also operates in the same way for both unsigned and signed numbers.
 
@@ -112,7 +112,7 @@ In this case, instead of `dl:al`, `ax` will be used.
 The lower portion of `ax` (`al`) will get the lower 8 bits of the product, while the upper portion (`ah`) will get the upper 8 bits.
 
 ~~~~exercism/caution
-The `rdx` register is implicitly used in an one-operand multiplication.
+The `rdx` register is implicitly used in a one-operand multiplication.
 This means any necessary value in `rdx` must be saved before that operation.
 ~~~~
 
@@ -134,14 +134,14 @@ This product is also truncated to fit into the destination operand.
 
 In case of a possible overflow, it is sometimes useful to move operands to a larger register size.
 
-A `movzx` instruction can be used to convert a value in a 8-bit or 16-bit source operand to a larger destination operand, clearing all remaining bits.
+A `movzx` instruction can be used to convert a value in an 8-bit or 16-bit source operand to a larger destination operand, clearing all remaining bits.
 This is called **zero extension**:
 
 ```x86asm
 mov ax, 1000 ; lower 16 bits of eax are 1000, upper bits are undefined
 mov cx, 200 ; lower 16 bits of ecx are 200, upper bits are undefined
 
-; 200 * 1000 does not fit in 16 bits, so a 32 bits multiplication is necessary
+; 200 * 1000 does not fit in 16 bits, so a 32-bit multiplication is necessary
 ; however, multiplying eax by ecx may produce an incorrect result due to undefined bits
 
 movzx eax, ax ; lower 16 bits of eax remain 1000, upper bits are cleared
@@ -150,13 +150,6 @@ mul ecx ; now eax correctly holds 200 * 1000
 ```
 
 A 32-bit source operand is always zero-extended to all 64 bits of the destination operand with a simple `mov`.
-
-#### Using imul with unsigned numbers
-
-It is possible to use `imul` to multiply unsigned numbers.
-However, this may give an incorrect result if one of the numbers may be interpreted as negative.
-
-Since the sign bit in a signed integer corresponds to the most significant bit in an unsigned integer, in practice, this difference becomes relevant when more than the truncated result is needed, i.e., when the full range of `rdx:rax` is used.
 
 ### Division
 
@@ -173,25 +166,30 @@ idiv src
 In both cases, the value in `rdx:rax` is divided by the value in the source operand.
 The quotient is written to the `rax` register and the remainder is written to the `rdx` register.
 
-Notice that as `rdx:rax` is the dividend, both registers must have the appropriate bits set.
+Note that as `rdx:rax` is the dividend, both registers must have the appropriate bits set.
 
-So, whenever working with 64-bit integers, all bits in the `rdx` register must be cleared for a non-negative number in `rax`, and set for a negative number.
+So, whenever working with 64-bit integers, the `rdx` register must be set up before the division.
+
+For unsigned division, all bits in `rdx` must be cleared.
+This is called **zero extension**.
+
+For signed division, all bits in `rdx` must be cleared for a non-negative number in `rax`, and set for a negative number.
 This is called **sign extension**.
 
-Failing to perform sign extension can cause a wrong result for the division or, if the quotient is too large to fit in `rax`, an error.
+Failing to do this can cause a wrong result for the division or, if the quotient is too large to fit in `rax`, an error.
 
-There are three instructions that automate this process: `cwd`, `cdq` and `cqo`.
+There are three instructions that automate the sign extension: `cwd`, `cdq` and `cqo`.
 They perform sign extension from `ax` to `dx`, from `eax` to `edx` and from `rax` to `rdx`, respectively.
 
-There's no equivalent instruction for sign extending `al` to `dl` because division between two bytes operate differently.
+There's no equivalent instruction for sign extending `al` to `dl` because division between two bytes operates differently.
 Instead of using `dl:al`, `ax` is used.
 
 So, the lower 8 bits of `ax` (`al`) will get the quotient of the operation and the higher 8 bits (`ah`) will get the remainder.
 
 There is also the instruction `movsx` that works similarly to `movzx`, extending from any 8-bit or 16-bit source operand to a larger destination operand.
-While `movzx` performs zero-extension, however, `movsx` performs sign-extension.
+While `movzx` performs zero-extension, `movsx` performs sign-extension.
 
-A variant of `movsx` called `movsxd` can sign-extend from a 32-bit source operand to a 64-bit destination operand, as well as between two 16-bit or two 32-bit operands.
+A variant of `movsx` called `movsxd` can sign-extend from a 32-bit source operand to a 64-bit destination operand.
 
 ~~~~exercism/caution
 The `rdx` register is implicitly used in an integer division.

--- a/exercises/concept/inventory-management/.docs/instructions.md
+++ b/exercises/concept/inventory-management/.docs/instructions.md
@@ -8,21 +8,21 @@ You have four tasks, all related to managing the transport.
 ~~~~exercism/note
 These are the instructions mentioned in this concept:
 
-| Instruction   | Description                                                           |
-|---------------|-----------------------------------------------------------------------|
-| add a, b      | sets a to a + b                                                       |
-| adc a, b      | sets a to a + b + CF (previous carry)                                 |
-| inc a         | sets a to a + 1                                                       |
-| sub a, b      | sets a to a - b                                                       |
-| dec a         | sets a to a - 1                                                       |
-| imul a        | sets rax to a * rax (signed)                                          |
-| imul a, b     | sets a to a * b                                                       |
-| imul a, b, c  | sets a to b * c                                                       |
-| mul a         | sets rax to a * rax (unsigned)                                        |
-| div a         | sets rax to rax / a and rdx to rax % a (unsigned)                     |
-| idiv a        | sets rax to rax / a and rdx to rax % a (signed)                       |
-| movzx a, b    | copies b to a, adding 0 to exceeding bits                             |
-| movsx a, b    | copies b to a, adding 1 to exceeding bits if num b < 0 or 0 otherwise |
+| Instruction   | Description                                                     |
+|---------------|-----------------------------------------------------------------|
+| add a, b      | a = a + b                                                       |
+| adc a, b      | a = a + b + CF (previous carry)                                 |
+| inc a         | a = a + 1                                                       |
+| sub a, b      | a = a - b                                                       |
+| dec a         | a = a - 1                                                       |
+| imul a        | rdx:rax = a * rax (signed)                                      |
+| imul a, b     | a = a * b (signed)                                              |
+| imul a, b, c  | a = b * c (signed)                                              |
+| mul a         | rdx:rax = a * rax (unsigned)                                    |
+| div a         | rax = quotient, rdx = remainder of rdx:rax / a (unsigned)       |
+| idiv a        | rax = quotient, rdx = remainder of rdx:rax / a (signed)         |
+| movzx a, b    | a = b, adding 0 to the extra bits                               |
+| movsx a, b    | a = b, adding 1 to the extra bits if b < 0 or 0 otherwise       |
 ~~~~
 
 ~~~~exercism/note
@@ -39,7 +39,7 @@ You can refer to the [previous concept][basics] for the full table.
 Items are being packed in boxes that must be labeled with their weight.
 There is no scale around, but luckily you know how much each item weighs on average.
 
-In order to better organize things, a box holds only items of two different products.
+To better organize things, a box holds only items of two different products.
 
 Define a function `get_box_weight` that returns the total weight of a box, in `g`.
 This function takes as parameters, in this order:
@@ -50,7 +50,7 @@ This function takes as parameters, in this order:
 - The weight of each item of the second product, in `g`
 
 Consider that an empty box weighs **500 g**.
-A constant `WEIGHT_OF_EMPTY_BOX` is defined at the top of the file.
+A constant `WEIGHT_OF_EMPTY_BOX` is defined at the top of the solution file.
 
 Example:
 
@@ -70,7 +70,7 @@ Define a function `max_number_of_boxes` that returns how many boxes of a certain
 
 This function takes as parameter the height of the box, in `cm`.
 Consider that the truck interior height is **300 cm**.
-A constant TRUCK_HEIGHT is defined at the top of the file.
+A constant `TRUCK_HEIGHT` is defined at the top of the solution file.
 
 Example:
 
@@ -80,6 +80,7 @@ max_number_of_boxes(30);
 ```
 
 The argument and the return value are 8-bit non-negative integers.
+The box height is always at least `2`, so the result fits in 8 bits.
 
 ## 3. Check if all products are accounted for
 
@@ -107,13 +108,21 @@ In case of an error in the process, it is possible that the result is a negative
 
 Your payment is based on how many boxes were moved and how many truck trips were necessary.
 For each box, you will be paid **5 dollars** and for each trip, you will be paid **220 dollars**.
-You may have received part of this payment up front to cover initial costs.
+Constants `PAY_PER_BOX` and `PAY_PER_TRUCK_TRIP` are defined at the top of the solution file.
 
-However, some products are not covered by insurance and your payment will be reduced by the value of any of those items broken or missing.
+Note that you may have received part of this payment up front to cover initial costs, and this up-front payment should be subtracted from the final pay.
+In addition, some products are not covered by insurance and your payment will also be reduced by the value of any of those items broken or missing.
 It is possible that you end up owing money if you are not careful!
+
+This means the net amount you are owed, or owe, is:
+
+```c
+net = boxes * PAY_PER_BOX + trips * PAY_PER_TRUCK_TRIP - up_front - broken_items * item_value
+```
 
 This payment, or debt, will be divided equally between you and a number of workers you hired.
 Any remaining money, or debt, is yours.
+For example, if the net amount of money is `100` being shared amongst `6` people (you and `5` workers), you get `20` (`100/(5 + 1) = 16` plus the remaining `4`).
 
 Define a function `calculate_payment` that returns how much you should be paid, or pay, at the end.
 This function takes as parameters, in this order:
@@ -123,7 +132,7 @@ This function takes as parameters, in this order:
 - The number of truck trips made, as a 32-bit non-negative integer
 - The number of broken or missing items, as a 32-bit non-negative integer
 - The value of each lost item, as a 64-bit non-negative integer
-- The number of workers to split the payment or debt with you, as a 8-bit positive integer
+- The number of workers to split the payment or debt with you, as an 8-bit positive integer
 
 Example:
 

--- a/exercises/concept/inventory-management/.docs/introduction.md
+++ b/exercises/concept/inventory-management/.docs/introduction.md
@@ -4,7 +4,7 @@
 
 An **integer** is an abstraction that represents whole numbers, such as `4`, `-2`, `0` or `64532`.
 
-In order to represent an integer as a sequence of bytes, the **binary notation** is used.
+To represent an integer as a sequence of bytes, the **binary notation** is used.
 In this system, each bit in the sequence represents a distinct power of two, with the value increasing as the index of the bit increases from right to left.
 
 ## Unsigned and Signed Integers
@@ -13,7 +13,7 @@ In this system, each bit in the sequence represents a distinct power of two, wit
 
 If the number can only be non-negative, it's called an **unsigned** number.
 
-Unsigned numbers are represented directly as the sum of all set bits in its sequence.
+Unsigned numbers are represented directly as the sum of all set bits in their sequence.
 
 The range of representable non-negative integers in a register goes from `0` (no bit set) to `2⁶⁴ - 1` (sum of all 64 bits set).
 
@@ -21,7 +21,7 @@ The range of representable non-negative integers in a register goes from `0` (no
 
 If an integer can assume positive or negative values, it's called a **signed** number.
 
-In order to represent negative numbers, x86-64 uses the **two's complement** representation.
+To represent negative numbers, x86-64 uses the **two's complement** representation.
 
 The `neg` instruction can be used to change the sign of a number.
 
@@ -46,10 +46,10 @@ The exception to this rule is `mov`, which accepts a _64-bit signed integer_ as 
 It is possible to use a signed negative integer as immediate in place of an unsigned integer with the same bit representation:
 
 ```x86asm
-add eax, -1          ; this is 4294967295 in unsigned representation
-                     ; an attempt to use 4294967295 directly wouldn't work because immediates are usually 32-bit signed integers
+add rax, -1  ; this is 18446744073709551615 in unsigned representation
+             ; an attempt to use 18446744073709551615 directly wouldn't work because immediates are usually 32-bit signed integers
 
-mov eax, 4294967295  ; this works because mov can take a 64-bit immediate as source operand
+mov rax, 18446744073709551615  ; this works because mov can take a 64-bit immediate as source operand
 ```
 
 ## Arithmetic
@@ -65,7 +65,7 @@ The `CF` can also be set by other instructions, performing other operations.
 The instruction `adc` can be used to sum two numbers and also the value in the carry flag.
 It is a two-operand instruction, with the same syntax as `add`.
 
-There's also a `inc` one-operand instruction, that sums 1 to the value in its operand.
+There's also an `inc` one-operand instruction, that sums 1 to the value in its operand.
 
 The sum of two integers operates in the same way for both unsigned and signed numbers.
 
@@ -73,7 +73,7 @@ The sum of two integers operates in the same way for both unsigned and signed nu
 
 The subtraction of two integers is performed using the `sub` instruction.
 
-There's also a `dec` one-operand instruction, that subtracts 1 from the value in its operand:
+There's also a `dec` one-operand instruction, that subtracts 1 from the value in its operand.
 
 The subtraction of two integers also operates in the same way for both unsigned and signed numbers.
 
@@ -112,7 +112,7 @@ In this case, instead of `dl:al`, `ax` will be used.
 The lower portion of `ax` (`al`) will get the lower 8 bits of the product, while the upper portion (`ah`) will get the upper 8 bits.
 
 ~~~~exercism/caution
-The `rdx` register is implicitly used in an one-operand multiplication.
+The `rdx` register is implicitly used in a one-operand multiplication.
 This means any necessary value in `rdx` must be saved before that operation.
 ~~~~
 
@@ -134,14 +134,14 @@ This product is also truncated to fit into the destination operand.
 
 In case of a possible overflow, it is sometimes useful to move operands to a larger register size.
 
-A `movzx` instruction can be used to convert a value in a 8-bit or 16-bit source operand to a larger destination operand, clearing all remaining bits.
+A `movzx` instruction can be used to convert a value in an 8-bit or 16-bit source operand to a larger destination operand, clearing all remaining bits.
 This is called **zero extension**:
 
 ```x86asm
 mov ax, 1000 ; lower 16 bits of eax are 1000, upper bits are undefined
 mov cx, 200 ; lower 16 bits of ecx are 200, upper bits are undefined
 
-; 200 * 1000 does not fit in 16 bits, so a 32 bits multiplication is necessary
+; 200 * 1000 does not fit in 16 bits, so a 32-bit multiplication is necessary
 ; however, multiplying eax by ecx may produce an incorrect result due to undefined bits
 
 movzx eax, ax ; lower 16 bits of eax remain 1000, upper bits are cleared
@@ -150,13 +150,6 @@ mul ecx ; now eax correctly holds 200 * 1000
 ```
 
 A 32-bit source operand is always zero-extended to all 64 bits of the destination operand with a simple `mov`.
-
-#### Using imul with unsigned numbers
-
-It is possible to use `imul` to multiply unsigned numbers.
-However, this may give an incorrect result if one of the numbers may be interpreted as negative.
-
-Since the sign bit in a signed integer corresponds to the most significant bit in an unsigned integer, in practice, this difference becomes relevant when more than the truncated result is needed, i.e., when the full range of `rdx:rax` is used.
 
 ### Division
 
@@ -173,25 +166,30 @@ idiv src
 In both cases, the value in `rdx:rax` is divided by the value in the source operand.
 The quotient is written to the `rax` register and the remainder is written to the `rdx` register.
 
-Notice that as `rdx:rax` is the dividend, both registers must have the appropriate bits set.
+Note that as `rdx:rax` is the dividend, both registers must have the appropriate bits set.
 
-So, whenever working with 64-bit integers, all bits in the `rdx` register must be cleared for a non-negative number in `rax`, and set for a negative number.
+So, whenever working with 64-bit integers, the `rdx` register must be set up before the division.
+
+For unsigned division, all bits in `rdx` must be cleared.
+This is called **zero extension**.
+
+For signed division, all bits in `rdx` must be cleared for a non-negative number in `rax`, and set for a negative number.
 This is called **sign extension**.
 
-Failing to perform sign extension can cause a wrong result for the division or, if the quotient is too large to fit in `rax`, an error.
+Failing to do this can cause a wrong result for the division or, if the quotient is too large to fit in `rax`, an error.
 
-There are three instructions that automate this process: `cwd`, `cdq` and `cqo`.
+There are three instructions that automate the sign extension: `cwd`, `cdq` and `cqo`.
 They perform sign extension from `ax` to `dx`, from `eax` to `edx` and from `rax` to `rdx`, respectively.
 
-There's no equivalent instruction for sign extending `al` to `dl` because division between two bytes operate differently.
+There's no equivalent instruction for sign extending `al` to `dl` because division between two bytes operates differently.
 Instead of using `dl:al`, `ax` is used.
 
 So, the lower 8 bits of `ax` (`al`) will get the quotient of the operation and the higher 8 bits (`ah`) will get the remainder.
 
 There is also the instruction `movsx` that works similarly to `movzx`, extending from any 8-bit or 16-bit source operand to a larger destination operand.
-While `movzx` performs zero-extension, however, `movsx` performs sign-extension.
+While `movzx` performs zero-extension, `movsx` performs sign-extension.
 
-A variant of `movsx` called `movsxd` can sign-extend from a 32-bit source operand to a 64-bit destination operand, as well as between two 16-bit or two 32-bit operands.
+A variant of `movsx` called `movsxd` can sign-extend from a 32-bit source operand to a 64-bit destination operand.
 
 ~~~~exercism/caution
 The `rdx` register is implicitly used in an integer division.


### PR DESCRIPTION
The most important change here is making the instructions for `inventory-management` clearer. There were a few reports on discord of students not understanding the instructions and Isaac suggested adding an example to clarify what the exercise meant by `remaining money` in task 4.

I also took the chance to revise the concept and the instructions more carefully, making many small changes to improve clarity.