### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/affine-cipher/.docs/instructions.append.md
+++ b/exercises/practice/affine-cipher/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Instructions
+# Instructions append
+
+## Implementation
 
 If `a` is not coprime to `m`, output an empty string.

--- a/exercises/practice/circular-buffer/.docs/instructions.append.md
+++ b/exercises/practice/circular-buffer/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## x86-64-assembly specific notes
 
 The buffer's capacity will be at most 100.

--- a/exercises/practice/dnd-character/.docs/instructions.append.md
+++ b/exercises/practice/dnd-character/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## x86-64 Assembly Specific Notes
 
 In the x86-64-assembly track, the randomness of the ability() function is checked by a [chi-squared test][chi-squared-test], at the level of [p][p-value] < 0.0001.

--- a/exercises/practice/eliuds-eggs/.docs/instructions.append.md
+++ b/exercises/practice/eliuds-eggs/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 Avoid using [POPCNT](https://www.felixcloutier.com/x86/popcnt) for this exercise.

--- a/exercises/practice/etl/.docs/instructions.append.md
+++ b/exercises/practice/etl/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Instructions
+# Instructions append
+
+## Instructions
 
 Elements in output array are tested in order of ascending key.
 

--- a/exercises/practice/high-scores/.docs/instructions.append.md
+++ b/exercises/practice/high-scores/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## x86-64 Assembly Specific Notes
 
 The functions in this exercise accept an array containing one or more numbers, each representing one 'game score'.

--- a/exercises/practice/kindergarten-garden/.docs/instructions.append.md
+++ b/exercises/practice/kindergarten-garden/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Output format
 
 Output the student's plants as a null-terminated string, using a comma and a space as separators.

--- a/exercises/practice/phone-number/.docs/instructions.append.md
+++ b/exercises/practice/phone-number/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 If the phone number is invalid, output an empty string.

--- a/exercises/practice/protein-translation/.docs/instructions.append.md
+++ b/exercises/practice/protein-translation/.docs/instructions.append.md
@@ -1,3 +1,7 @@
 # Instructions append
 
-- Note that the tests for this exercise expect the output words to be proper C strings. That is, they should be NUL terminated. See <https://en.wikipedia.org/wiki/C_string_handling>
+## Implementation
+
+- Note that the tests for this exercise expect the output words to be proper C strings.
+  That is, they should be NUL terminated.
+  See <https://en.wikipedia.org/wiki/C_string_handling>

--- a/exercises/practice/simple-linked-list/.docs/instructions.append.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 ## Instructions append
 
+## Implementation
+
 You may consider that all functions will be called with valid values and that `pop_list` and `peek_list` won't be called on empty lists.

--- a/exercises/practice/split-second-stopwatch/.docs/instructions.append.md
+++ b/exercises/practice/split-second-stopwatch/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## x86-64-assembly specific notes
 
 The maximum number of laps for a stopwatch is 10.

--- a/exercises/practice/square-root/.docs/instructions.append.md
+++ b/exercises/practice/square-root/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 Avoid using floating point [square root] instructions for this exercise.
 
 [square root]: https://www.felixcloutier.com/x86/fsqrt


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.