### PR TITLE
Add `simd` concept and its exercise

### DIFF
--- a/concepts/simd/.meta/config.json
+++ b/concepts/simd/.meta/config.json
@@ -1,0 +1,4 @@
+{
+  "blurb": "Introduction to SIMD operations in x86-64 assembly.",
+  "authors": ["oxe-i"]
+}

--- a/concepts/simd/about.md
+++ b/concepts/simd/about.md
@@ -1,0 +1,218 @@
+# About
+
+[Single instruction, multiple data (SIMD)][SIMD] is a form of hardware-level parallelism.
+The same computation is performed by the CPU over multiple elements at the same time.
+
+Consider, for example, summing two arrays of four 32-bit floats element-wise.
+A scalar implementation would issue four separate `addss` instructions, one per element.
+A SIMD implementation uses a single `addps` to do all four additions in parallel.
+That gives four times the work per instruction.
+
+In x86-64 assembly, SIMD instructions are typically performed using `xmm` registers.
+Some of those instructions operate on integers.
+Others operate on floating-point numbers.
+
+Those integers or floating-point numbers are called **packed**.
+Each occupies a space, called a **lane**, within the same register.
+SIMD instructions typically operate in parallel on values at the same lane position across two source operands.
+The result of each operation is stored in the lane at the same position in the destination operand.
+
+A lane is not a hard limit.
+It is an interpretation given by each instruction to a sequence of bytes.
+A 128-bit operand contains 16 bytes.
+Depending on the instruction, those bytes can be interpreted as 16 _1-byte_ lanes, 8 _2-byte_ lanes, 4 _4-byte_ lanes, 2 _8-byte_ lanes, or even a single _16-byte_ lane.
+
+For example, the instruction `addps` adds packed single-precision (4-byte) floating-point values.
+For this instruction, each 4-byte chunk in an operand is a different lane.
+In a 128-bit wide (16-byte) operand:
+
+| operand     | 4th lane | 3rd lane | 2nd lane | 1st lane |
+|:-----------:|:--------:|:--------:|:--------:|:--------:|
+| source 1    |  1.5     |  2.1     | 6.2      | 3.4      |
+|    +        |  +       |  +       | +        | +        |
+| source 2    |  0.5     |  8.26    | -13.4    | 22.9     |
+|    =        |  =       |  =       | =        | =        |
+| result      |  2.0     |  10.36   | -7.2     | 26.3     |
+
+On the other hand, a 128-bit operand would be interpreted as having 2 lanes in the case of `mulpd`.
+This is because this instruction performs packed multiplication on double-precision (8-byte) values:
+
+| operand     | 2nd lane | 1st lane |
+|:-----------:|:--------:|:--------:|
+| source 1    |  4.2     |  2.1     |
+|    *        |  *       |  *       |
+| source 2    |  1.0     |  92.4    |
+|    =        |  =       |  =       |
+| result      |  4.2     |  194.04  |
+
+In this concept we will focus on a small selection of SIMD instructions.
+They operate on packed floating-point values using `xmm` registers.
+
+## Floating-Point SIMD Instructions
+
+As a rule of thumb, SIMD instructions that operate on floating-point values take a two-operand form.
+Their name follows a certain structure:
+
+1. The operation being performed, with the same name as their non-SIMD (also called _scalar_) counterpart (e.g., `add`, `mul`, etc.).
+2. A suffix `p` to indicate that the instruction operates on _packed_ data, in the same position previously occupied by an `s` (for _scalar_ data).
+3. A suffix to indicate the size of each lane, following the same semantics as their non-SIMD counterpart (`s` for single-precision and `d` for double-precision).
+
+The packed name is therefore obtained from the scalar name by substituting the `s` (scalar) in the middle of the mnemonic for a `p` (packed).
+The operation name and the size suffix stay unchanged:
+
+| scalar  | packed  | meaning                                |
+|---------|---------|----------------------------------------|
+| `addss` | `addps` | add, single-precision (32-bit lanes)   |
+| `addsd` | `addpd` | add, double-precision (64-bit lanes)   |
+| `mulss` | `mulps` | multiply, single-precision             |
+| `mulsd` | `mulpd` | multiply, double-precision             |
+
+### Arithmetic
+
+Arithmetic SIMD instructions follow the rule above.
+Some examples:
+
+```x86asm
+addps xmm0, xmm1 ; xmm0 = xmm0 + xmm1 (each 32-bit float at the same position)
+subpd xmm2, xmm3 ; xmm2 = xmm2 - xmm3 (each 64-bit float at the same position)
+mulps xmm4, xmm5 ; xmm4 = xmm4 * xmm5 (each 32-bit float at the same position)
+divpd xmm6, xmm7 ; xmm6 = xmm6 / xmm7 (each 64-bit float at the same position)
+```
+
+### Conversion Between Precisions
+
+There are also SIMD instructions to convert between packed single-precision and packed double-precision floating-point values.
+They follow the same naming rule, with each `s` for _scalar_ replaced by a `p` for _packed_:
+
+| scalar     | packed     | meaning                                      |
+|------------|------------|----------------------------------------------|
+| `cvtss2sd` | `cvtps2pd` | convert single-precision to double-precision |
+| `cvtsd2ss` | `cvtpd2ps` | convert double-precision to single-precision |
+
+These instructions illustrate the earlier point that a lane is an interpretation, not a hard limit.
+The source and destination operands have different lane sizes, so they have different lane counts.
+
+For `cvtps2pd`, the source (`ps`) has 4 single-precision lanes.
+The destination (`pd`) has 2 double-precision lanes.
+Only the lower 2 lanes of the source are read.
+The upper 2 are ignored:
+
+| operand              | 4th lane | 3rd lane | 2nd lane | 1st lane |
+|:--------------------:|:--------:|:--------:|:--------:|:--------:|
+| source as `ps`       | ignored  | ignored  | 2.5      | 1.5      |
+| destination as `pd`  |          |          | 2.5      | 1.5      |
+
+For `cvtpd2ps`, the source (`pd`) has 2 double-precision lanes.
+The destination (`ps`) has 4 single-precision lanes.
+Both source lanes are converted and written to the lower 2 lanes of the destination.
+The upper 2 lanes of the destination are set to zero:
+
+| operand              | 4th lane | 3rd lane | 2nd lane | 1st lane |
+|:--------------------:|:--------:|:--------:|:--------:|:--------:|
+| source as `pd`       |          |          | 4.0      | 3.0      |
+| destination as `ps`  | 0        | 0        | 4.0      | 3.0      |
+
+Some examples:
+
+```x86asm
+cvtps2pd xmm0, xmm1 ; xmm0 = xmm1 as 2 doubles (low 2 lanes of xmm1 are read)
+cvtpd2ps xmm0, xmm1 ; xmm0 = xmm1 as 2 floats (in low 2 lanes; upper 2 zeroed)
+```
+
+### Memory Operands
+
+The SIMD instructions above have all been shown with register-to-register operands.
+They may also take a memory operand as their source (but **not** their destination).
+
+The number of bytes read from memory is determined by the instruction.
+For example, `addps` reads 16 bytes (4 single-precision floats).
+`cvtps2pd`, by contrast, reads only 8 bytes (2 single-precision floats), because that is all the input it needs.
+
+```x86asm
+addps    xmm0, [rsi]      ; xmm0 = xmm0 + 4 floats at [rsi]
+mulpd    xmm1, [rsi + 16] ; xmm1 = xmm1 * 2 doubles at [rsi + 16]
+cvtps2pd xmm2, [rsi + 8]  ; xmm2 = (2 floats at [rsi + 8]) converted to 2 doubles
+```
+
+When the memory operand is 16 bytes wide, it must be _16-byte aligned_.
+An aligned memory location is one whose address is a multiple of the size of the operation (16 bytes in this case).
+
+To declare aligned memory, you can use the `align` directive on section .data and .rodata, or `alignb`, on section .bss:
+
+```x86asm
+section .rodata
+align 16
+mem1: dd 4.0, 3.5, 2.0, -1.0
+
+section .data
+align 16
+mem2: dq 6.0, 2.1
+
+section .bss
+alignb 16
+mem3: resb 16
+```
+
+Memory operands smaller than 16 bytes, such as the 8-byte source of `cvtps2pd`, have no alignment requirement.
+
+### Loading/Storing Values
+
+There are four instructions that copy 128 bits of packed floating-point values.
+They operate between two `xmm` registers, or between one `xmm` register and a memory location:
+
+| instruction | description                                                                       |
+|-------------|-----------------------------------------------------------------------------------|
+| `movaps`    | copies packed single-precision data from, or to, an _aligned_ memory location     |
+| `movups`    | copies packed single-precision data from, or to, an _unaligned_ memory location   |
+| `movapd`    | copies packed double-precision data from, or to, an _aligned_  memory location    |
+| `movupd`    | copies packed double-precision data from, or to, an _unaligned_ memory location   |
+
+All of those instructions may be used to copy values between two `xmm` registers.
+
+If the operation involves a memory location, `movaps` and `movapd` require that it be _aligned_.
+`movaps` and `movapd` will raise a fault if given a misaligned address.
+They double as a safety check that your data layout is what you think it is.
+
+On the other hand, `movups` and `movupd` may be used with any memory location, aligned or not.
+
+The size prefix for a 16-byte value in NASM is `oword`.
+
+## SIMD Extensions
+
+SIMD has been a target of active development in the x86-64 ecosystem for decades.
+Each extension to the architecture brings new instructions or new uses for old instructions.
+
+In particular, the extensions [AVX and AVX2][AVX] introduce some relevant changes.
+
+First, support for 256-bit SIMD registers, called `ymm`.
+They extend corresponding `xmm` registers, much as `rax` contains `eax`.
+
+Second, they include support for 3-operand variants for most instructions that operate on `xmm` (and `ymm`) registers.
+This includes not only SIMD instructions, but also those that operate on scalar floating-point values.
+Those variants follow the same notation of their SSE equivalent, with a `v` added before:
+
+```x86asm
+vaddsd xmm0, xmm1, xmm2   ; xmm0 = xmm1 + xmm2 (scalar sum of 64-bit floats)
+vmulps xmm1, xmm3, xmm4   ; xmm1 = xmm3 * xmm4 (packed multiplication of 32-bit floats)
+vmovupd ymm5, yword [mem] ; this copies 32 bytes from the location at mem to ymm5
+```
+
+Third, the alignment required of SIMD memory operands is relaxed.
+Only explicitly aligned moves, such as `vmovaps`, require this alignment.
+
+In this track, we have restricted ourselves to instructions and registers up to the previous SSE extensions.
+This is enough to teach foundations and ensures compatibility with a wide array of CPUs.
+
+However, the test-runner fully supports AVX and AVX2, and even the newer extensions that are part of AVX-512.
+You are free to use them.
+
+~~~~exercism/note
+It is good practice to be consistent in your use of SIMD variants.
+Try to not mix SSE and AVX variants for the same instructions.
+
+If your code base mixes those variants, it is good practice to use `vzeroupper` after you have finished your work with AVX and before using SSE.
+This breaks dependency chains and avoids a costly stall when the CPU transitions between AVX and SSE state.
+~~~~
+
+[SIMD]: https://en.wikipedia.org/wiki/Single_instruction,_multiple_data
+[AVX]: https://en.wikipedia.org/wiki/Advanced_Vector_Extensions

--- a/concepts/simd/about.md
+++ b/concepts/simd/about.md
@@ -151,6 +151,13 @@ mem2: dq 6.0, 2.1
 section .bss
 alignb 16
 mem3: resb 16
+
+section .text
+fn:
+    movaps xmm0, oword [rel mem1] ; loads 4 packed 32-bit floats in xmm0
+    movapd xmm1, oword [rel mem2] ; loads 2 packed 64-bit floats in xmm1
+    movaps oword [rel mem3], xmm0 ; stores 4 packed 32-bit floats in mem3
+    ret
 ```
 
 Memory operands smaller than 16 bytes, such as the 8-byte source of `cvtps2pd`, have no alignment requirement.
@@ -208,7 +215,7 @@ You are free to use them.
 
 ~~~~exercism/note
 It is good practice to be consistent in your use of SIMD variants.
-Try to not mix SSE and AVX variants for the same instructions.
+Try not to mix SSE and AVX variants for the same instructions.
 
 If your code base mixes those variants, it is good practice to use `vzeroupper` after you have finished your work with AVX and before using SSE.
 This breaks dependency chains and avoids a costly stall when the CPU transitions between AVX and SSE state.

--- a/concepts/simd/introduction.md
+++ b/concepts/simd/introduction.md
@@ -1,0 +1,222 @@
+# Introduction
+
+**Single instruction, multiple data (SIMD)** is a form of hardware-level parallelism.
+The same computation is performed by the CPU over multiple elements at the same time.
+
+Consider, for example, summing two arrays of four 32-bit floats element-wise.
+A scalar implementation would issue four separate `addss` instructions, one per element.
+A SIMD implementation uses a single `addps` to do all four additions in parallel.
+That gives four times the work per instruction.
+
+In x86-64 assembly, SIMD instructions are typically performed using `xmm` registers.
+Some of those instructions operate on integers.
+Others operate on floating-point numbers.
+
+Those integers or floating-point numbers are called **packed**.
+Each occupies a space, called a **lane**, within the same register.
+SIMD instructions typically operate in parallel on values at the same lane position across two source operands.
+The result of each operation is stored in the lane at the same position in the destination operand.
+
+A lane is not a hard limit.
+It is an interpretation given by each instruction to a sequence of bytes.
+A 128-bit operand contains 16 bytes.
+Depending on the instruction, those bytes can be interpreted as 16 _1-byte_ lanes, 8 _2-byte_ lanes, 4 _4-byte_ lanes, 2 _8-byte_ lanes, or even a single _16-byte_ lane.
+
+For example, the instruction `addps` adds packed single-precision (4-byte) floating-point values.
+For this instruction, each 4-byte chunk in an operand is a different lane.
+In a 128-bit wide (16-byte) operand:
+
+| operand     | 4th lane | 3rd lane | 2nd lane | 1st lane |
+|:-----------:|:--------:|:--------:|:--------:|:--------:|
+| source 1    |  1.5     |  2.1     | 6.2      | 3.4      |
+|    +        |  +       |  +       | +        | +        |
+| source 2    |  0.5     |  8.26    | -13.4    | 22.9     |
+|    =        |  =       |  =       | =        | =        |
+| result      |  2.0     |  10.36   | -7.2     | 26.3     |
+
+On the other hand, a 128-bit operand would be interpreted as having 2 lanes in the case of `mulpd`.
+This is because this instruction performs packed multiplication on double-precision (8-byte) values:
+
+| operand     | 2nd lane | 1st lane |
+|:-----------:|:--------:|:--------:|
+| source 1    |  4.2     |  2.1     |
+|    *        |  *       |  *       |
+| source 2    |  1.0     |  92.4    |
+|    =        |  =       |  =       |
+| result      |  4.2     |  194.04  |
+
+In this concept we will focus on a small selection of SIMD instructions.
+They operate on packed floating-point values using `xmm` registers.
+
+## Floating-Point SIMD Instructions
+
+As a rule of thumb, SIMD instructions that operate on floating-point values take a two-operand form.
+Their name follows a certain structure:
+
+1. The operation being performed, with the same name as their non-SIMD (also called _scalar_) counterpart (e.g., `add`, `mul`, etc.).
+2. A suffix `p` to indicate that the instruction operates on _packed_ data, in the same position previously occupied by an `s` (for _scalar_ data).
+3. A suffix to indicate the size of each lane, following the same semantics as their non-SIMD counterpart (`s` for single-precision and `d` for double-precision).
+
+The packed name is therefore obtained from the scalar name by substituting the `s` (scalar) in the middle of the mnemonic for a `p` (packed).
+The operation name and the size suffix stay unchanged:
+
+| scalar  | packed  | meaning                                |
+|---------|---------|----------------------------------------|
+| `addss` | `addps` | add, single-precision (32-bit lanes)   |
+| `addsd` | `addpd` | add, double-precision (64-bit lanes)   |
+| `mulss` | `mulps` | multiply, single-precision             |
+| `mulsd` | `mulpd` | multiply, double-precision             |
+
+### Arithmetic
+
+Arithmetic SIMD instructions follow the rule above.
+Some examples:
+
+```x86asm
+addps xmm0, xmm1 ; xmm0 = xmm0 + xmm1 (each 32-bit float at the same position)
+subpd xmm2, xmm3 ; xmm2 = xmm2 - xmm3 (each 64-bit float at the same position)
+mulps xmm4, xmm5 ; xmm4 = xmm4 * xmm5 (each 32-bit float at the same position)
+divpd xmm6, xmm7 ; xmm6 = xmm6 / xmm7 (each 64-bit float at the same position)
+```
+
+### Conversion Between Precisions
+
+There are also SIMD instructions to convert between packed single-precision and packed double-precision floating-point values.
+They follow the same naming rule, with each `s` for _scalar_ replaced by a `p` for _packed_:
+
+| scalar     | packed     | meaning                                      |
+|------------|------------|----------------------------------------------|
+| `cvtss2sd` | `cvtps2pd` | convert single-precision to double-precision |
+| `cvtsd2ss` | `cvtpd2ps` | convert double-precision to single-precision |
+
+These instructions illustrate the earlier point that a lane is an interpretation, not a hard limit.
+The source and destination operands have different lane sizes, so they have different lane counts.
+
+For `cvtps2pd`, the source (`ps`) has 4 single-precision lanes.
+The destination (`pd`) has 2 double-precision lanes.
+Only the lower 2 lanes of the source are read.
+The upper 2 are ignored:
+
+| operand              | 4th lane | 3rd lane | 2nd lane | 1st lane |
+|:--------------------:|:--------:|:--------:|:--------:|:--------:|
+| source as `ps`       | ignored  | ignored  | 2.5      | 1.5      |
+| destination as `pd`  |          |          | 2.5      | 1.5      |
+
+For `cvtpd2ps`, the source (`pd`) has 2 double-precision lanes.
+The destination (`ps`) has 4 single-precision lanes.
+Both source lanes are converted and written to the lower 2 lanes of the destination.
+The upper 2 lanes of the destination are set to zero:
+
+| operand              | 4th lane | 3rd lane | 2nd lane | 1st lane |
+|:--------------------:|:--------:|:--------:|:--------:|:--------:|
+| source as `pd`       |          |          | 4.0      | 3.0      |
+| destination as `ps`  | 0        | 0        | 4.0      | 3.0      |
+
+Some examples:
+
+```x86asm
+cvtps2pd xmm0, xmm1 ; xmm0 = xmm1 as 2 doubles (low 2 lanes of xmm1 are read)
+cvtpd2ps xmm0, xmm1 ; xmm0 = xmm1 as 2 floats (in low 2 lanes; upper 2 zeroed)
+```
+
+### Memory Operands
+
+The SIMD instructions above have all been shown with register-to-register operands.
+They may also take a memory operand as their source (but **not** their destination).
+
+The number of bytes read from memory is determined by the instruction.
+For example, `addps` reads 16 bytes (4 single-precision floats).
+`cvtps2pd`, by contrast, reads only 8 bytes (2 single-precision floats), because that is all the input it needs.
+
+```x86asm
+addps    xmm0, [rsi]      ; xmm0 = xmm0 + 4 floats at [rsi]
+mulpd    xmm1, [rsi + 16] ; xmm1 = xmm1 * 2 doubles at [rsi + 16]
+cvtps2pd xmm2, [rsi + 8]  ; xmm2 = (2 floats at [rsi + 8]) converted to 2 doubles
+```
+
+When the memory operand is 16 bytes wide, it must be _16-byte aligned_.
+An aligned memory location is one whose address is a multiple of the size of the operation (16 bytes in this case).
+
+To declare aligned memory, you can use the `align` directive on section .data and .rodata, or `alignb`, on section .bss:
+
+```x86asm
+section .rodata
+align 16
+mem1: dd 4.0, 3.5, 2.0, -1.0
+
+section .data
+align 16
+mem2: dq 6.0, 2.1
+
+section .bss
+alignb 16
+mem3: resb 16
+
+section .text
+fn:
+    movaps xmm0, oword [rel mem1] ; loads 4 packed 32-bit floats in xmm0
+    movapd xmm1, oword [rel mem2] ; loads 2 packed 64-bit floats in xmm1
+    movaps oword [rel mem3], xmm0 ; stores 4 packed 32-bit floats in mem3
+    ret
+```
+
+Memory operands smaller than 16 bytes, such as the 8-byte source of `cvtps2pd`, have no alignment requirement.
+
+### Loading/Storing Values
+
+There are four instructions that copy 128 bits of packed floating-point values.
+They operate between two `xmm` registers, or between one `xmm` register and a memory location:
+
+| instruction | description                                                                       |
+|-------------|-----------------------------------------------------------------------------------|
+| `movaps`    | copies packed single-precision data from, or to, an _aligned_ memory location     |
+| `movups`    | copies packed single-precision data from, or to, an _unaligned_ memory location   |
+| `movapd`    | copies packed double-precision data from, or to, an _aligned_  memory location    |
+| `movupd`    | copies packed double-precision data from, or to, an _unaligned_ memory location   |
+
+All of those instructions may be used to copy values between two `xmm` registers.
+
+If the operation involves a memory location, `movaps` and `movapd` require that it be _aligned_.
+`movaps` and `movapd` will raise a fault if given a misaligned address.
+They double as a safety check that your data layout is what you think it is.
+
+On the other hand, `movups` and `movupd` may be used with any memory location, aligned or not.
+
+The size prefix for a 16-byte value in NASM is `oword`.
+
+## SIMD Extensions
+
+SIMD has been a target of active development in the x86-64 ecosystem for decades.
+Each extension to the architecture brings new instructions or new uses for old instructions.
+
+In particular, the extensions AVX and AVX2 introduce some relevant changes.
+
+First, support for 256-bit SIMD registers, called `ymm`.
+They extend corresponding `xmm` registers, much as `rax` contains `eax`.
+
+Second, they include support for 3-operand variants for most instructions that operate on `xmm` (and `ymm`) registers.
+This includes not only SIMD instructions, but also those that operate on scalar floating-point values.
+Those variants follow the same notation of their SSE equivalent, with a `v` added before:
+
+```x86asm
+vaddsd xmm0, xmm1, xmm2   ; xmm0 = xmm1 + xmm2 (scalar sum of 64-bit floats)
+vmulps xmm1, xmm3, xmm4   ; xmm1 = xmm3 * xmm4 (packed multiplication of 32-bit floats)
+vmovupd ymm5, yword [mem] ; this copies 32 bytes from the location at mem to ymm5
+```
+
+Third, the alignment required of SIMD memory operands is relaxed.
+Only explicitly aligned moves, such as `vmovaps`, require this alignment.
+
+In this track, we have restricted ourselves to instructions and registers up to the previous SSE extensions.
+This is enough to teach foundations and ensures compatibility with a wide array of CPUs.
+
+However, the test-runner fully supports AVX and AVX2, and even the newer extensions that are part of AVX-512.
+You are free to use them.
+
+~~~~exercism/note
+It is good practice to be consistent in your use of SIMD variants.
+Try to not mix SSE and AVX variants for the same instructions.
+
+If your code base mixes those variants, it is good practice to use `vzeroupper` after you have finished your work with AVX and before using SSE.
+This breaks dependency chains and avoids a costly stall when the CPU transitions between AVX and SSE state.
+~~~~

--- a/concepts/simd/introduction.md
+++ b/concepts/simd/introduction.md
@@ -215,7 +215,7 @@ You are free to use them.
 
 ~~~~exercism/note
 It is good practice to be consistent in your use of SIMD variants.
-Try to not mix SSE and AVX variants for the same instructions.
+Try not to mix SSE and AVX variants for the same instructions.
 
 If your code base mixes those variants, it is good practice to use `vzeroupper` after you have finished your work with AVX and before using SSE.
 This breaks dependency chains and avoids a costly stall when the CPU transitions between AVX and SSE state.

--- a/concepts/simd/links.json
+++ b/concepts/simd/links.json
@@ -1,0 +1,14 @@
+[
+  {
+    "url": "https://en.wikipedia.org/wiki/Single_instruction,_multiple_data",
+    "description": "Wikipedia Entry for SIMD"
+  },
+  {
+    "url": "https://www.felixcloutier.com/x86/",
+    "description": "Reference for x86-64 Instructions"
+  },
+  {
+    "url": "https://en.wikipedia.org/wiki/Advanced_Vector_Extensions",
+    "description": "Wikipedia Entry for AVX"
+  }
+]

--- a/config.json
+++ b/config.json
@@ -231,6 +231,20 @@
           "integers"
         ],
         "status": "beta"
+      },
+      {
+        "slug": "production-line",
+        "name": "Production Line",
+        "uuid": "3d6febe0-885a-4ef6-91ba-997dc635464a",
+        "concepts": [
+          "simd"
+        ],
+        "prerequisites": [
+          "floating-point-numbers",
+          "loops",
+          "arrays"
+        ],
+        "status": "beta"
       }
     ],
     "practice": [
@@ -1528,6 +1542,11 @@
       "uuid": "f4c4eda0-4948-43b4-a2c2-a4bfb70ea35e",
       "slug": "branchless-code",
       "name": "Branchless Code"
+    },
+    {
+      "uuid": "1f1d4891-131e-4f75-be06-38ee55e746e0",
+      "slug": "simd",
+      "name": "SIMD"
     }
   ],
   "key_features": [

--- a/exercises/concept/production-line/.docs/hints.md
+++ b/exercises/concept/production-line/.docs/hints.md
@@ -1,0 +1,41 @@
+# Hints
+
+## General
+
+- `movapd` and `movaps` should only be used when a memory operand is known to be aligned.
+  They are safe to use when both operands are `xmm` registers.
+- Memory addresses are passed as integer values.
+  The first six integer arguments are passed to a function in `rdi`, `rsi`, `rdx`, `rcx`, `r8` and `r9`, respectively.
+
+## 1. Combine yields from two lines
+
+- The packed addition for 32-bit floats is `addps`.
+- All three pointer arguments are guaranteed to be 16-byte aligned, so the aligned move variant, `movaps`, is appropriate.
+
+## 2. Compute scaled deviation
+
+- The packed subtraction for 64-bit floats is `subpd`.
+- The packed multiplication for 64-bit floats is `mulpd`.
+- `measured` is aligned and `target` is not, so they need different load variants.
+
+## 3. Calibrate a batch
+
+- Both `reference` and `offset` are aligned, `raw` is not, so they need different load variants.
+- Both `reference` and `offset` are needed for both rows.
+- Two-operand instructions usually overwrite their destination operand.
+- To convert the upper 2 floats of `raw` to doubles, use `cvtps2pd` with a memory operand offset by 8 bytes from the raw pointer.
+- The conversion factor should be stored in memory as 2 64-bit floating-point numbers (both equal to `0.5`).
+- The result spans 32 bytes (4 64-bit floating-point numbers): the first 16 bytes at `[result]`, the next 16 at `[result + 16]`.
+
+## 4. Normalize scores along a line
+
+- Two-operand instructions usually overwrite their destination operand.
+- Memory can't be the destination operand for arithmetic packed instructions.
+- For each 64-bit floating-point `score` in the `scores` array (first argument), there is an equivalent `gain` in the `gains` array (second argument).
+  Each `score` will operate with the `gain` at the same position.
+- The third argument is a fixed `scale` with 2 packed 64-bit floating-point numbers.
+- For each pair `score` and `gain`, the function calculates `score * gain / scale_lane`.
+  The first lane in `scale` scales the first element of every pair (lanes at even positions), the second lane scales the second (lanes at odd positions).
+- The normalized score is stored in-place in the `scores` array, at the same position of its input `score`.
+- The number of elements in `scores` and `gains` is the same and equal to the value of `n` (the fourth argument).
+- You should use a loop to process all pairs of elements, advancing 16 bytes (2 elements) each iteration.

--- a/exercises/concept/production-line/.docs/instructions.md
+++ b/exercises/concept/production-line/.docs/instructions.md
@@ -1,0 +1,129 @@
+# Instructions
+
+You are writing code for the data system on an automotive parts factory floor.
+Engine and chassis components move through a series of machining stations.
+Each station produces measurements that have to be combined, compared, calibrated, or normalized before the next stage runs.
+The functions you implement here are one for each station.
+
+~~~~exercism/note
+The computations in this exercise should be performed using SIMD instructions, not scalar operations.
+~~~~
+
+## 1. Combine yields from two lines
+
+The factory floor runs two parallel assembly lines.
+At the end of each shift, both lines report their yields for 4 part bins as single-precision numbers.
+The supervisor's dashboard shows the combined yield per bin, so the two reports are summed bin by bin.
+All three buffers are managed by the reporting system and are always 16-byte aligned.
+
+Define a function `sum_yields` that, given the per-bin yields from `line_a` and `line_b`, writes the bin-wise sum to `result`.
+The arguments, in order, are:
+
+1. `line_a`: 16-byte aligned memory address holding 4 32-bit floating-point numbers
+2. `line_b`: 16-byte aligned memory address holding 4 32-bit floating-point numbers
+3. `result`: 16-byte aligned memory address where the function will write 4 32-bit floating-point numbers
+
+This function has no return value, instead the result is stored in the passed buffer (`result`):
+
+```c
+line_a = {10.0, 20.0, 30.0, 40.0};
+line_b = { 5.0, 15.0, 25.0, 35.0};
+sum_yields(line_a, line_b, result);
+// => result == {15.0, 35.0, 55.0, 75.0};
+```
+
+## 2. Compute scaled deviation
+
+Between operations, a sampling station measures machined parts and compares them against target dimensions.
+The measured values stream in from a precision gauge into a buffer that is always 16-byte aligned.
+The target values come from the work order packet, which has no alignment guarantee.
+The deviation is multiplied by a per-axis sensitivity factor before it is passed to the downstream tolerance checker.
+For this stage, the downstream checker reads the deviation directly from a SIMD register rather than from memory.
+
+Define a function `scaled_deviation` that, given `measured` and `target` and a `sensitivity`, writes the scaled deviation to `result`.
+The arguments, in order, are:
+
+1. `measured`: 16-byte aligned memory address holding 2 64-bit floating-point numbers
+2. `target`: memory address holding 2 64-bit floating-point numbers (alignment not guaranteed)
+3. `sensitivity`: memory address holding 2 64-bit floating-point numbers (alignment not guaranteed)
+4. `result`: memory address for a buffer where the function will write 2 64-bit floating-point numbers (alignment not guaranteed)
+
+The scaled deviation is `(measured - target) * sensitivity`, lane-wise.
+
+This function has no return value, instead the result is stored in the passed buffer (`result`) as a pair of 64-bit floating-point numbers.
+
+```c
+measured    = {10.5, 20.5};
+target      = {10.0, 20.0};
+sensitivity = { 2.0,  4.0};
+scaled_deviation(measured, target, sensitivity, result);
+// => result == {1.0, 2.0};
+```
+
+## 3. Calibrate a batch
+
+Before parts enter the final inspection bay, the dimensional readings from a 4-part batch are rescaled into double precision and corrected for known temperature drift.
+
+The 4 raw readings arrive as single-precision numbers.
+For each row of 2 readings, the calibration computes `reference / (raw - offset)`, and then multiplies this result by a constant conversion factor of `0.5`.
+
+Note that the reference and the offset are the same for both rows of the batch.
+The conversion factor is the same on every calibration, so rather than receiving as an argument, you should declare it as a packed 16-byte constant in memory.
+
+Define a function `calibrate_batch` that, given a `raw` batch, a `reference`, an `offset`, and a `result` buffer, writes the calibrated values to `result`.
+The arguments, in order, are:
+
+1. `raw`: memory address holding 4 32-bit floating-point numbers (alignment not guaranteed)
+2. `reference`: 16-byte aligned memory address holding 2 64-bit floating-point numbers
+3. `offset`: 16-byte aligned memory address holding 2 64-bit floating-point numbers
+4. `result`: 16-byte aligned memory address where the function will write 4 64-bit floating-point numbers (32 bytes total)
+
+The function should, for each of the two rows of the batch:
+
+1. Convert the 2 single-precision raw values of the row to double precision.
+2. Subtract `offset` from the converted pair.
+3. Divide `reference` by the result.
+4. Lane-wise multiply each 64-bit floating-point number by the fixed conversion factor of `0.5`.
+5. Store the 2 64-bit floating-point numbers to the corresponding 16 bytes of `result`.
+
+This function has no return value, instead the result is stored in the passed buffer (`result`):
+
+```c
+raw       = {10.0, 20.0, 25.0, 50.0};
+reference = {100.0, 100.0};
+offset    = {  5.0,  10.0};
+calibrate_batch(raw, reference, offset, result);
+// => result == {10.0, 5.0, 2.5, 1.25};
+```
+
+## 4. Normalize scores along a line
+
+At the end of the line, every part has a quality score that needs to be normalized before it gets reported.
+Each score is multiplied by its own per-part gain, then divided by a per-axis production scale.
+The gains buffer holds one gain per part.
+
+The production scale is the same for the whole run and is passed in a memory address holding two 64-bit floating-point numbers.
+The scores are updated **in place**: the same buffer that held the raw scores now holds the normalized scores.
+
+Define a function `normalize_scores` that, given a `scores` array, a `gains` array, a `scale`, and a count `n`, normalizes the scores in place.
+The arguments, in order, are:
+
+1. `scores`: 16-byte aligned memory address holding `n` 64-bit floating-point numbers (modified in place)
+2. `gains`: 16-byte aligned memory address holding `n` 64-bit floating-point numbers
+3. `scale`: 16-byte aligned memory address holding 2 64-bit floating-point numbers
+4. `n`: a 64-bit positive even integer (minimum `2`), the number of scores to normalize
+
+The two scale lanes apply to the two elements of each pair.
+The first lane scales the first element of every pair (lanes at even positions), the second lane scales the second (lanes at odd positions).
+Each score is multiplied by its corresponding gain, then divided by the appropriate scale lane: `score * gain / scale_lane`.
+
+This function has no return value, instead the result is stored in the input buffer (`scores`), at the same position of the corresponding `score` that was normalized:
+
+```c
+n      = 4
+scores = {10.0, 20.0, 30.0, 40.0};
+gains  = { 2.0,  1.5,  1.0,  0.5};
+scale  = { 2.0,  4.0};
+normalize_scores(scores, gains, scale, n);
+// => scores == {10.0, 7.5, 15.0, 5.0};
+```

--- a/exercises/concept/production-line/.docs/introduction.md
+++ b/exercises/concept/production-line/.docs/introduction.md
@@ -1,0 +1,224 @@
+# Introduction
+
+## SIMD
+
+**Single instruction, multiple data (SIMD)** is a form of hardware-level parallelism.
+The same computation is performed by the CPU over multiple elements at the same time.
+
+Consider, for example, summing two arrays of four 32-bit floats element-wise.
+A scalar implementation would issue four separate `addss` instructions, one per element.
+A SIMD implementation uses a single `addps` to do all four additions in parallel.
+That gives four times the work per instruction.
+
+In x86-64 assembly, SIMD instructions are typically performed using `xmm` registers.
+Some of those instructions operate on integers.
+Others operate on floating-point numbers.
+
+Those integers or floating-point numbers are called **packed**.
+Each occupies a space, called a **lane**, within the same register.
+SIMD instructions typically operate in parallel on values at the same lane position across two source operands.
+The result of each operation is stored in the lane at the same position in the destination operand.
+
+A lane is not a hard limit.
+It is an interpretation given by each instruction to a sequence of bytes.
+A 128-bit operand contains 16 bytes.
+Depending on the instruction, those bytes can be interpreted as 16 _1-byte_ lanes, 8 _2-byte_ lanes, 4 _4-byte_ lanes, 2 _8-byte_ lanes, or even a single _16-byte_ lane.
+
+For example, the instruction `addps` adds packed single-precision (4-byte) floating-point values.
+For this instruction, each 4-byte chunk in an operand is a different lane.
+In a 128-bit wide (16-byte) operand:
+
+| operand     | 4th lane | 3rd lane | 2nd lane | 1st lane |
+|:-----------:|:--------:|:--------:|:--------:|:--------:|
+| source 1    |  1.5     |  2.1     | 6.2      | 3.4      |
+|    +        |  +       |  +       | +        | +        |
+| source 2    |  0.5     |  8.26    | -13.4    | 22.9     |
+|    =        |  =       |  =       | =        | =        |
+| result      |  2.0     |  10.36   | -7.2     | 26.3     |
+
+On the other hand, a 128-bit operand would be interpreted as having 2 lanes in the case of `mulpd`.
+This is because this instruction performs packed multiplication on double-precision (8-byte) values:
+
+| operand     | 2nd lane | 1st lane |
+|:-----------:|:--------:|:--------:|
+| source 1    |  4.2     |  2.1     |
+|    *        |  *       |  *       |
+| source 2    |  1.0     |  92.4    |
+|    =        |  =       |  =       |
+| result      |  4.2     |  194.04  |
+
+In this concept we will focus on a small selection of SIMD instructions.
+They operate on packed floating-point values using `xmm` registers.
+
+### Floating-Point SIMD Instructions
+
+As a rule of thumb, SIMD instructions that operate on floating-point values take a two-operand form.
+Their name follows a certain structure:
+
+1. The operation being performed, with the same name as their non-SIMD (also called _scalar_) counterpart (e.g., `add`, `mul`, etc.).
+2. A suffix `p` to indicate that the instruction operates on _packed_ data, in the same position previously occupied by an `s` (for _scalar_ data).
+3. A suffix to indicate the size of each lane, following the same semantics as their non-SIMD counterpart (`s` for single-precision and `d` for double-precision).
+
+The packed name is therefore obtained from the scalar name by substituting the `s` (scalar) in the middle of the mnemonic for a `p` (packed).
+The operation name and the size suffix stay unchanged:
+
+| scalar  | packed  | meaning                                |
+|---------|---------|----------------------------------------|
+| `addss` | `addps` | add, single-precision (32-bit lanes)   |
+| `addsd` | `addpd` | add, double-precision (64-bit lanes)   |
+| `mulss` | `mulps` | multiply, single-precision             |
+| `mulsd` | `mulpd` | multiply, double-precision             |
+
+#### Arithmetic
+
+Arithmetic SIMD instructions follow the rule above.
+Some examples:
+
+```x86asm
+addps xmm0, xmm1 ; xmm0 = xmm0 + xmm1 (each 32-bit float at the same position)
+subpd xmm2, xmm3 ; xmm2 = xmm2 - xmm3 (each 64-bit float at the same position)
+mulps xmm4, xmm5 ; xmm4 = xmm4 * xmm5 (each 32-bit float at the same position)
+divpd xmm6, xmm7 ; xmm6 = xmm6 / xmm7 (each 64-bit float at the same position)
+```
+
+#### Conversion Between Precisions
+
+There are also SIMD instructions to convert between packed single-precision and packed double-precision floating-point values.
+They follow the same naming rule, with each `s` for _scalar_ replaced by a `p` for _packed_:
+
+| scalar     | packed     | meaning                                      |
+|------------|------------|----------------------------------------------|
+| `cvtss2sd` | `cvtps2pd` | convert single-precision to double-precision |
+| `cvtsd2ss` | `cvtpd2ps` | convert double-precision to single-precision |
+
+These instructions illustrate the earlier point that a lane is an interpretation, not a hard limit.
+The source and destination operands have different lane sizes, so they have different lane counts.
+
+For `cvtps2pd`, the source (`ps`) has 4 single-precision lanes.
+The destination (`pd`) has 2 double-precision lanes.
+Only the lower 2 lanes of the source are read.
+The upper 2 are ignored:
+
+| operand              | 4th lane | 3rd lane | 2nd lane | 1st lane |
+|:--------------------:|:--------:|:--------:|:--------:|:--------:|
+| source as `ps`       | ignored  | ignored  | 2.5      | 1.5      |
+| destination as `pd`  |          |          | 2.5      | 1.5      |
+
+For `cvtpd2ps`, the source (`pd`) has 2 double-precision lanes.
+The destination (`ps`) has 4 single-precision lanes.
+Both source lanes are converted and written to the lower 2 lanes of the destination.
+The upper 2 lanes of the destination are set to zero:
+
+| operand              | 4th lane | 3rd lane | 2nd lane | 1st lane |
+|:--------------------:|:--------:|:--------:|:--------:|:--------:|
+| source as `pd`       |          |          | 4.0      | 3.0      |
+| destination as `ps`  | 0        | 0        | 4.0      | 3.0      |
+
+Some examples:
+
+```x86asm
+cvtps2pd xmm0, xmm1 ; xmm0 = xmm1 as 2 doubles (low 2 lanes of xmm1 are read)
+cvtpd2ps xmm0, xmm1 ; xmm0 = xmm1 as 2 floats (in low 2 lanes; upper 2 zeroed)
+```
+
+#### Memory Operands
+
+The SIMD instructions above have all been shown with register-to-register operands.
+They may also take a memory operand as their source (but **not** their destination).
+
+The number of bytes read from memory is determined by the instruction.
+For example, `addps` reads 16 bytes (4 single-precision floats).
+`cvtps2pd`, by contrast, reads only 8 bytes (2 single-precision floats), because that is all the input it needs.
+
+```x86asm
+addps    xmm0, [rsi]      ; xmm0 = xmm0 + 4 floats at [rsi]
+mulpd    xmm1, [rsi + 16] ; xmm1 = xmm1 * 2 doubles at [rsi + 16]
+cvtps2pd xmm2, [rsi + 8]  ; xmm2 = (2 floats at [rsi + 8]) converted to 2 doubles
+```
+
+When the memory operand is 16 bytes wide, it must be _16-byte aligned_.
+An aligned memory location is one whose address is a multiple of the size of the operation (16 bytes in this case).
+
+To declare aligned memory, you can use the `align` directive on section .data and .rodata, or `alignb`, on section .bss:
+
+```x86asm
+section .rodata
+align 16
+mem1: dd 4.0, 3.5, 2.0, -1.0
+
+section .data
+align 16
+mem2: dq 6.0, 2.1
+
+section .bss
+alignb 16
+mem3: resb 16
+
+section .text
+fn:
+    movaps xmm0, oword [rel mem1] ; loads 4 packed 32-bit floats in xmm0
+    movapd xmm1, oword [rel mem2] ; loads 2 packed 64-bit floats in xmm1
+    movaps oword [rel mem3], xmm0 ; stores 4 packed 32-bit floats in mem3
+    ret
+```
+
+Memory operands smaller than 16 bytes, such as the 8-byte source of `cvtps2pd`, have no alignment requirement.
+
+#### Loading/Storing Values
+
+There are four instructions that copy 128 bits of packed floating-point values.
+They operate between two `xmm` registers, or between one `xmm` register and a memory location:
+
+| instruction | description                                                                       |
+|-------------|-----------------------------------------------------------------------------------|
+| `movaps`    | copies packed single-precision data from, or to, an _aligned_ memory location     |
+| `movups`    | copies packed single-precision data from, or to, an _unaligned_ memory location   |
+| `movapd`    | copies packed double-precision data from, or to, an _aligned_  memory location    |
+| `movupd`    | copies packed double-precision data from, or to, an _unaligned_ memory location   |
+
+All of those instructions may be used to copy values between two `xmm` registers.
+
+If the operation involves a memory location, `movaps` and `movapd` require that it be _aligned_.
+`movaps` and `movapd` will raise a fault if given a misaligned address.
+They double as a safety check that your data layout is what you think it is.
+
+On the other hand, `movups` and `movupd` may be used with any memory location, aligned or not.
+
+The size prefix for a 16-byte value in NASM is `oword`.
+
+### SIMD Extensions
+
+SIMD has been a target of active development in the x86-64 ecosystem for decades.
+Each extension to the architecture brings new instructions or new uses for old instructions.
+
+In particular, the extensions AVX and AVX2 introduce some relevant changes.
+
+First, support for 256-bit SIMD registers, called `ymm`.
+They extend corresponding `xmm` registers, much as `rax` contains `eax`.
+
+Second, they include support for 3-operand variants for most instructions that operate on `xmm` (and `ymm`) registers.
+This includes not only SIMD instructions, but also those that operate on scalar floating-point values.
+Those variants follow the same notation of their SSE equivalent, with a `v` added before:
+
+```x86asm
+vaddsd xmm0, xmm1, xmm2   ; xmm0 = xmm1 + xmm2 (scalar sum of 64-bit floats)
+vmulps xmm1, xmm3, xmm4   ; xmm1 = xmm3 * xmm4 (packed multiplication of 32-bit floats)
+vmovupd ymm5, yword [mem] ; this copies 32 bytes from the location at mem to ymm5
+```
+
+Third, the alignment required of SIMD memory operands is relaxed.
+Only explicitly aligned moves, such as `vmovaps`, require this alignment.
+
+In this track, we have restricted ourselves to instructions and registers up to the previous SSE extensions.
+This is enough to teach foundations and ensures compatibility with a wide array of CPUs.
+
+However, the test-runner fully supports AVX and AVX2, and even the newer extensions that are part of AVX-512.
+You are free to use them.
+
+~~~~exercism/note
+It is good practice to be consistent in your use of SIMD variants.
+Try to not mix SSE and AVX variants for the same instructions.
+
+If your code base mixes those variants, it is good practice to use `vzeroupper` after you have finished your work with AVX and before using SSE.
+This breaks dependency chains and avoids a costly stall when the CPU transitions between AVX and SSE state.
+~~~~

--- a/exercises/concept/production-line/.docs/introduction.md
+++ b/exercises/concept/production-line/.docs/introduction.md
@@ -217,7 +217,7 @@ You are free to use them.
 
 ~~~~exercism/note
 It is good practice to be consistent in your use of SIMD variants.
-Try to not mix SSE and AVX variants for the same instructions.
+Try not to mix SSE and AVX variants for the same instructions.
 
 If your code base mixes those variants, it is good practice to use `vzeroupper` after you have finished your work with AVX and before using SSE.
 This breaks dependency chains and avoids a costly stall when the CPU transitions between AVX and SSE state.

--- a/exercises/concept/production-line/.docs/introduction.md.tpl
+++ b/exercises/concept/production-line/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept:simd}

--- a/exercises/concept/production-line/.meta/config.json
+++ b/exercises/concept/production-line/.meta/config.json
@@ -1,0 +1,18 @@
+{
+  "authors": [
+    "oxe-i"
+  ],
+  "files": {
+    "solution": [
+      "production_line.asm"
+    ],
+    "test": [
+      "production_line_test.c"
+    ],
+    "exemplar": [
+      ".meta/exemplar.asm"
+    ]
+  },
+  "icon": "assembly-line",
+  "blurb": "Learn about SIMD instructions in x86-64 assembly."
+}

--- a/exercises/concept/production-line/.meta/design.md
+++ b/exercises/concept/production-line/.meta/design.md
@@ -1,0 +1,28 @@
+# Design
+
+## Learning objectives
+
+- Know what is SIMD.
+- Know how `xmm` registers can hold packed data.
+- Know packed arithmetic instructions for floating-point values.
+- Know how to declare memory aligned to some boundary in NASM.
+- Know about `mov` variants for 128-bit floating-point values.
+- Know the main updates introduced by `AVX` and `AVX2` and how to use vector-updated instructions.
+
+## Out of Scope
+
+- Packed integer arithmetic.
+- SIMD bitwise operations.
+- Conditionals, masks and blending.
+- Horizontal reduction.
+- Cross-lanes operations.
+
+## Concepts
+
+- `simd`
+
+## Prerequisites
+
+- `loops`
+- `arrays`
+- `floating-point numbers`

--- a/exercises/concept/production-line/.meta/exemplar.asm
+++ b/exercises/concept/production-line/.meta/exemplar.asm
@@ -1,0 +1,63 @@
+section .rodata
+align 16
+factor: dq 0.5, 0.5
+
+section .text
+
+global sum_yields
+sum_yields:
+    movaps xmm0, oword [rdi]
+    addps  xmm0, oword [rsi]
+    movaps oword [rdx], xmm0
+    ret
+
+global scaled_deviation
+scaled_deviation:
+    movapd xmm1, oword [rdi]
+    movupd xmm2, oword [rsi]
+    subpd  xmm1, xmm2
+    movupd xmm0, oword [rdx]
+    mulpd  xmm0, xmm1
+    movupd oword [rcx], xmm0
+    ret
+
+global calibrate_batch
+calibrate_batch:
+    movapd   xmm0, oword [rsi]        ; reference
+    movapd   xmm1, oword [rdx]        ; offset
+    movapd   xmm2, oword [rel factor] ; factor
+
+    cvtps2pd xmm3, qword [rdi]        ; first row
+    cvtps2pd xmm4, qword [rdi + 8]    ; second row
+
+    subpd    xmm3, xmm1
+    subpd    xmm4, xmm1
+
+    movapd   xmm1, xmm0
+    divpd    xmm0, xmm3
+    divpd    xmm1, xmm4
+
+    mulpd    xmm0, xmm2
+    mulpd    xmm1, xmm2
+
+    movapd   oword [rcx]     , xmm0
+    movapd   oword [rcx + 16], xmm1
+    ret
+
+global normalize_scores
+normalize_scores:
+    xor eax, eax
+    movapd xmm1, oword [rdx]
+.loop:
+    movapd xmm0, oword [rdi + 8*rax]
+    mulpd  xmm0, oword [rsi + 8*rax]
+    divpd  xmm0, xmm1
+    movapd oword [rdi + 8*rax], xmm0
+    add rax, 2
+    cmp rax, rcx
+    jb .loop
+    ret
+
+%ifidn __OUTPUT_FORMAT__,elf64
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif

--- a/exercises/concept/production-line/Makefile
+++ b/exercises/concept/production-line/Makefile
@@ -1,0 +1,46 @@
+AS = nasm
+
+CFLAGS = -g -Wall -Wextra -pedantic -Werror -std=c2x -Wno-gnu-binary-literal
+LDFLAGS =
+ASFLAGS = -g -F dwarf -Werror
+
+ifeq ($(shell uname -s),Darwin)
+ifeq ($(shell sysctl -n hw.optional.arm64 2>/dev/null),1)
+	ALL_CFLAGS = -target x86_64-apple-darwin
+endif
+	ALL_LDFLAGS = -Wl,-pie
+	ALL_ASFLAGS = -f macho64 --prefix _
+else
+	ALL_LDFLAGS = -pie -Wl,--fatal-warnings
+	ALL_ASFLAGS = -f elf64
+endif
+
+ALL_CFLAGS += -std=c99 -fPIE -m64 $(CFLAGS)
+ALL_LDFLAGS += $(LDFLAGS)
+ALL_ASFLAGS += $(ASFLAGS)
+
+C_OBJS = $(patsubst %.c,%.o,$(wildcard *.c))
+AS_OBJS = $(patsubst %.asm,%.o,$(wildcard *.asm))
+ALL_OBJS = $(filter-out exemplar.o,$(C_OBJS) $(AS_OBJS) vendor/unity.o)
+
+CC_CMD = $(CC) $(ALL_CFLAGS) -c -o $@ $<
+
+all: tests
+	@./$<
+
+tests: $(ALL_OBJS)
+	@$(CC) $(ALL_CFLAGS) $(ALL_LDFLAGS) -o $@ $(ALL_OBJS)
+
+%.o: %.asm
+	@$(AS) $(ALL_ASFLAGS) -o $@ $<
+
+%.o: %.c
+	@$(CC_CMD)
+
+vendor/unity.o: vendor/unity.c vendor/unity.h vendor/unity_internals.h
+	@$(CC_CMD)
+
+clean:
+	@rm -f *.o vendor/*.o tests
+
+.PHONY: all clean

--- a/exercises/concept/production-line/debug.mac
+++ b/exercises/concept/production-line/debug.mac
@@ -1,0 +1,821 @@
+%ifndef DEBUG_MAC
+%define DEBUG_MAC
+
+extern printf
+
+section .rodata
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                     FORMATTING STRINGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; formatting string for signed integers
+fmtzd: db "debug signed integer... %zd", 0xA, 0x0
+
+; formatting string for unsigned integers
+fmtzu: db "debug unsigned integer... %zu", 0xA, 0x0
+
+; formatting string for unsigned integers in hexadecimal format
+fmtzx: db "debug hexadecimal... %zX", 0xA, 0x0
+
+; formatting string for floating-point values
+fmtf: db "debug floating-point... %f", 0xA, 0x0
+
+; formatting string for characters
+fmtc: db "debug character... %c", 0xA, 0x0
+
+; formatting string for strings
+fmts: db `debug string... "%s"`, 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR PACKED VALUES
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Generates a formatting string with label of the form fmt_xmm_$x$n where:
+;
+; 1. $x is a format identifier such as 'd' or 'zx'
+; 2. $n is one of the following size identifiers: 8, 16, 32 or 64.
+;
+; For example, a fmt_xmm_d32 formats a SIMD register as 4 signed integer DWORDs
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro _fmt_xmm 3
+    %assign _i_x 0
+    fmt_xmm_%1: db "debug... ["
+    %rep %3
+        %if _i_x > 0
+            db ", "
+        %endif
+        db %2
+        %assign _i_x _i_x + 1
+    %endrep
+    db "]", 0xA, 0x0
+%endmacro
+
+; generates formatting string for floating-point SIMD values
+_fmt_xmm f32, "%f", 4
+_fmt_xmm f64, "%f", 2
+
+; expands to four different formatting string, one for each size: 8, 16, 32 and 64
+%macro _fmt_xmm_is 2
+    %assign _i_is 8
+    %assign _j_is 16
+    %rep 4
+        _fmt_xmm %1 %+ %[_i_is], %2, %[_j_is]
+        %assign _i_is (_i_is * 2)
+        %assign _j_is (_j_is / 2)
+    %endrep
+%endmacro
+
+; generates formatting string for integer SIMD values
+_fmt_xmm_is zd, "%zd"
+_fmt_xmm_is zu, "%zu"
+_fmt_xmm_is zx, "%zX"
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                       HELPER MACROS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; saves all caller-saved and XMM registers, as well as RFLAGS
+%macro save_registers 0
+
+    ; Preserve RFLAGS
+    pushfq
+
+    ; Preserve caller-save registers
+    push rax
+    push rcx
+    push rdx
+    push rsi
+    push rdi
+    push r8
+    push r9
+    push r10
+    push r11
+
+    ; Preserve xmm registers
+    sub rsp, 16 * 16
+%assign i 0
+%assign n 0
+%rep 16
+    movdqu [rsp + i], xmm %+ n
+    %assign i i + 16
+    %assign n n + 1
+%endrep
+
+%endmacro
+
+; restores all caller-saved and XMM registers, as well as RFLAGS, to their original values
+%macro restore_registers 0
+
+    ; Restore xmm registers
+%assign i 0
+%assign n 0
+%rep 16
+    movdqu xmm %+ n, [rsp + i]
+    %assign i i + 16
+    %assign n n + 1
+%endrep
+    add rsp, 16 * 16
+
+    ; Restore caller-save registers
+    pop r11
+    pop r10
+    pop r9
+    pop r8
+    pop rdi
+    pop rsi
+    pop rdx
+    pop rcx
+    pop rax
+
+    ; Restore RFLAGS
+    popfq
+
+%endmacro
+
+; preserves RSP
+%macro save_sp 0
+
+    push rbp
+    mov rbp, rsp
+
+%endmacro
+
+; restores RSP
+%macro restore_sp 0
+
+    mov rsp, rbp
+    pop rbp
+
+%endmacro
+
+; System V ABI requires the stack to be 16-byte aligned before calling an external function
+%macro align_sp 0
+
+    and rsp, -16
+
+%endmacro
+
+%macro prologue 0
+
+    save_registers
+    save_sp
+    align_sp
+
+%endmacro
+
+%macro epilogue 0
+
+    restore_sp
+    restore_registers
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING MACROS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; All the following macros may be called with: 1. registers or 2. memory operands.
+; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
+;
+; If called with a memory operand, it might be necessary to specify the size, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+; Note that the stack is modified temporarily by all macros
+; This means any value pointed by RSP won't be valid at the time it is dereferenced
+; Such value should be loaded on a register before debugging
+;
+; The macro name is usually of the form: "debug" + type + size
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm"
+;
+; In this case, the types are the same and the sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; Finally, "debugc" and "debugs" do not need an explicit size.
+; They print an individual character and a NUL-terminated string, respectively.
+;
+; Note that the `debugs` macro expects a memory address.
+; If not in a register, this address should be passed directly, without brackets:
+; - debugs <address>
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; prints the value of a 8-bit signed integer
+%macro debugd8 1-*
+
+    %rep %0
+        prologue
+
+        movsx rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints the value of a 16-bit signed integer
+%macro debugd16 1-*
+
+    debugd8 %{1:-1}
+
+%endmacro
+
+; prints the value of a 32-bit signed integer
+%macro debugd32 1-*
+
+    %rep %0
+        prologue
+
+        movsxd rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints the value of a 64-bit signed integer
+%macro debugd64 1-*
+
+    %rep %0
+        prologue
+
+        mov rsi, %1
+        lea rdi, [rel fmtzd]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints the value of a 8-bit unsigned integer
+%macro debugu8 1-*
+
+    %rep %0
+        prologue
+
+        movzx rsi, %1
+        lea rdi, [rel fmtzu]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints the value of a 16-bit unsigned integer
+%macro debugu16 1-*
+
+    debugu8 %{1:-1}
+
+%endmacro
+
+; prints the value of a 32-bit unsigned integer
+%macro debugu32 1-*
+
+    %rep %0
+        prologue
+
+        mov esi, %1
+        lea rdi, [rel fmtzu]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints the value of a 64-bit unsigned integer
+%macro debugu64 1-*
+
+    %rep %0
+        prologue
+
+        mov rsi, %1
+        lea rdi, [rel fmtzu]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints the value of a 8-bit unsigned integer in hexadecimal format
+%macro debugx8 1-*
+
+    %rep %0
+        prologue
+
+        movzx rsi, %1
+        lea rdi, [rel fmtzx]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints the value of a 16-bit unsigned integer in hexadecimal format
+%macro debugx16 1-*
+
+    debugx8 %{1:-1}
+
+%endmacro
+
+; prints the value of a 32-bit unsigned integer in hexadecimal format
+%macro debugx32 1-*
+
+    %rep %0
+        prologue
+
+        mov esi, %1
+        lea rdi, [rel fmtzx]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints the value of a 64-bit unsigned integer in hexadecimal format
+%macro debugx64 1-*
+
+    %rep %0
+        prologue
+
+        mov rsi, %1
+        lea rdi, [rel fmtzx]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints the value of a 32-bit floating-point number
+%macro debugf32 1-*
+
+    %rep %0
+        prologue
+
+        cvtss2sd xmm0, %1
+        lea rdi, [rel fmtf]
+        mov eax, 1
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints the value of a 64-bit floating-point number
+%macro debugf64 1-*
+
+    %rep %0
+        prologue
+
+        movsd xmm0, %1
+        lea rdi, [rel fmtf]
+        mov eax, 1
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints a 8-bit unsigned integer interpreted as a character
+%macro debugc 1-*
+
+    %rep %0
+        prologue
+
+        movzx rsi, %1
+        lea rdi, [rel fmtc]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints a NUL-terminated string. The argument is a 64-bit memory address
+%macro debugs 1-*
+
+    %rep %0
+        prologue
+
+        lea rsi, [%1]
+        lea rdi, [rel fmts]
+        xor eax, eax
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
+%macro debugf32_xmm 1-*
+
+    %rep %0
+        prologue
+
+        sub rsp, 16
+        movdqu xmm0, %1
+        movdqa [rsp], xmm0
+
+        cvtss2sd xmm0, [rsp]
+        cvtss2sd xmm1, [rsp + 4]
+        cvtss2sd xmm2, [rsp + 8]
+        cvtss2sd xmm3, [rsp + 12]
+        lea rdi, [rel fmt_xmm_f32]
+        mov eax, 4
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints a XMM register interpreted as 2 packed 64-bit floating-point numbers
+%macro debugf64_xmm 1-*
+
+    %rep %0
+        prologue
+
+        sub rsp, 16
+        movdqu xmm0, %1
+        movdqa [rsp], xmm0
+
+        movsd xmm0, [rsp]
+        movsd xmm1, [rsp + 8]
+        lea rdi, [rel fmt_xmm_f64]
+        mov eax, 2
+
+        call printf wrt ..plt
+
+        epilogue
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Generic macro for debugging packed 8-bit integers
+; The arguments are:
+; 1. the value to be printed.
+; 2. a flag for signedness ("s") or unsignedness ("z") of the integers
+; 3. the type specifier for the formatting string ("zd", "zx" or "zu")
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+%macro _debug_si_xmm8 3
+
+    prologue
+
+    %defalias _mov_xmm %[mov %+ %2 %+ x]
+
+    sub rsp, 96
+    movdqu xmm0, %1
+    movdqa [rsp], xmm0
+
+    mov r10, [rsp]
+    mov r11, [rsp + 8]
+
+    _mov_xmm rsi, r10b
+    shr r10, 8
+
+    _mov_xmm rdx, r10b
+    shr r10, 8
+
+    _mov_xmm rcx, r10b
+    shr r10, 8
+
+    _mov_xmm r8 , r10b
+    shr r10, 8
+
+    _mov_xmm r9 , r10b
+    shr r10, 8
+
+    _mov_xmm rax, r10b
+    mov [rsp], rax
+    shr r10, 8
+
+    _mov_xmm rax, r10b
+    mov [rsp + 8], rax
+    shr r10, 8
+
+    _mov_xmm rax, r10b
+    mov [rsp + 16], rax
+
+    %assign _i_d8_xmm 24
+    %rep 8
+        _mov_xmm rax, r11b
+        shr r11, 8
+        mov [rsp + _i_d8_xmm], rax
+        %assign _i_d8_xmm _i_d8_xmm + 8
+    %endrep
+
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
+    xor eax, eax
+    call printf wrt ..plt
+
+    epilogue
+
+%endmacro
+
+; prints a XMM register interpreted as 16 packed 8-bit signed integers
+%macro debugd8_xmm 1-*
+
+    %rep %0
+        _debug_si_xmm8 %1, s, zd
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints a XMM register interpreted as 16 packed 8-bit unsigned integers
+%macro debugu8_xmm 1-*
+
+    %rep %0
+        _debug_si_xmm8 %1, z, zu
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints a XMM register interpreted as 16 packed 8-bit unsigned integers in hexadecimal format
+%macro debugx8_xmm 1-*
+
+    %rep %0
+        _debug_si_xmm8 %1, z, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Generic macro for debugging packed 16-bit integers
+; The arguments are:
+; 1. the value to be printed.
+; 2. a flag for signedness ("s") or unsignedness ("z") of the integers
+; 3. the type specifier for the formatting string ("zd", "zx" or "zu")
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+%macro _debug_si_xmm16 3
+
+    prologue
+
+    %defalias _mov_xmm %[mov %+ %2 %+ x]
+
+    sub rsp, 32
+    movdqu xmm0, %1
+    movdqa [rsp], xmm0
+
+    mov rax, [rsp]
+    _mov_xmm rsi, ax
+    shr rax, 16
+
+    _mov_xmm rdx, ax
+    shr rax, 16
+
+    _mov_xmm rcx, ax
+    shr rax, 16
+
+    _mov_xmm r8, ax
+    shr rax, 16
+
+    mov rax, [rsp + 8]
+    _mov_xmm r9, ax
+    shr rax, 16
+
+    _mov_xmm r10, ax
+    mov [rsp], r10
+    shr rax, 16
+
+    _mov_xmm r10, ax
+    mov [rsp + 8], r10
+    shr rax, 16
+
+    _mov_xmm r10, ax
+    mov [rsp + 16], r10
+
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
+    xor eax, eax
+    call printf wrt ..plt
+
+    epilogue
+
+%endmacro
+
+; prints a XMM register interpreted as 8 packed 16-bit signed integers
+%macro debugd16_xmm 1-*
+
+    %rep %0
+        _debug_si_xmm16  %1, s, zd
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints a XMM register interpreted as 8 packed 16-bit unsigned integers
+%macro debugu16_xmm 1-*
+
+    %rep %0
+        _debug_si_xmm16 %1, z, zu
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints a XMM register interpreted as 8 packed 16-bit unsigned integers in hexadecimal format
+%macro debugx16_xmm 1-*
+
+    %rep %0
+        _debug_si_xmm16 %1, z, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Generic macro for debugging packed 32-bit integers
+; The arguments are:
+; 1. the value to be printed.
+; 2. a flag for signedness or unsignedness of the integers
+; 3. the type specifier for the formatting string ("zd", "zx" or "zu")
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+%macro _debug_si_xmm32 3
+
+    prologue
+
+    sub rsp, 16
+    movdqu xmm0, %1
+    movdqa [rsp], xmm0
+
+    mov esi, dword [rsp]
+    mov edx, dword [rsp + 4]
+    mov ecx, dword [rsp + 8]
+    mov r8d, dword [rsp + 12]
+
+    %ifidn %2, s
+        movsxd rsi, esi
+        movsxd rdx, edx
+        movsxd rcx, ecx
+        movsxd r8, r8d
+    %endif
+
+    lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
+    xor eax, eax
+    call printf wrt ..plt
+
+    epilogue
+
+%endmacro
+
+; prints a XMM register interpreted as 4 packed 32-bit signed integers
+%macro debugd32_xmm 1-*
+
+    %rep %0
+        _debug_si_xmm32 %1, s, zd
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints a XMM register interpreted as 4 packed 32-bit unsigned integers
+%macro debugu32_xmm 1-*
+
+    %rep %0
+        _debug_si_xmm32 %1, z, zu
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints a XMM register interpreted as 4 packed 32-bit unsigned integers in hexadecimal format
+%macro debugx32_xmm 1-*
+
+    %rep %0
+        _debug_si_xmm32 %1, z, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Generic macro for debugging packed 64-bit integers
+; The arguments are:
+; 1. the value to be printed.
+; 2. the type specifier for the formatting string ("zd", "zx" or "zu")
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+%macro _debug_si_xmm64 2
+
+    prologue
+
+    sub rsp, 16
+    movdqu xmm0, %1
+    movdqa [rsp], xmm0
+
+    mov rsi, [rsp]
+    mov rdx, [rsp + 8]
+    lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
+    xor eax, eax
+
+    call printf wrt ..plt
+
+    epilogue
+
+%endmacro
+
+; prints a XMM register interpreted as 2 packed 64-bit signed integers
+%macro debugd64_xmm 1-*
+
+    %rep %0
+        _debug_si_xmm64 %1, zd
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints a XMM register interpreted as 2 packed 64-bit unsigned integers
+%macro debugu64_xmm 1-*
+
+    %rep %0
+        _debug_si_xmm64 %1, zu
+    %rotate 1
+    %endrep
+
+%endmacro
+
+; prints a XMM register interpreted as 2 packed 64-bit unsigned integers in hexadecimal format
+%macro debugx64_xmm 1-*
+
+    %rep %0
+        _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+%endif

--- a/exercises/concept/production-line/production_line.asm
+++ b/exercises/concept/production-line/production_line.asm
@@ -1,0 +1,94 @@
+section .text
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           TASK 1
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+global sum_yields
+sum_yields:
+    ; TODO: Define the function `sum_yields`
+    ;
+    ; This function takes as arguments, in order:
+    ; 1. `line_a`: 16-byte aligned memory address holding 4 32-bit floating-point numbers
+    ; 2. `line_b`: 16-byte aligned memory address holding 4 32-bit floating-point numbers
+    ; 3. `result`: 16-byte aligned memory address where the function will write 4 32-bit floating-point numbers
+    ;
+    ; It calculates the lane-wise sum of the numbers in `line_a` and `line_b` and stores this sum in `result`
+    ;
+    ; The function has no return value
+    ret
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           TASK 2
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+global scaled_deviation
+scaled_deviation:
+    ; TODO: Define the function `scaled_deviation`
+    ;
+    ; This function takes as arguments, in order:
+    ; 1. `measured`: 16-byte aligned memory address holding 2 64-bit floating-point numbers
+    ; 2. `target`: memory address holding 2 64-bit floating-point numbers (alignment not guaranteed)
+    ; 3. `sensitivity`: memory address holding 2 64-bit floating-point numbers (alignment not guaranteed)
+    ; 4. `result`: memory address for a buffer where the function will write 2 64-bit floating-point numbers (alignment not guaranteed)
+    ;
+    ; It calculates the lane-wise scaled deviation of the numbers in `measured` and stores this deviation in `result`
+    ; The scaled deviation is defined as (measured - target) * sensitivity
+    ;
+    ; The function has no return value
+    ret
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           TASK 3
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+section .rodata
+    ; TODO: Define a conversion factor for `calibrate_batch`
+
+section .text
+
+global calibrate_batch
+calibrate_batch:
+    ; TODO: Define the function `calibrate_batch`
+    ;
+    ; This function takes as arguments, in order:
+    ; 1. `raw`: memory address holding 4 32-bit floating-point numbers (alignment not guaranteed)
+    ; 2. `reference`: 16-byte aligned memory address holding 2 64-bit floating-point numbers
+    ; 3. `offset`: 16-byte aligned memory address holding 2 64-bit floating-point numbers
+    ; 4. `result`: 16-byte aligned memory address where the function will write 4 64-bit floating-point numbers (32 bytes total)
+    ;
+    ; The function should, for each of the two rows of the batch:
+    ; 1. Convert the 2 single-precision raw values of the row to double precision.
+    ; 2. Subtract `offset` from the converted pair.
+    ; 3. Divide `reference` by the result.
+    ; 4. Lane-wise multiply each 64-bit floating-point number by the fixed conversion factor of `0.5`.
+    ; 5. Store the 2 64-bit floating-point numbers to the corresponding 16 bytes of `result`.
+    ;
+    ; Note that the reference and the offset are the same for both rows of the batch.
+    ; The conversion factor is the same on every calibration, so you should declare it as a packed 16-byte constant in memory.
+    ;
+    ; The function has no return value
+    ret
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           TASK 4
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+global normalize_scores
+normalize_scores:
+    ; TODO: Define the `normalize_scores` function
+    ;
+    ; This function takes as arguments, in order:
+    ; 1. `scores`: 16-byte aligned memory address holding `n` 64-bit floating-point numbers (modified in place)
+    ; 2. `gains`: 16-byte aligned memory address holding `n` 64-bit floating-point numbers
+    ; 3. `scale`: 16-byte aligned memory address holding 2 64-bit floating-point numbers
+    ; 4. `n`: a 64-bit positive even integer (minimum `2`), the number of scores to normalize
+    ;
+    ; The two scale lanes apply to the two elements of each pair:
+    ; 1. the first lane scales the first element of each pair (lanes at even positions)
+    ; 2. the second lane scales the second element of each pair (lanes at odd positions)
+    ;
+    ; For each score, the function computes `score * gain / scale_lane` and stores it back in-place
+    ;
+    ; The function has no return value
+    ret
+
+%ifidn __OUTPUT_FORMAT__,elf64
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif

--- a/exercises/concept/production-line/production_line_test.c
+++ b/exercises/concept/production-line/production_line_test.c
@@ -1,0 +1,553 @@
+#include "vendor/unity.h"
+
+#include <stdalign.h>
+#include <stddef.h>
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
+extern void sum_yields(const float line_a[4], const float line_b[4], float result[4]);
+extern void scaled_deviation(const double measured[], const double target[], const double sensitivity[], double result[]);
+extern void calibrate_batch(const float raw[], const double reference[2], const double offset[2], double result[2]);
+extern void normalize_scores(double scores[], const double gains[], const double scale[2], size_t n);
+
+void setUp(void) {
+}
+
+void tearDown(void) {
+}
+
+// TASK: 1
+void test_sum_yields_example(void) {
+    alignas(16) const float line_a[4] = {10.0, 20.0, 30.0, 40.0};
+    alignas(16) const float line_b[4] = {5.0, 15.0, 25.0, 35.0};
+    alignas(16) float result[4];
+    sum_yields(line_a, line_b, result);
+    const float expected[4] = {15.0, 35.0, 55.0, 75.0};
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[0], result[0], "The 32-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[1], result[1], "The 32-bit floating-point number at lane 1 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[2], result[2], "The 32-bit floating-point number at lane 2 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[3], result[3], "The 32-bit floating-point number at lane 3 is different from expected");
+}
+
+void test_sum_yields_all_zeros(void) {
+    TEST_IGNORE();
+    alignas(16) const float line_a[4] = {0.0, 0.0, 0.0, 0.0};
+    alignas(16) const float line_b[4] = {0.0, 0.0, 0.0, 0.0};
+    alignas(16) float result[4];
+    sum_yields(line_a, line_b, result);
+    const float expected[4] = {0.0, 0.0, 0.0, 0.0};
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[0], result[0], "The 32-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[1], result[1], "The 32-bit floating-point number at lane 1 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[2], result[2], "The 32-bit floating-point number at lane 2 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[3], result[3], "The 32-bit floating-point number at lane 3 is different from expected");
+}
+
+void test_sum_yields_cancels_to_zero(void) {
+    TEST_IGNORE();
+    alignas(16) const float line_a[4] = {-1.0, -2.0, -3.0, -4.0};
+    alignas(16) const float line_b[4] = {1.0, 2.0, 3.0, 4.0};
+    alignas(16) float result[4];
+    sum_yields(line_a, line_b, result);
+    const float expected[4] = {0.0, 0.0, 0.0, 0.0};
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[0], result[0], "The 32-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[1], result[1], "The 32-bit floating-point number at lane 1 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[2], result[2], "The 32-bit floating-point number at lane 2 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[3], result[3], "The 32-bit floating-point number at lane 3 is different from expected");
+}
+
+void test_sum_yields_mixed_signs(void) {
+    TEST_IGNORE();
+    alignas(16) const float line_a[4] = {1.5, -2.5, 3.5, -4.5};
+    alignas(16) const float line_b[4] = {-0.5, 2.5, -1.5, 4.5};
+    alignas(16) float result[4];
+    sum_yields(line_a, line_b, result);
+    const float expected[4] = {1.0, 0.0, 2.0, 0.0};
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[0], result[0], "The 32-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[1], result[1], "The 32-bit floating-point number at lane 1 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[2], result[2], "The 32-bit floating-point number at lane 2 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[3], result[3], "The 32-bit floating-point number at lane 3 is different from expected");
+}
+
+void test_sum_yields_fractional(void) {
+    TEST_IGNORE();
+    alignas(16) const float line_a[4] = {0.5, 0.25, 0.125, 0.75};
+    alignas(16) const float line_b[4] = {0.5, 0.75, 0.875, 0.25};
+    alignas(16) float result[4];
+    sum_yields(line_a, line_b, result);
+    const float expected[4] = {1.0, 1.0, 1.0, 1.0};
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[0], result[0], "The 32-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[1], result[1], "The 32-bit floating-point number at lane 1 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[2], result[2], "The 32-bit floating-point number at lane 2 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[3], result[3], "The 32-bit floating-point number at lane 3 is different from expected");
+}
+
+void test_sum_yields_large_values(void) {
+    TEST_IGNORE();
+    alignas(16) const float line_a[4] = {1000000.0, 2000000.0, 3000000.0, 4000000.0};
+    alignas(16) const float line_b[4] = {500000.0, 500000.0, 500000.0, 500000.0};
+    alignas(16) float result[4];
+    sum_yields(line_a, line_b, result);
+    const float expected[4] = {1500000.0, 2500000.0, 3500000.0, 4500000.0};
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[0], result[0], "The 32-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[1], result[1], "The 32-bit floating-point number at lane 1 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[2], result[2], "The 32-bit floating-point number at lane 2 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[3], result[3], "The 32-bit floating-point number at lane 3 is different from expected");
+}
+
+void test_sum_yields_one_operand_zero(void) {
+    TEST_IGNORE();
+    alignas(16) const float line_a[4] = {7.0, 8.0, 9.0, 10.0};
+    alignas(16) const float line_b[4] = {0.0, 0.0, 0.0, 0.0};
+    alignas(16) float result[4];
+    sum_yields(line_a, line_b, result);
+    const float expected[4] = {7.0, 8.0, 9.0, 10.0};
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[0], result[0], "The 32-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[1], result[1], "The 32-bit floating-point number at lane 1 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[2], result[2], "The 32-bit floating-point number at lane 2 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[3], result[3], "The 32-bit floating-point number at lane 3 is different from expected");
+}
+
+void test_sum_yields_both_negative(void) {
+    TEST_IGNORE();
+    alignas(16) const float line_a[4] = {-10.0, -20.0, -30.0, -40.0};
+    alignas(16) const float line_b[4] = {-5.0, -15.0, -25.0, -35.0};
+    alignas(16) float result[4];
+    sum_yields(line_a, line_b, result);
+    const float expected[4] = {-15.0, -35.0, -55.0, -75.0};
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[0], result[0], "The 32-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[1], result[1], "The 32-bit floating-point number at lane 1 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[2], result[2], "The 32-bit floating-point number at lane 2 is different from expected");
+    TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[3], result[3], "The 32-bit floating-point number at lane 3 is different from expected");
+}
+
+// TASK: 2
+void test_scaled_deviation_example(void) {
+    TEST_IGNORE();
+    alignas(16) const double measured[2] = {10.5, 20.5};
+    const char x1 = 'X';
+    (void)x1;
+    alignas(8) const double target[2] = {10.0, 20.0};
+    const char x2 = 'X';
+    (void)x2;
+    alignas(8) const double sensitivity[2] = {2.0, 4.0};
+    const char x3 = 'X';
+    (void)x3;
+    alignas(8) double result[2];
+    scaled_deviation(measured, target, sensitivity, result);
+    const double expected[2] = {1.0, 2.0};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0], "The 64-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1], "The 64-bit floating-point number at lane 1 is different from expected");
+}
+
+void test_scaled_deviation_zero_deviation(void) {
+    TEST_IGNORE();
+    alignas(16) const double measured[2] = {5.0, 5.0};
+    const char x1 = 'X';
+    (void)x1;
+    alignas(8) const double target[2] = {5.0, 5.0};
+    const char x2 = 'X';
+    (void)x2;
+    alignas(8) const double sensitivity[2] = {2.0, 2.0};
+    const char x3 = 'X';
+    (void)x3;
+    alignas(8) double result[2];
+    scaled_deviation(measured, target, sensitivity, result);
+    const double expected[2] = {0.0, 0.0};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0], "The 64-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1], "The 64-bit floating-point number at lane 1 is different from expected");
+}
+
+void test_scaled_deviation_negative_deviation(void) {
+    TEST_IGNORE();
+    alignas(16) const double measured[2] = {1.0, 2.0};
+    const char x1 = 'X';
+    (void)x1;
+    alignas(8) const double target[2] = {3.0, 5.0};
+    const char x2 = 'X';
+    (void)x2;
+    alignas(8) const double sensitivity[2] = {1.0, 1.0};
+    const char x3 = 'X';
+    (void)x3;
+    alignas(8) double result[2];
+    scaled_deviation(measured, target, sensitivity, result);
+    const double expected[2] = {-2.0, -3.0};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0], "The 64-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1], "The 64-bit floating-point number at lane 1 is different from expected");
+}
+
+void test_scaled_deviation_zero_sensitivity(void) {
+    TEST_IGNORE();
+    alignas(16) const double measured[2] = {100.0, 200.0};
+    const char x1 = 'X';
+    (void)x1;
+    alignas(8) const double target[2] = {50.0, 50.0};
+    const char x2 = 'X';
+    (void)x2;
+    alignas(8) const double sensitivity[2] = {0.0, 0.0};
+    const char x3 = 'X';
+    (void)x3;
+    alignas(8) double result[2];
+    scaled_deviation(measured, target, sensitivity, result);
+    const double expected[2] = {0.0, 0.0};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0], "The 64-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1], "The 64-bit floating-point number at lane 1 is different from expected");
+}
+
+void test_scaled_deviation_fractional_sensitivity(void) {
+    TEST_IGNORE();
+    alignas(16) const double measured[2] = {4.0, 8.0};
+    const char x1 = 'X';
+    (void)x1;
+    alignas(8) const double target[2] = {2.0, 4.0};
+    const char x2 = 'X';
+    (void)x2;
+    alignas(8) const double sensitivity[2] = {0.5, 0.25};
+    const char x3 = 'X';
+    (void)x3;
+    alignas(8) double result[2];
+    scaled_deviation(measured, target, sensitivity, result);
+    const double expected[2] = {1.0, 1.0};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0], "The 64-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1], "The 64-bit floating-point number at lane 1 is different from expected");
+}
+
+void test_scaled_deviation_negative_target(void) {
+    TEST_IGNORE();
+    alignas(16) const double measured[2] = {0.0, 0.0};
+    const char x1 = 'X';
+    (void)x1;
+    alignas(8) const double target[2] = {-3.0, -7.0};
+    const char x2 = 'X';
+    (void)x2;
+    alignas(8) const double sensitivity[2] = {1.0, 1.0};
+    const char x3 = 'X';
+    (void)x3;
+    alignas(8) double result[2];
+    scaled_deviation(measured, target, sensitivity, result);
+    const double expected[2] = {3.0, 7.0};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0], "The 64-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1], "The 64-bit floating-point number at lane 1 is different from expected");
+}
+
+void test_scaled_deviation_negative_sensitivity(void) {
+    TEST_IGNORE();
+    alignas(16) const double measured[2] = {10.0, 10.0};
+    const char x1 = 'X';
+    (void)x1;
+    alignas(8) const double target[2] = {5.0, 5.0};
+    const char x2 = 'X';
+    (void)x2;
+    alignas(8) const double sensitivity[2] = {-2.0, -3.0};
+    const char x3 = 'X';
+    (void)x3;
+    alignas(8) double result[2];
+    scaled_deviation(measured, target, sensitivity, result);
+    const double expected[2] = {-10.0, -15.0};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0], "The 64-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1], "The 64-bit floating-point number at lane 1 is different from expected");
+}
+
+void test_scaled_deviation_larger_values(void) {
+    TEST_IGNORE();
+    alignas(16) const double measured[2] = {1000.0, 2000.0};
+    const char x1 = 'X';
+    (void)x1;
+    alignas(8) const double target[2] = {1000.0, 1500.0};
+    const char x2 = 'X';
+    (void)x2;
+    alignas(8) const double sensitivity[2] = {3.0, 2.0};
+    const char x3 = 'X';
+    (void)x3;
+    alignas(8) double result[2];
+    scaled_deviation(measured, target, sensitivity, result);
+    const double expected[2] = {0.0, 1000.0};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0], "The 64-bit floating-point number at lane 0 is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1], "The 64-bit floating-point number at lane 1 is different from expected");
+}
+
+// TASK: 3
+void test_calibrate_batch_example(void) {
+    TEST_IGNORE();
+    const char x = 'X';
+    (void)x;
+    alignas(4) const float raw[] = {10.0, 20.0, 25.0, 50.0};
+    alignas(16) const double reference[2] = {100.0, 100.0};
+    alignas(16) const double offset[2] = {5.0, 10.0};
+    alignas(16) double result[4];
+    calibrate_batch(raw, reference, offset, result);
+    const double expected[] = {10.0, 5.0, 2.5, 1.25};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0],
+                                     "The 64-bit floating-point number at lane 0 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1],
+                                     "The 64-bit floating-point number at lane 1 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[2], result[2],
+                                     "The 64-bit floating-point number at lane 0 of the second row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[3], result[3],
+                                     "The 64-bit floating-point number at lane 1 of the second row is different from expected");
+}
+
+void test_calibrate_batch_uniform(void) {
+    TEST_IGNORE();
+    const char x = 'X';
+    (void)x;
+    alignas(4) const float raw[] = {6.0, 6.0, 6.0, 6.0};
+    alignas(16) const double reference[2] = {12.0, 12.0};
+    alignas(16) const double offset[2] = {2.0, 2.0};
+    alignas(16) double result[4];
+    calibrate_batch(raw, reference, offset, result);
+    const double expected[] = {1.5, 1.5, 1.5, 1.5};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0],
+                                     "The 64-bit floating-point number at lane 0 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1],
+                                     "The 64-bit floating-point number at lane 1 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[2], result[2],
+                                     "The 64-bit floating-point number at lane 0 of the second row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[3], result[3],
+                                     "The 64-bit floating-point number at lane 1 of the second row is different from expected");
+}
+
+void test_calibrate_batch_different_offset_per_lane(void) {
+    TEST_IGNORE();
+    const char x = 'X';
+    (void)x;
+    alignas(4) const float raw[] = {10.0, 10.0, 10.0, 10.0};
+    alignas(16) const double reference[2] = {20.0, 20.0};
+    alignas(16) const double offset[2] = {5.0, 8.0};
+    alignas(16) double result[4];
+    calibrate_batch(raw, reference, offset, result);
+    const double expected[] = {2.0, 5.0, 2.0, 5.0};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0],
+                                     "The 64-bit floating-point number at lane 0 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1],
+                                     "The 64-bit floating-point number at lane 1 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[2], result[2],
+                                     "The 64-bit floating-point number at lane 0 of the second row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[3], result[3],
+                                     "The 64-bit floating-point number at lane 1 of the second row is different from expected");
+}
+
+void test_calibrate_batch_negative_raw(void) {
+    TEST_IGNORE();
+    const char x = 'X';
+    (void)x;
+    alignas(4) const float raw[] = {-2.0, -4.0, -8.0, -16.0};
+    alignas(16) const double reference[2] = {16.0, 16.0};
+    alignas(16) const double offset[2] = {0.0, 0.0};
+    alignas(16) double result[4];
+    calibrate_batch(raw, reference, offset, result);
+    const double expected[] = {-4.0, -2.0, -1.0, -0.5};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0],
+                                     "The 64-bit floating-point number at lane 0 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1],
+                                     "The 64-bit floating-point number at lane 1 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[2], result[2],
+                                     "The 64-bit floating-point number at lane 0 of the second row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[3], result[3],
+                                     "The 64-bit floating-point number at lane 1 of the second row is different from expected");
+}
+
+void test_calibrate_batch_different_reference_per_lane(void) {
+    TEST_IGNORE();
+    const char x = 'X';
+    (void)x;
+    alignas(4) const float raw[] = {10.0, 10.0, 10.0, 10.0};
+    alignas(16) const double reference[2] = {100.0, 50.0};
+    alignas(16) const double offset[2] = {0.0, 0.0};
+    alignas(16) double result[4];
+    calibrate_batch(raw, reference, offset, result);
+    const double expected[] = {5.0, 2.5, 5.0, 2.5};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0],
+                                     "The 64-bit floating-point number at lane 0 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1],
+                                     "The 64-bit floating-point number at lane 1 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[2], result[2],
+                                     "The 64-bit floating-point number at lane 0 of the second row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[3], result[3],
+                                     "The 64-bit floating-point number at lane 1 of the second row is different from expected");
+}
+
+void test_calibrate_batch_fractional_raw(void) {
+    TEST_IGNORE();
+    const char x = 'X';
+    (void)x;
+    alignas(4) const float raw[] = {0.5, 1.0, 2.0, 4.0};
+    alignas(16) const double reference[2] = {4.0, 4.0};
+    alignas(16) const double offset[2] = {0.0, 0.0};
+    alignas(16) double result[4];
+    calibrate_batch(raw, reference, offset, result);
+    const double expected[] = {4.0, 2.0, 1.0, 0.5};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0],
+                                     "The 64-bit floating-point number at lane 0 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1],
+                                     "The 64-bit floating-point number at lane 1 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[2], result[2],
+                                     "The 64-bit floating-point number at lane 0 of the second row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[3], result[3],
+                                     "The 64-bit floating-point number at lane 1 of the second row is different from expected");
+}
+
+void test_calibrate_batch_offset_exceeds_raw(void) {
+    TEST_IGNORE();
+    const char x = 'X';
+    (void)x;
+    alignas(4) const float raw[] = {2.0, 2.0, 6.0, 8.0};
+    alignas(16) const double reference[2] = {8.0, 8.0};
+    alignas(16) const double offset[2] = {10.0, 10.0};
+    alignas(16) double result[4];
+    calibrate_batch(raw, reference, offset, result);
+    const double expected[] = {-0.5, -0.5, -1.0, -2.0};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0],
+                                     "The 64-bit floating-point number at lane 0 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1],
+                                     "The 64-bit floating-point number at lane 1 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[2], result[2],
+                                     "The 64-bit floating-point number at lane 0 of the second row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[3], result[3],
+                                     "The 64-bit floating-point number at lane 1 of the second row is different from expected");
+}
+
+void test_calibrate_batch_mixed_reference_offset(void) {
+    TEST_IGNORE();
+    const char x = 'X';
+    (void)x;
+    alignas(4) const float raw[] = {3.0, 5.0, 9.0, 17.0};
+    alignas(16) const double reference[2] = {2.0, 4.0};
+    alignas(16) const double offset[2] = {1.0, 1.0};
+    alignas(16) double result[4];
+    calibrate_batch(raw, reference, offset, result);
+    const double expected[] = {0.5, 0.5, 0.125, 0.125};
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0],
+                                     "The 64-bit floating-point number at lane 0 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1],
+                                     "The 64-bit floating-point number at lane 1 of the first row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[2], result[2],
+                                     "The 64-bit floating-point number at lane 0 of the second row is different from expected");
+    TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[3], result[3],
+                                     "The 64-bit floating-point number at lane 1 of the second row is different from expected");
+}
+
+// TASK: 4
+void test_normalize_scores_example(void) {
+    TEST_IGNORE();
+    alignas(16) double scores[] = {10.0, 20.0, 30.0, 40.0};
+    alignas(16) const double gains[] = {2.0, 1.5, 1.0, 0.5};
+    alignas(16) const double scale[2] = {2.0, 4.0};
+    normalize_scores(scores, gains, scale, 4);
+    const double expected[] = {10.0, 7.5, 15.0, 5.0};
+    TEST_ASSERT_EQUAL_DOUBLE_ARRAY_MESSAGE(expected, scores, ARRAY_SIZE(expected),
+                                           "The sequence of 64-bit floating-point numbers is different from expected");
+}
+
+void test_normalize_scores_single_iteration(void) {
+    TEST_IGNORE();
+    alignas(16) double scores[] = {8.0, 16.0};
+    alignas(16) const double gains[] = {2.0, 2.0};
+    alignas(16) const double scale[2] = {4.0, 8.0};
+    normalize_scores(scores, gains, scale, 2);
+    const double expected[] = {4.0, 4.0};
+    TEST_ASSERT_EQUAL_DOUBLE_ARRAY_MESSAGE(expected, scores, ARRAY_SIZE(expected),
+                                           "The sequence of 64-bit floating-point numbers is different from expected");
+}
+
+void test_normalize_scores_identity(void) {
+    TEST_IGNORE();
+    alignas(16) double scores[] = {1.0, 2.0, 3.0, 4.0};
+    alignas(16) const double gains[] = {1.0, 1.0, 1.0, 1.0};
+    alignas(16) const double scale[2] = {1.0, 1.0};
+    normalize_scores(scores, gains, scale, 4);
+    const double expected[] = {1.0, 2.0, 3.0, 4.0};
+    TEST_ASSERT_EQUAL_DOUBLE_ARRAY_MESSAGE(expected, scores, ARRAY_SIZE(expected),
+                                           "The sequence of 64-bit floating-point numbers is different from expected");
+}
+
+void test_normalize_scores_three_iterations(void) {
+    TEST_IGNORE();
+    alignas(16) double scores[] = {2.0, 4.0, 6.0, 8.0, 10.0, 12.0};
+    alignas(16) const double gains[] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+    alignas(16) const double scale[2] = {2.0, 4.0};
+    normalize_scores(scores, gains, scale, 6);
+    const double expected[] = {1.0, 1.0, 3.0, 2.0, 5.0, 3.0};
+    TEST_ASSERT_EQUAL_DOUBLE_ARRAY_MESSAGE(expected, scores, ARRAY_SIZE(expected),
+                                           "The sequence of 64-bit floating-point numbers is different from expected");
+}
+
+void test_normalize_scores_negative_scores(void) {
+    TEST_IGNORE();
+    alignas(16) double scores[] = {-4.0, -8.0, -12.0, -16.0};
+    alignas(16) const double gains[] = {1.0, 1.0, 1.0, 1.0};
+    alignas(16) const double scale[2] = {2.0, 4.0};
+    normalize_scores(scores, gains, scale, 4);
+    const double expected[] = {-2.0, -2.0, -6.0, -4.0};
+    TEST_ASSERT_EQUAL_DOUBLE_ARRAY_MESSAGE(expected, scores, ARRAY_SIZE(expected),
+                                           "The sequence of 64-bit floating-point numbers is different from expected");
+}
+
+void test_normalize_scores_negative_gains(void) {
+    TEST_IGNORE();
+    alignas(16) double scores[] = {10.0, 10.0};
+    alignas(16) const double gains[] = {-2.0, -4.0};
+    alignas(16) const double scale[2] = {1.0, 1.0};
+    normalize_scores(scores, gains, scale, 2);
+    const double expected[] = {-20.0, -40.0};
+    TEST_ASSERT_EQUAL_DOUBLE_ARRAY_MESSAGE(expected, scores, ARRAY_SIZE(expected),
+                                           "The sequence of 64-bit floating-point numbers is different from expected");
+}
+
+void test_normalize_scores_fractional_gains(void) {
+    TEST_IGNORE();
+    alignas(16) double scores[] = {8.0, 8.0, 8.0, 8.0};
+    alignas(16) const double gains[] = {0.5, 0.25, 0.125, 0.5};
+    alignas(16) const double scale[2] = {1.0, 1.0};
+    normalize_scores(scores, gains, scale, 4);
+    const double expected[] = {4.0, 2.0, 1.0, 4.0};
+    TEST_ASSERT_EQUAL_DOUBLE_ARRAY_MESSAGE(expected, scores, ARRAY_SIZE(expected),
+                                           "The sequence of 64-bit floating-point numbers is different from expected");
+}
+
+void test_normalize_scores_negative_scale(void) {
+    TEST_IGNORE();
+    alignas(16) double scores[] = {6.0, 8.0};
+    alignas(16) const double gains[] = {2.0, 2.0};
+    alignas(16) const double scale[2] = {-3.0, -4.0};
+    normalize_scores(scores, gains, scale, 2);
+    const double expected[] = {-4.0, -4.0};
+    TEST_ASSERT_EQUAL_DOUBLE_ARRAY_MESSAGE(expected, scores, ARRAY_SIZE(expected),
+                                           "The sequence of 64-bit floating-point numbers is different from expected");
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_sum_yields_example);
+    RUN_TEST(test_sum_yields_all_zeros);
+    RUN_TEST(test_sum_yields_cancels_to_zero);
+    RUN_TEST(test_sum_yields_mixed_signs);
+    RUN_TEST(test_sum_yields_fractional);
+    RUN_TEST(test_sum_yields_large_values);
+    RUN_TEST(test_sum_yields_one_operand_zero);
+    RUN_TEST(test_sum_yields_both_negative);
+    RUN_TEST(test_scaled_deviation_example);
+    RUN_TEST(test_scaled_deviation_zero_deviation);
+    RUN_TEST(test_scaled_deviation_negative_deviation);
+    RUN_TEST(test_scaled_deviation_zero_sensitivity);
+    RUN_TEST(test_scaled_deviation_fractional_sensitivity);
+    RUN_TEST(test_scaled_deviation_negative_target);
+    RUN_TEST(test_scaled_deviation_negative_sensitivity);
+    RUN_TEST(test_scaled_deviation_larger_values);
+    RUN_TEST(test_calibrate_batch_example);
+    RUN_TEST(test_calibrate_batch_uniform);
+    RUN_TEST(test_calibrate_batch_different_offset_per_lane);
+    RUN_TEST(test_calibrate_batch_negative_raw);
+    RUN_TEST(test_calibrate_batch_different_reference_per_lane);
+    RUN_TEST(test_calibrate_batch_fractional_raw);
+    RUN_TEST(test_calibrate_batch_offset_exceeds_raw);
+    RUN_TEST(test_calibrate_batch_mixed_reference_offset);
+    RUN_TEST(test_normalize_scores_example);
+    RUN_TEST(test_normalize_scores_single_iteration);
+    RUN_TEST(test_normalize_scores_identity);
+    RUN_TEST(test_normalize_scores_three_iterations);
+    RUN_TEST(test_normalize_scores_negative_scores);
+    RUN_TEST(test_normalize_scores_negative_gains);
+    RUN_TEST(test_normalize_scores_fractional_gains);
+    RUN_TEST(test_normalize_scores_negative_scale);
+    return UNITY_END();
+}

--- a/exercises/concept/production-line/vendor/unity.c
+++ b/exercises/concept/production-line/vendor/unity.c
@@ -1,0 +1,1861 @@
+/* =========================================================================
+    Unity Project - A Test Framework for C
+    Copyright (c) 2007-14 Mike Karlesky, Mark VanderVoord, Greg Williams
+    [Released under MIT License. Please refer to license.txt for details]
+============================================================================ */
+
+#define UNITY_INCLUDE_SETUP_STUBS
+#include "unity.h"
+#include <stddef.h>
+
+/* If omitted from header, declare overrideable prototypes here so they're ready for use */
+#ifdef UNITY_OMIT_OUTPUT_CHAR_HEADER_DECLARATION
+void UNITY_OUTPUT_CHAR(int);
+#endif
+
+/* Helpful macros for us to use here in Assert functions */
+#define UNITY_FAIL_AND_BAIL   { Unity.CurrentTestFailed  = 1; UNITY_OUTPUT_FLUSH(); TEST_ABORT(); }
+#define UNITY_IGNORE_AND_BAIL { Unity.CurrentTestIgnored = 1; UNITY_OUTPUT_FLUSH(); TEST_ABORT(); }
+#define RETURN_IF_FAIL_OR_IGNORE if (Unity.CurrentTestFailed || Unity.CurrentTestIgnored) return
+
+struct UNITY_STORAGE_T Unity;
+
+#ifdef UNITY_OUTPUT_COLOR
+static const char UnityStrOk[]                     = "\033[42mOK\033[00m";
+static const char UnityStrPass[]                   = "\033[42mPASS\033[00m";
+static const char UnityStrFail[]                   = "\033[41mFAIL\033[00m";
+static const char UnityStrIgnore[]                 = "\033[43mIGNORE\033[00m";
+#else
+static const char UnityStrOk[]                     = "OK";
+static const char UnityStrPass[]                   = "PASS";
+static const char UnityStrFail[]                   = "FAIL";
+static const char UnityStrIgnore[]                 = "IGNORE";
+#endif
+static const char UnityStrNull[]                   = "NULL";
+static const char UnityStrSpacer[]                 = ". ";
+static const char UnityStrExpected[]               = " Expected ";
+static const char UnityStrWas[]                    = " Was ";
+static const char UnityStrGt[]                     = " to be greater than ";
+static const char UnityStrLt[]                     = " to be less than ";
+static const char UnityStrOrEqual[]                = "or equal to ";
+static const char UnityStrElement[]                = " Element ";
+static const char UnityStrByte[]                   = " Byte ";
+static const char UnityStrMemory[]                 = " Memory Mismatch.";
+static const char UnityStrDelta[]                  = " Values Not Within Delta ";
+static const char UnityStrPointless[]              = " You Asked Me To Compare Nothing, Which Was Pointless.";
+static const char UnityStrNullPointerForExpected[] = " Expected pointer to be NULL";
+static const char UnityStrNullPointerForActual[]   = " Actual pointer was NULL";
+#ifndef UNITY_EXCLUDE_FLOAT
+static const char UnityStrNot[]                    = "Not ";
+static const char UnityStrInf[]                    = "Infinity";
+static const char UnityStrNegInf[]                 = "Negative Infinity";
+static const char UnityStrNaN[]                    = "NaN";
+static const char UnityStrDet[]                    = "Determinate";
+static const char UnityStrInvalidFloatTrait[]      = "Invalid Float Trait";
+#endif
+const char UnityStrErrFloat[]                      = "Unity Floating Point Disabled";
+const char UnityStrErrDouble[]                     = "Unity Double Precision Disabled";
+const char UnityStrErr64[]                         = "Unity 64-bit Support Disabled";
+static const char UnityStrBreaker[]                = "-----------------------";
+static const char UnityStrResultsTests[]           = " Tests ";
+static const char UnityStrResultsFailures[]        = " Failures ";
+static const char UnityStrResultsIgnored[]         = " Ignored ";
+static const char UnityStrDetail1Name[]            = UNITY_DETAIL1_NAME " ";
+static const char UnityStrDetail2Name[]            = " " UNITY_DETAIL2_NAME " ";
+
+/*-----------------------------------------------
+ * Pretty Printers & Test Result Output Handlers
+ *-----------------------------------------------*/
+
+/*-----------------------------------------------*/
+/* Local helper function to print characters. */
+static void UnityPrintChar(const char* pch)
+{
+    /* printable characters plus CR & LF are printed */
+    if ((*pch <= 126) && (*pch >= 32))
+    {
+        UNITY_OUTPUT_CHAR(*pch);
+    }
+    /* write escaped carriage returns */
+    else if (*pch == 13)
+    {
+        UNITY_OUTPUT_CHAR('\\');
+        UNITY_OUTPUT_CHAR('r');
+    }
+    /* write escaped line feeds */
+    else if (*pch == 10)
+    {
+        UNITY_OUTPUT_CHAR('\\');
+        UNITY_OUTPUT_CHAR('n');
+    }
+    /* unprintable characters are shown as codes */
+    else
+    {
+        UNITY_OUTPUT_CHAR('\\');
+        UNITY_OUTPUT_CHAR('x');
+        UnityPrintNumberHex((UNITY_UINT)*pch, 2);
+    }
+}
+
+/*-----------------------------------------------*/
+/* Local helper function to print ANSI escape strings e.g. "\033[42m". */
+#ifdef UNITY_OUTPUT_COLOR
+static UNITY_UINT UnityPrintAnsiEscapeString(const char* string)
+{
+    const char* pch = string;
+    UNITY_UINT count = 0;
+
+    while (*pch && (*pch != 'm'))
+    {
+        UNITY_OUTPUT_CHAR(*pch);
+        pch++;
+        count++;
+    }
+    UNITY_OUTPUT_CHAR('m');
+    count++;
+
+    return count;
+}
+#endif
+
+/*-----------------------------------------------*/
+void UnityPrint(const char* string)
+{
+    const char* pch = string;
+
+    if (pch != NULL)
+    {
+        while (*pch)
+        {
+#ifdef UNITY_OUTPUT_COLOR
+            /* print ANSI escape code */
+            if ((*pch == 27) && (*(pch + 1) == '['))
+            {
+                pch += UnityPrintAnsiEscapeString(pch);
+                continue;
+            }
+#endif
+            UnityPrintChar(pch);
+            pch++;
+        }
+    }
+}
+
+/*-----------------------------------------------*/
+#ifdef UNITY_INCLUDE_PRINT_FORMATTED
+void UnityPrintFormatted(const char* format, ...)
+{
+    const char* pch = format;
+    va_list va;
+    va_start(va, format);
+
+    if (pch != NULL)
+    {
+        while (*pch)
+        {
+            /* format identification character */
+            if (*pch == '%')
+            {
+                pch++;
+
+                if (pch != NULL)
+                {
+                    switch (*pch)
+                    {
+                        case 'd':
+                        case 'i':
+                            {
+                                const int number = va_arg(va, int);
+                                UnityPrintNumber((UNITY_INT)number);
+                                break;
+                            }
+#ifndef UNITY_EXCLUDE_FLOAT_PRINT
+                        case 'f':
+                        case 'g':
+                            {
+                                const double number = va_arg(va, double);
+                                UnityPrintFloat((UNITY_DOUBLE)number);
+                                break;
+                            }
+#endif
+                        case 'u':
+                            {
+                                const unsigned int number = va_arg(va, unsigned int);
+                                UnityPrintNumberUnsigned((UNITY_UINT)number);
+                                break;
+                            }
+                        case 'b':
+                            {
+                                const unsigned int number = va_arg(va, unsigned int);
+                                const UNITY_UINT mask = (UNITY_UINT)0 - (UNITY_UINT)1;
+                                UNITY_OUTPUT_CHAR('0');
+                                UNITY_OUTPUT_CHAR('b');
+                                UnityPrintMask(mask, (UNITY_UINT)number);
+                                break;
+                            }
+                        case 'x':
+                        case 'X':
+                        case 'p':
+                            {
+                                const unsigned int number = va_arg(va, unsigned int);
+                                UNITY_OUTPUT_CHAR('0');
+                                UNITY_OUTPUT_CHAR('x');
+                                UnityPrintNumberHex((UNITY_UINT)number, 8);
+                                break;
+                            }
+                        case 'c':
+                            {
+                                const int ch = va_arg(va, int);
+                                UnityPrintChar((const char *)&ch);
+                                break;
+                            }
+                        case 's':
+                            {
+                                const char * string = va_arg(va, const char *);
+                                UnityPrint(string);
+                                break;
+                            }
+                        case '%':
+                            {
+                                UnityPrintChar(pch);
+                                break;
+                            }
+                        default:
+                            {
+                                /* print the unknown format character */
+                                UNITY_OUTPUT_CHAR('%');
+                                UnityPrintChar(pch);
+                                break;
+                            }
+                    }
+                }
+            }
+#ifdef UNITY_OUTPUT_COLOR
+            /* print ANSI escape code */
+            else if ((*pch == 27) && (*(pch + 1) == '['))
+            {
+                pch += UnityPrintAnsiEscapeString(pch);
+                continue;
+            }
+#endif
+            else if (*pch == '\n')
+            {
+                UNITY_PRINT_EOL();
+            }
+            else
+            {
+                UnityPrintChar(pch);
+            }
+
+            pch++;
+        }
+    }
+
+    va_end(va);
+}
+#endif /* ! UNITY_INCLUDE_PRINT_FORMATTED */
+
+/*-----------------------------------------------*/
+void UnityPrintLen(const char* string, const UNITY_UINT32 length)
+{
+    const char* pch = string;
+
+    if (pch != NULL)
+    {
+        while (*pch && ((UNITY_UINT32)(pch - string) < length))
+        {
+            /* printable characters plus CR & LF are printed */
+            if ((*pch <= 126) && (*pch >= 32))
+            {
+                UNITY_OUTPUT_CHAR(*pch);
+            }
+            /* write escaped carriage returns */
+            else if (*pch == 13)
+            {
+                UNITY_OUTPUT_CHAR('\\');
+                UNITY_OUTPUT_CHAR('r');
+            }
+            /* write escaped line feeds */
+            else if (*pch == 10)
+            {
+                UNITY_OUTPUT_CHAR('\\');
+                UNITY_OUTPUT_CHAR('n');
+            }
+            /* unprintable characters are shown as codes */
+            else
+            {
+                UNITY_OUTPUT_CHAR('\\');
+                UNITY_OUTPUT_CHAR('x');
+                UnityPrintNumberHex((UNITY_UINT)*pch, 2);
+            }
+            pch++;
+        }
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityPrintNumberByStyle(const UNITY_INT number, const UNITY_DISPLAY_STYLE_T style)
+{
+    if ((style & UNITY_DISPLAY_RANGE_INT) == UNITY_DISPLAY_RANGE_INT)
+    {
+        UnityPrintNumber(number);
+    }
+    else if ((style & UNITY_DISPLAY_RANGE_UINT) == UNITY_DISPLAY_RANGE_UINT)
+    {
+        UnityPrintNumberUnsigned((UNITY_UINT)number);
+    }
+    else
+    {
+        UNITY_OUTPUT_CHAR('0');
+        UNITY_OUTPUT_CHAR('x');
+        UnityPrintNumberHex((UNITY_UINT)number, (char)((style & 0xF) * 2));
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityPrintNumber(const UNITY_INT number_to_print)
+{
+    UNITY_UINT number = (UNITY_UINT)number_to_print;
+
+    if (number_to_print < 0)
+    {
+        /* A negative number, including MIN negative */
+        UNITY_OUTPUT_CHAR('-');
+        number = (UNITY_UINT)-number_to_print;
+    }
+    UnityPrintNumberUnsigned(number);
+}
+
+/*-----------------------------------------------
+ * basically do an itoa using as little ram as possible */
+void UnityPrintNumberUnsigned(const UNITY_UINT number)
+{
+    UNITY_UINT divisor = 1;
+
+    /* figure out initial divisor */
+    while (number / divisor > 9)
+    {
+        divisor *= 10;
+    }
+
+    /* now mod and print, then divide divisor */
+    do
+    {
+        UNITY_OUTPUT_CHAR((char)('0' + (number / divisor % 10)));
+        divisor /= 10;
+    } while (divisor > 0);
+}
+
+/*-----------------------------------------------*/
+void UnityPrintNumberHex(const UNITY_UINT number, const char nibbles_to_print)
+{
+    int nibble;
+    char nibbles = nibbles_to_print;
+
+    if ((unsigned)nibbles > (2 * sizeof(number)))
+    {
+        nibbles = 2 * sizeof(number);
+    }
+
+    while (nibbles > 0)
+    {
+        nibbles--;
+        nibble = (int)(number >> (nibbles * 4)) & 0x0F;
+        if (nibble <= 9)
+        {
+            UNITY_OUTPUT_CHAR((char)('0' + nibble));
+        }
+        else
+        {
+            UNITY_OUTPUT_CHAR((char)('A' - 10 + nibble));
+        }
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityPrintMask(const UNITY_UINT mask, const UNITY_UINT number)
+{
+    UNITY_UINT current_bit = (UNITY_UINT)1 << (UNITY_INT_WIDTH - 1);
+    UNITY_INT32 i;
+
+    for (i = 0; i < UNITY_INT_WIDTH; i++)
+    {
+        if (current_bit & mask)
+        {
+            if (current_bit & number)
+            {
+                UNITY_OUTPUT_CHAR('1');
+            }
+            else
+            {
+                UNITY_OUTPUT_CHAR('0');
+            }
+        }
+        else
+        {
+            UNITY_OUTPUT_CHAR('X');
+        }
+        current_bit = current_bit >> 1;
+    }
+}
+
+/*-----------------------------------------------*/
+#ifndef UNITY_EXCLUDE_FLOAT_PRINT
+/*
+ * This function prints a floating-point value in a format similar to
+ * printf("%.7g") on a single-precision machine or printf("%.9g") on a
+ * double-precision machine.  The 7th digit won't always be totally correct
+ * in single-precision operation (for that level of accuracy, a more
+ * complicated algorithm would be needed).
+ */
+void UnityPrintFloat(const UNITY_DOUBLE input_number)
+{
+#ifdef UNITY_INCLUDE_DOUBLE
+    static const int sig_digits = 9;
+    static const UNITY_INT32 min_scaled = 100000000;
+    static const UNITY_INT32 max_scaled = 1000000000;
+#else
+    static const int sig_digits = 7;
+    static const UNITY_INT32 min_scaled = 1000000;
+    static const UNITY_INT32 max_scaled = 10000000;
+#endif
+
+    UNITY_DOUBLE number = input_number;
+
+    /* print minus sign (including for negative zero) */
+    if ((number < 0.0f) || ((number == 0.0f) && ((1.0f / number) < 0.0f)))
+    {
+        UNITY_OUTPUT_CHAR('-');
+        number = -number;
+    }
+
+    /* handle zero, NaN, and +/- infinity */
+    if (number == 0.0f)
+    {
+        UnityPrint("0");
+    }
+    else if (isnan(number))
+    {
+        UnityPrint("nan");
+    }
+    else if (isinf(number))
+    {
+        UnityPrint("inf");
+    }
+    else
+    {
+        UNITY_INT32 n_int = 0, n;
+        int exponent = 0;
+        int decimals, digits;
+        char buf[16] = {0};
+
+        /*
+         * Scale up or down by powers of 10.  To minimize rounding error,
+         * start with a factor/divisor of 10^10, which is the largest
+         * power of 10 that can be represented exactly.  Finally, compute
+         * (exactly) the remaining power of 10 and perform one more
+         * multiplication or division.
+         */
+        if (number < 1.0f)
+        {
+            UNITY_DOUBLE factor = 1.0f;
+
+            while (number < (UNITY_DOUBLE)max_scaled / 1e10f)  { number *= 1e10f; exponent -= 10; }
+            while (number * factor < (UNITY_DOUBLE)min_scaled) { factor *= 10.0f; exponent--; }
+
+            number *= factor;
+        }
+        else if (number > (UNITY_DOUBLE)max_scaled)
+        {
+            UNITY_DOUBLE divisor = 1.0f;
+
+            while (number > (UNITY_DOUBLE)min_scaled * 1e10f)   { number  /= 1e10f; exponent += 10; }
+            while (number / divisor > (UNITY_DOUBLE)max_scaled) { divisor *= 10.0f; exponent++; }
+
+            number /= divisor;
+        }
+        else
+        {
+            /*
+             * In this range, we can split off the integer part before
+             * doing any multiplications.  This reduces rounding error by
+             * freeing up significant bits in the fractional part.
+             */
+            UNITY_DOUBLE factor = 1.0f;
+            n_int = (UNITY_INT32)number;
+            number -= (UNITY_DOUBLE)n_int;
+
+            while (n_int < min_scaled) { n_int *= 10; factor *= 10.0f; exponent--; }
+
+            number *= factor;
+        }
+
+        /* round to nearest integer */
+        n = ((UNITY_INT32)(number + number) + 1) / 2;
+
+#ifndef UNITY_ROUND_TIES_AWAY_FROM_ZERO
+        /* round to even if exactly between two integers */
+        if ((n & 1) && (((UNITY_DOUBLE)n - number) == 0.5f))
+            n--;
+#endif
+
+        n += n_int;
+
+        if (n >= max_scaled)
+        {
+            n = min_scaled;
+            exponent++;
+        }
+
+        /* determine where to place decimal point */
+        decimals = ((exponent <= 0) && (exponent >= -(sig_digits + 3))) ? (-exponent) : (sig_digits - 1);
+        exponent += decimals;
+
+        /* truncate trailing zeroes after decimal point */
+        while ((decimals > 0) && ((n % 10) == 0))
+        {
+            n /= 10;
+            decimals--;
+        }
+
+        /* build up buffer in reverse order */
+        digits = 0;
+        while ((n != 0) || (digits < (decimals + 1)))
+        {
+            buf[digits++] = (char)('0' + n % 10);
+            n /= 10;
+        }
+        while (digits > 0)
+        {
+            if (digits == decimals) { UNITY_OUTPUT_CHAR('.'); }
+            UNITY_OUTPUT_CHAR(buf[--digits]);
+        }
+
+        /* print exponent if needed */
+        if (exponent != 0)
+        {
+            UNITY_OUTPUT_CHAR('e');
+
+            if (exponent < 0)
+            {
+                UNITY_OUTPUT_CHAR('-');
+                exponent = -exponent;
+            }
+            else
+            {
+                UNITY_OUTPUT_CHAR('+');
+            }
+
+            digits = 0;
+            while ((exponent != 0) || (digits < 2))
+            {
+                buf[digits++] = (char)('0' + exponent % 10);
+                exponent /= 10;
+            }
+            while (digits > 0)
+            {
+                UNITY_OUTPUT_CHAR(buf[--digits]);
+            }
+        }
+    }
+}
+#endif /* ! UNITY_EXCLUDE_FLOAT_PRINT */
+
+/*-----------------------------------------------*/
+static void UnityTestResultsBegin(const char* file, const UNITY_LINE_TYPE line)
+{
+    UnityPrint(file);
+    UNITY_OUTPUT_CHAR(':');
+    UnityPrintNumber((UNITY_INT)line);
+    UNITY_OUTPUT_CHAR(':');
+    UnityPrint(Unity.CurrentTestName);
+    UNITY_OUTPUT_CHAR(':');
+}
+
+/*-----------------------------------------------*/
+static void UnityTestResultsFailBegin(const UNITY_LINE_TYPE line)
+{
+    UnityTestResultsBegin(Unity.TestFile, line);
+    UnityPrint(UnityStrFail);
+    UNITY_OUTPUT_CHAR(':');
+}
+
+/*-----------------------------------------------*/
+void UnityConcludeTest(void)
+{
+    if (Unity.CurrentTestIgnored)
+    {
+        Unity.TestIgnores++;
+    }
+    else if (!Unity.CurrentTestFailed)
+    {
+        UnityTestResultsBegin(Unity.TestFile, Unity.CurrentTestLineNumber);
+        UnityPrint(UnityStrPass);
+    }
+    else
+    {
+        Unity.TestFailures++;
+    }
+
+    Unity.CurrentTestFailed = 0;
+    Unity.CurrentTestIgnored = 0;
+    UNITY_EXEC_TIME_RESET();
+    UNITY_PRINT_EOL();
+    UNITY_FLUSH_CALL();
+}
+
+/*-----------------------------------------------*/
+static void UnityAddMsgIfSpecified(const char* msg)
+{
+    if (msg)
+    {
+        UnityPrint(UnityStrSpacer);
+#ifndef UNITY_EXCLUDE_DETAILS
+        if (Unity.CurrentDetail1)
+        {
+            UnityPrint(UnityStrDetail1Name);
+            UnityPrint(Unity.CurrentDetail1);
+            if (Unity.CurrentDetail2)
+            {
+                UnityPrint(UnityStrDetail2Name);
+                UnityPrint(Unity.CurrentDetail2);
+            }
+            UnityPrint(UnityStrSpacer);
+        }
+#endif
+        UnityPrint(msg);
+    }
+}
+
+/*-----------------------------------------------*/
+static void UnityPrintExpectedAndActualStrings(const char* expected, const char* actual)
+{
+    UnityPrint(UnityStrExpected);
+    if (expected != NULL)
+    {
+        UNITY_OUTPUT_CHAR('\'');
+        UnityPrint(expected);
+        UNITY_OUTPUT_CHAR('\'');
+    }
+    else
+    {
+        UnityPrint(UnityStrNull);
+    }
+    UnityPrint(UnityStrWas);
+    if (actual != NULL)
+    {
+        UNITY_OUTPUT_CHAR('\'');
+        UnityPrint(actual);
+        UNITY_OUTPUT_CHAR('\'');
+    }
+    else
+    {
+        UnityPrint(UnityStrNull);
+    }
+}
+
+/*-----------------------------------------------*/
+static void UnityPrintExpectedAndActualStringsLen(const char* expected,
+                                                  const char* actual,
+                                                  const UNITY_UINT32 length)
+{
+    UnityPrint(UnityStrExpected);
+    if (expected != NULL)
+    {
+        UNITY_OUTPUT_CHAR('\'');
+        UnityPrintLen(expected, length);
+        UNITY_OUTPUT_CHAR('\'');
+    }
+    else
+    {
+        UnityPrint(UnityStrNull);
+    }
+    UnityPrint(UnityStrWas);
+    if (actual != NULL)
+    {
+        UNITY_OUTPUT_CHAR('\'');
+        UnityPrintLen(actual, length);
+        UNITY_OUTPUT_CHAR('\'');
+    }
+    else
+    {
+        UnityPrint(UnityStrNull);
+    }
+}
+
+/*-----------------------------------------------
+ * Assertion & Control Helpers
+ *-----------------------------------------------*/
+
+/*-----------------------------------------------*/
+static int UnityIsOneArrayNull(UNITY_INTERNAL_PTR expected,
+                               UNITY_INTERNAL_PTR actual,
+                               const UNITY_LINE_TYPE lineNumber,
+                               const char* msg)
+{
+    if (expected == actual) return 0; /* Both are NULL or same pointer */
+
+    /* print and return true if just expected is NULL */
+    if (expected == NULL)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrNullPointerForExpected);
+        UnityAddMsgIfSpecified(msg);
+        return 1;
+    }
+
+    /* print and return true if just actual is NULL */
+    if (actual == NULL)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrNullPointerForActual);
+        UnityAddMsgIfSpecified(msg);
+        return 1;
+    }
+
+    return 0; /* return false if neither is NULL */
+}
+
+/*-----------------------------------------------
+ * Assertion Functions
+ *-----------------------------------------------*/
+
+/*-----------------------------------------------*/
+void UnityAssertBits(const UNITY_INT mask,
+                     const UNITY_INT expected,
+                     const UNITY_INT actual,
+                     const char* msg,
+                     const UNITY_LINE_TYPE lineNumber)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if ((mask & expected) != (mask & actual))
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrExpected);
+        UnityPrintMask((UNITY_UINT)mask, (UNITY_UINT)expected);
+        UnityPrint(UnityStrWas);
+        UnityPrintMask((UNITY_UINT)mask, (UNITY_UINT)actual);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertEqualNumber(const UNITY_INT expected,
+                            const UNITY_INT actual,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber,
+                            const UNITY_DISPLAY_STYLE_T style)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if (expected != actual)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrExpected);
+        UnityPrintNumberByStyle(expected, style);
+        UnityPrint(UnityStrWas);
+        UnityPrintNumberByStyle(actual, style);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertGreaterOrLessOrEqualNumber(const UNITY_INT threshold,
+                                           const UNITY_INT actual,
+                                           const UNITY_COMPARISON_T compare,
+                                           const char *msg,
+                                           const UNITY_LINE_TYPE lineNumber,
+                                           const UNITY_DISPLAY_STYLE_T style)
+{
+    int failed = 0;
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if ((threshold == actual) && (compare & UNITY_EQUAL_TO)) { return; }
+    if ((threshold == actual))                               { failed = 1; }
+
+    if ((style & UNITY_DISPLAY_RANGE_INT) == UNITY_DISPLAY_RANGE_INT)
+    {
+        if ((actual > threshold) && (compare & UNITY_SMALLER_THAN)) { failed = 1; }
+        if ((actual < threshold) && (compare & UNITY_GREATER_THAN)) { failed = 1; }
+    }
+    else /* UINT or HEX */
+    {
+        if (((UNITY_UINT)actual > (UNITY_UINT)threshold) && (compare & UNITY_SMALLER_THAN)) { failed = 1; }
+        if (((UNITY_UINT)actual < (UNITY_UINT)threshold) && (compare & UNITY_GREATER_THAN)) { failed = 1; }
+    }
+
+    if (failed)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrExpected);
+        UnityPrintNumberByStyle(actual, style);
+        if (compare & UNITY_GREATER_THAN) { UnityPrint(UnityStrGt);      }
+        if (compare & UNITY_SMALLER_THAN) { UnityPrint(UnityStrLt);      }
+        if (compare & UNITY_EQUAL_TO)     { UnityPrint(UnityStrOrEqual); }
+        UnityPrintNumberByStyle(threshold, style);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+#define UnityPrintPointlessAndBail()       \
+{                                          \
+    UnityTestResultsFailBegin(lineNumber); \
+    UnityPrint(UnityStrPointless);         \
+    UnityAddMsgIfSpecified(msg);           \
+    UNITY_FAIL_AND_BAIL; }
+
+/*-----------------------------------------------*/
+void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
+                              UNITY_INTERNAL_PTR actual,
+                              const UNITY_UINT32 num_elements,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber,
+                              const UNITY_DISPLAY_STYLE_T style,
+                              const UNITY_FLAGS_T flags)
+{
+    UNITY_UINT32 elements = num_elements;
+    unsigned int length   = style & 0xF;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if (num_elements == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
+
+    if (expected == actual)
+    {
+        return; /* Both are NULL or same pointer */
+    }
+
+    if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))
+    {
+        UNITY_FAIL_AND_BAIL;
+    }
+
+    while ((elements > 0) && (elements--))
+    {
+        UNITY_INT expect_val;
+        UNITY_INT actual_val;
+        switch (length)
+        {
+            case 1:
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT8*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT8*)actual;
+                break;
+            case 2:
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT16*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT16*)actual;
+                break;
+#ifdef UNITY_SUPPORT_64
+            case 8:
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT64*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT64*)actual;
+                break;
+#endif
+            default: /* length 4 bytes */
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT32*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT32*)actual;
+                length = 4;
+                break;
+        }
+
+        if (expect_val != actual_val)
+        {
+            if ((style & UNITY_DISPLAY_RANGE_UINT) && (length < sizeof(expect_val)))
+            {   /* For UINT, remove sign extension (padding 1's) from signed type casts above */
+                UNITY_INT mask = 1;
+                mask = (mask << 8 * length) - 1;
+                expect_val &= mask;
+                actual_val &= mask;
+            }
+            UnityTestResultsFailBegin(lineNumber);
+            UnityPrint(UnityStrElement);
+            UnityPrintNumberUnsigned(num_elements - elements - 1);
+            UnityPrint(UnityStrExpected);
+            UnityPrintNumberByStyle(expect_val, style);
+            UnityPrint(UnityStrWas);
+            UnityPrintNumberByStyle(actual_val, style);
+            UnityAddMsgIfSpecified(msg);
+            UNITY_FAIL_AND_BAIL;
+        }
+        if (flags == UNITY_ARRAY_TO_ARRAY)
+        {
+            expected = (UNITY_INTERNAL_PTR)(length + (const char*)expected);
+        }
+        actual   = (UNITY_INTERNAL_PTR)(length + (const char*)actual);
+    }
+}
+
+/*-----------------------------------------------*/
+#ifndef UNITY_EXCLUDE_FLOAT
+/* Wrap this define in a function with variable types as float or double */
+#define UNITY_FLOAT_OR_DOUBLE_WITHIN(delta, expected, actual, diff)                           \
+    if (isinf(expected) && isinf(actual) && (((expected) < 0) == ((actual) < 0))) return 1;   \
+    if (UNITY_NAN_CHECK) return 1;                                                            \
+    (diff) = (actual) - (expected);                                                           \
+    if ((diff) < 0) (diff) = -(diff);                                                         \
+    if ((delta) < 0) (delta) = -(delta);                                                      \
+    return !(isnan(diff) || isinf(diff) || ((diff) > (delta)))
+    /* This first part of this condition will catch any NaN or Infinite values */
+#ifndef UNITY_NAN_NOT_EQUAL_NAN
+  #define UNITY_NAN_CHECK isnan(expected) && isnan(actual)
+#else
+  #define UNITY_NAN_CHECK 0
+#endif
+
+#ifndef UNITY_EXCLUDE_FLOAT_PRINT
+  #define UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(expected, actual) \
+  {                                                               \
+    UnityPrint(UnityStrExpected);                                 \
+    UnityPrintFloat(expected);                                    \
+    UnityPrint(UnityStrWas);                                      \
+    UnityPrintFloat(actual); }
+#else
+  #define UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(expected, actual) \
+    UnityPrint(UnityStrDelta)
+#endif /* UNITY_EXCLUDE_FLOAT_PRINT */
+
+/*-----------------------------------------------*/
+static int UnityFloatsWithin(UNITY_FLOAT delta, UNITY_FLOAT expected, UNITY_FLOAT actual)
+{
+    UNITY_FLOAT diff;
+    UNITY_FLOAT_OR_DOUBLE_WITHIN(delta, expected, actual, diff);
+}
+
+/*-----------------------------------------------*/
+void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* expected,
+                                UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* actual,
+                                const UNITY_UINT32 num_elements,
+                                const char* msg,
+                                const UNITY_LINE_TYPE lineNumber,
+                                const UNITY_FLAGS_T flags)
+{
+    UNITY_UINT32 elements = num_elements;
+    UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* ptr_expected = expected;
+    UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* ptr_actual = actual;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if (elements == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
+
+    if (expected == actual)
+    {
+        return; /* Both are NULL or same pointer */
+    }
+
+    if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
+    {
+        UNITY_FAIL_AND_BAIL;
+    }
+
+    while (elements--)
+    {
+        if (!UnityFloatsWithin(*ptr_expected * UNITY_FLOAT_PRECISION, *ptr_expected, *ptr_actual))
+        {
+            UnityTestResultsFailBegin(lineNumber);
+            UnityPrint(UnityStrElement);
+            UnityPrintNumberUnsigned(num_elements - elements - 1);
+            UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT((UNITY_DOUBLE)*ptr_expected, (UNITY_DOUBLE)*ptr_actual);
+            UnityAddMsgIfSpecified(msg);
+            UNITY_FAIL_AND_BAIL;
+        }
+        if (flags == UNITY_ARRAY_TO_ARRAY)
+        {
+            ptr_expected++;
+        }
+        ptr_actual++;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertFloatsWithin(const UNITY_FLOAT delta,
+                             const UNITY_FLOAT expected,
+                             const UNITY_FLOAT actual,
+                             const char* msg,
+                             const UNITY_LINE_TYPE lineNumber)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+
+    if (!UnityFloatsWithin(delta, expected, actual))
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT((UNITY_DOUBLE)expected, (UNITY_DOUBLE)actual);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertFloatSpecial(const UNITY_FLOAT actual,
+                             const char* msg,
+                             const UNITY_LINE_TYPE lineNumber,
+                             const UNITY_FLOAT_TRAIT_T style)
+{
+    const char* trait_names[] = {UnityStrInf, UnityStrNegInf, UnityStrNaN, UnityStrDet};
+    UNITY_INT should_be_trait = ((UNITY_INT)style & 1);
+    UNITY_INT is_trait        = !should_be_trait;
+    UNITY_INT trait_index     = (UNITY_INT)(style >> 1);
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    switch (style)
+    {
+        case UNITY_FLOAT_IS_INF:
+        case UNITY_FLOAT_IS_NOT_INF:
+            is_trait = isinf(actual) && (actual > 0);
+            break;
+        case UNITY_FLOAT_IS_NEG_INF:
+        case UNITY_FLOAT_IS_NOT_NEG_INF:
+            is_trait = isinf(actual) && (actual < 0);
+            break;
+
+        case UNITY_FLOAT_IS_NAN:
+        case UNITY_FLOAT_IS_NOT_NAN:
+            is_trait = isnan(actual) ? 1 : 0;
+            break;
+
+        case UNITY_FLOAT_IS_DET: /* A determinate number is non infinite and not NaN. */
+        case UNITY_FLOAT_IS_NOT_DET:
+            is_trait = !isinf(actual) && !isnan(actual);
+            break;
+
+        default:
+            trait_index = 0;
+            trait_names[0] = UnityStrInvalidFloatTrait;
+            break;
+    }
+
+    if (is_trait != should_be_trait)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrExpected);
+        if (!should_be_trait)
+        {
+            UnityPrint(UnityStrNot);
+        }
+        UnityPrint(trait_names[trait_index]);
+        UnityPrint(UnityStrWas);
+#ifndef UNITY_EXCLUDE_FLOAT_PRINT
+        UnityPrintFloat((UNITY_DOUBLE)actual);
+#else
+        if (should_be_trait)
+        {
+            UnityPrint(UnityStrNot);
+        }
+        UnityPrint(trait_names[trait_index]);
+#endif
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+#endif /* not UNITY_EXCLUDE_FLOAT */
+
+/*-----------------------------------------------*/
+#ifndef UNITY_EXCLUDE_DOUBLE
+static int UnityDoublesWithin(UNITY_DOUBLE delta, UNITY_DOUBLE expected, UNITY_DOUBLE actual)
+{
+    UNITY_DOUBLE diff;
+    UNITY_FLOAT_OR_DOUBLE_WITHIN(delta, expected, actual, diff);
+}
+
+/*-----------------------------------------------*/
+void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* expected,
+                                 UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* actual,
+                                 const UNITY_UINT32 num_elements,
+                                 const char* msg,
+                                 const UNITY_LINE_TYPE lineNumber,
+                                 const UNITY_FLAGS_T flags)
+{
+    UNITY_UINT32 elements = num_elements;
+    UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* ptr_expected = expected;
+    UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* ptr_actual = actual;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if (elements == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
+
+    if (expected == actual)
+    {
+        return; /* Both are NULL or same pointer */
+    }
+
+    if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
+    {
+        UNITY_FAIL_AND_BAIL;
+    }
+
+    while (elements--)
+    {
+        if (!UnityDoublesWithin(*ptr_expected * UNITY_DOUBLE_PRECISION, *ptr_expected, *ptr_actual))
+        {
+            UnityTestResultsFailBegin(lineNumber);
+            UnityPrint(UnityStrElement);
+            UnityPrintNumberUnsigned(num_elements - elements - 1);
+            UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(*ptr_expected, *ptr_actual);
+            UnityAddMsgIfSpecified(msg);
+            UNITY_FAIL_AND_BAIL;
+        }
+        if (flags == UNITY_ARRAY_TO_ARRAY)
+        {
+            ptr_expected++;
+        }
+        ptr_actual++;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertDoublesWithin(const UNITY_DOUBLE delta,
+                              const UNITY_DOUBLE expected,
+                              const UNITY_DOUBLE actual,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if (!UnityDoublesWithin(delta, expected, actual))
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(expected, actual);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertDoubleSpecial(const UNITY_DOUBLE actual,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber,
+                              const UNITY_FLOAT_TRAIT_T style)
+{
+    const char* trait_names[] = {UnityStrInf, UnityStrNegInf, UnityStrNaN, UnityStrDet};
+    UNITY_INT should_be_trait = ((UNITY_INT)style & 1);
+    UNITY_INT is_trait        = !should_be_trait;
+    UNITY_INT trait_index     = (UNITY_INT)(style >> 1);
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    switch (style)
+    {
+        case UNITY_FLOAT_IS_INF:
+        case UNITY_FLOAT_IS_NOT_INF:
+            is_trait = isinf(actual) && (actual > 0);
+            break;
+        case UNITY_FLOAT_IS_NEG_INF:
+        case UNITY_FLOAT_IS_NOT_NEG_INF:
+            is_trait = isinf(actual) && (actual < 0);
+            break;
+
+        case UNITY_FLOAT_IS_NAN:
+        case UNITY_FLOAT_IS_NOT_NAN:
+            is_trait = isnan(actual) ? 1 : 0;
+            break;
+
+        case UNITY_FLOAT_IS_DET: /* A determinate number is non infinite and not NaN. */
+        case UNITY_FLOAT_IS_NOT_DET:
+            is_trait = !isinf(actual) && !isnan(actual);
+            break;
+
+        default:
+            trait_index = 0;
+            trait_names[0] = UnityStrInvalidFloatTrait;
+            break;
+    }
+
+    if (is_trait != should_be_trait)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrExpected);
+        if (!should_be_trait)
+        {
+            UnityPrint(UnityStrNot);
+        }
+        UnityPrint(trait_names[trait_index]);
+        UnityPrint(UnityStrWas);
+#ifndef UNITY_EXCLUDE_FLOAT_PRINT
+        UnityPrintFloat(actual);
+#else
+        if (should_be_trait)
+        {
+            UnityPrint(UnityStrNot);
+        }
+        UnityPrint(trait_names[trait_index]);
+#endif
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+#endif /* not UNITY_EXCLUDE_DOUBLE */
+
+/*-----------------------------------------------*/
+void UnityAssertNumbersWithin(const UNITY_UINT delta,
+                              const UNITY_INT expected,
+                              const UNITY_INT actual,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber,
+                              const UNITY_DISPLAY_STYLE_T style)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if ((style & UNITY_DISPLAY_RANGE_INT) == UNITY_DISPLAY_RANGE_INT)
+    {
+        if (actual > expected)
+        {
+            Unity.CurrentTestFailed = (((UNITY_UINT)actual - (UNITY_UINT)expected) > delta);
+        }
+        else
+        {
+            Unity.CurrentTestFailed = (((UNITY_UINT)expected - (UNITY_UINT)actual) > delta);
+        }
+    }
+    else
+    {
+        if ((UNITY_UINT)actual > (UNITY_UINT)expected)
+        {
+            Unity.CurrentTestFailed = (((UNITY_UINT)actual - (UNITY_UINT)expected) > delta);
+        }
+        else
+        {
+            Unity.CurrentTestFailed = (((UNITY_UINT)expected - (UNITY_UINT)actual) > delta);
+        }
+    }
+
+    if (Unity.CurrentTestFailed)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrDelta);
+        UnityPrintNumberByStyle((UNITY_INT)delta, style);
+        UnityPrint(UnityStrExpected);
+        UnityPrintNumberByStyle(expected, style);
+        UnityPrint(UnityStrWas);
+        UnityPrintNumberByStyle(actual, style);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertEqualString(const char* expected,
+                            const char* actual,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber)
+{
+    UNITY_UINT32 i;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    /* if both pointers not null compare the strings */
+    if (expected && actual)
+    {
+        for (i = 0; expected[i] || actual[i]; i++)
+        {
+            if (expected[i] != actual[i])
+            {
+                Unity.CurrentTestFailed = 1;
+                break;
+            }
+        }
+    }
+    else
+    { /* handle case of one pointers being null (if both null, test should pass) */
+        if (expected != actual)
+        {
+            Unity.CurrentTestFailed = 1;
+        }
+    }
+
+    if (Unity.CurrentTestFailed)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrintExpectedAndActualStrings(expected, actual);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertEqualStringLen(const char* expected,
+                               const char* actual,
+                               const UNITY_UINT32 length,
+                               const char* msg,
+                               const UNITY_LINE_TYPE lineNumber)
+{
+    UNITY_UINT32 i;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    /* if both pointers not null compare the strings */
+    if (expected && actual)
+    {
+        for (i = 0; (i < length) && (expected[i] || actual[i]); i++)
+        {
+            if (expected[i] != actual[i])
+            {
+                Unity.CurrentTestFailed = 1;
+                break;
+            }
+        }
+    }
+    else
+    { /* handle case of one pointers being null (if both null, test should pass) */
+        if (expected != actual)
+        {
+            Unity.CurrentTestFailed = 1;
+        }
+    }
+
+    if (Unity.CurrentTestFailed)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrintExpectedAndActualStringsLen(expected, actual, length);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertEqualStringArray(UNITY_INTERNAL_PTR expected,
+                                 const char** actual,
+                                 const UNITY_UINT32 num_elements,
+                                 const char* msg,
+                                 const UNITY_LINE_TYPE lineNumber,
+                                 const UNITY_FLAGS_T flags)
+{
+    UNITY_UINT32 i = 0;
+    UNITY_UINT32 j = 0;
+    const char* expd = NULL;
+    const char* act = NULL;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    /* if no elements, it's an error */
+    if (num_elements == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
+
+    if ((const void*)expected == (const void*)actual)
+    {
+        return; /* Both are NULL or same pointer */
+    }
+
+    if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
+    {
+        UNITY_FAIL_AND_BAIL;
+    }
+
+    if (flags != UNITY_ARRAY_TO_ARRAY)
+    {
+        expd = (const char*)expected;
+    }
+
+    do
+    {
+        act = actual[j];
+        if (flags == UNITY_ARRAY_TO_ARRAY)
+        {
+            expd = ((const char* const*)expected)[j];
+        }
+
+        /* if both pointers not null compare the strings */
+        if (expd && act)
+        {
+            for (i = 0; expd[i] || act[i]; i++)
+            {
+                if (expd[i] != act[i])
+                {
+                    Unity.CurrentTestFailed = 1;
+                    break;
+                }
+            }
+        }
+        else
+        { /* handle case of one pointers being null (if both null, test should pass) */
+            if (expd != act)
+            {
+                Unity.CurrentTestFailed = 1;
+            }
+        }
+
+        if (Unity.CurrentTestFailed)
+        {
+            UnityTestResultsFailBegin(lineNumber);
+            if (num_elements > 1)
+            {
+                UnityPrint(UnityStrElement);
+                UnityPrintNumberUnsigned(j);
+            }
+            UnityPrintExpectedAndActualStrings(expd, act);
+            UnityAddMsgIfSpecified(msg);
+            UNITY_FAIL_AND_BAIL;
+        }
+    } while (++j < num_elements);
+}
+
+/*-----------------------------------------------*/
+void UnityAssertEqualMemory(UNITY_INTERNAL_PTR expected,
+                            UNITY_INTERNAL_PTR actual,
+                            const UNITY_UINT32 length,
+                            const UNITY_UINT32 num_elements,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber,
+                            const UNITY_FLAGS_T flags)
+{
+    UNITY_PTR_ATTRIBUTE const unsigned char* ptr_exp = (UNITY_PTR_ATTRIBUTE const unsigned char*)expected;
+    UNITY_PTR_ATTRIBUTE const unsigned char* ptr_act = (UNITY_PTR_ATTRIBUTE const unsigned char*)actual;
+    UNITY_UINT32 elements = num_elements;
+    UNITY_UINT32 bytes;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if ((elements == 0) || (length == 0))
+    {
+        UnityPrintPointlessAndBail();
+    }
+
+    if (expected == actual)
+    {
+        return; /* Both are NULL or same pointer */
+    }
+
+    if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))
+    {
+        UNITY_FAIL_AND_BAIL;
+    }
+
+    while (elements--)
+    {
+        bytes = length;
+        while (bytes--)
+        {
+            if (*ptr_exp != *ptr_act)
+            {
+                UnityTestResultsFailBegin(lineNumber);
+                UnityPrint(UnityStrMemory);
+                if (num_elements > 1)
+                {
+                    UnityPrint(UnityStrElement);
+                    UnityPrintNumberUnsigned(num_elements - elements - 1);
+                }
+                UnityPrint(UnityStrByte);
+                UnityPrintNumberUnsigned(length - bytes - 1);
+                UnityPrint(UnityStrExpected);
+                UnityPrintNumberByStyle(*ptr_exp, UNITY_DISPLAY_STYLE_HEX8);
+                UnityPrint(UnityStrWas);
+                UnityPrintNumberByStyle(*ptr_act, UNITY_DISPLAY_STYLE_HEX8);
+                UnityAddMsgIfSpecified(msg);
+                UNITY_FAIL_AND_BAIL;
+            }
+            ptr_exp++;
+            ptr_act++;
+        }
+        if (flags == UNITY_ARRAY_TO_VAL)
+        {
+            ptr_exp = (UNITY_PTR_ATTRIBUTE const unsigned char*)expected;
+        }
+    }
+}
+
+/*-----------------------------------------------*/
+
+static union
+{
+    UNITY_INT8 i8;
+    UNITY_INT16 i16;
+    UNITY_INT32 i32;
+#ifdef UNITY_SUPPORT_64
+    UNITY_INT64 i64;
+#endif
+#ifndef UNITY_EXCLUDE_FLOAT
+    float f;
+#endif
+#ifndef UNITY_EXCLUDE_DOUBLE
+    double d;
+#endif
+} UnityQuickCompare;
+
+UNITY_INTERNAL_PTR UnityNumToPtr(const UNITY_INT num, const UNITY_UINT8 size)
+{
+    switch(size)
+    {
+        case 1:
+          UnityQuickCompare.i8 = (UNITY_INT8)num;
+          return (UNITY_INTERNAL_PTR)(&UnityQuickCompare.i8);
+
+        case 2:
+          UnityQuickCompare.i16 = (UNITY_INT16)num;
+          return (UNITY_INTERNAL_PTR)(&UnityQuickCompare.i16);
+
+#ifdef UNITY_SUPPORT_64
+        case 8:
+          UnityQuickCompare.i64 = (UNITY_INT64)num;
+          return (UNITY_INTERNAL_PTR)(&UnityQuickCompare.i64);
+#endif
+        default: /* 4 bytes */
+          UnityQuickCompare.i32 = (UNITY_INT32)num;
+          return (UNITY_INTERNAL_PTR)(&UnityQuickCompare.i32);
+    }
+}
+
+#ifndef UNITY_EXCLUDE_FLOAT
+/*-----------------------------------------------*/
+UNITY_INTERNAL_PTR UnityFloatToPtr(const float num)
+{
+    UnityQuickCompare.f = num;
+    return (UNITY_INTERNAL_PTR)(&UnityQuickCompare.f);
+}
+#endif
+
+#ifndef UNITY_EXCLUDE_DOUBLE
+/*-----------------------------------------------*/
+UNITY_INTERNAL_PTR UnityDoubleToPtr(const double num)
+{
+    UnityQuickCompare.d = num;
+    return (UNITY_INTERNAL_PTR)(&UnityQuickCompare.d);
+}
+#endif
+
+/*-----------------------------------------------
+ * Control Functions
+ *-----------------------------------------------*/
+
+/*-----------------------------------------------*/
+void UnityFail(const char* msg, const UNITY_LINE_TYPE line)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    UnityTestResultsBegin(Unity.TestFile, line);
+    UnityPrint(UnityStrFail);
+    if (msg != NULL)
+    {
+        UNITY_OUTPUT_CHAR(':');
+
+#ifndef UNITY_EXCLUDE_DETAILS
+        if (Unity.CurrentDetail1)
+        {
+            UnityPrint(UnityStrDetail1Name);
+            UnityPrint(Unity.CurrentDetail1);
+            if (Unity.CurrentDetail2)
+            {
+                UnityPrint(UnityStrDetail2Name);
+                UnityPrint(Unity.CurrentDetail2);
+            }
+            UnityPrint(UnityStrSpacer);
+        }
+#endif
+        if (msg[0] != ' ')
+        {
+            UNITY_OUTPUT_CHAR(' ');
+        }
+        UnityPrint(msg);
+    }
+
+    UNITY_FAIL_AND_BAIL;
+}
+
+/*-----------------------------------------------*/
+void UnityIgnore(const char* msg, const UNITY_LINE_TYPE line)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    UnityTestResultsBegin(Unity.TestFile, line);
+    UnityPrint(UnityStrIgnore);
+    if (msg != NULL)
+    {
+        UNITY_OUTPUT_CHAR(':');
+        UNITY_OUTPUT_CHAR(' ');
+        UnityPrint(msg);
+    }
+    UNITY_IGNORE_AND_BAIL;
+}
+
+/*-----------------------------------------------*/
+void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int FuncLineNum)
+{
+    Unity.CurrentTestName = FuncName;
+    Unity.CurrentTestLineNumber = (UNITY_LINE_TYPE)FuncLineNum;
+    Unity.NumberOfTests++;
+    UNITY_CLR_DETAILS();
+    if (TEST_PROTECT())
+    {
+        setUp();
+        Func();
+    }
+    if (TEST_PROTECT())
+    {
+        tearDown();
+    }
+    UnityConcludeTest();
+}
+
+/*-----------------------------------------------*/
+void UnityBegin(const char* filename)
+{
+    Unity.TestFile = filename;
+    Unity.CurrentTestName = NULL;
+    Unity.CurrentTestLineNumber = 0;
+    Unity.NumberOfTests = 0;
+    Unity.TestFailures = 0;
+    Unity.TestIgnores = 0;
+    Unity.CurrentTestFailed = 0;
+    Unity.CurrentTestIgnored = 0;
+    UNITY_EXEC_TIME_RESET();
+
+    UNITY_CLR_DETAILS();
+    UNITY_OUTPUT_START();
+}
+
+/*-----------------------------------------------*/
+int UnityEnd(void)
+{
+    UNITY_PRINT_EOL();
+    UnityPrint(UnityStrBreaker);
+    UNITY_PRINT_EOL();
+    UnityPrintNumber((UNITY_INT)(Unity.NumberOfTests));
+    UnityPrint(UnityStrResultsTests);
+    UnityPrintNumber((UNITY_INT)(Unity.TestFailures));
+    UnityPrint(UnityStrResultsFailures);
+    UnityPrintNumber((UNITY_INT)(Unity.TestIgnores));
+    UnityPrint(UnityStrResultsIgnored);
+    UNITY_PRINT_EOL();
+    if (Unity.TestFailures == 0U)
+    {
+        UnityPrint(UnityStrOk);
+    }
+    else
+    {
+        UnityPrint(UnityStrFail);
+#ifdef UNITY_DIFFERENTIATE_FINAL_FAIL
+        UNITY_OUTPUT_CHAR('E'); UNITY_OUTPUT_CHAR('D');
+#endif
+    }
+    UNITY_PRINT_EOL();
+    UNITY_FLUSH_CALL();
+    UNITY_OUTPUT_COMPLETE();
+    return (int)(Unity.TestFailures);
+}
+
+/*-----------------------------------------------
+ * Command Line Argument Support
+ *-----------------------------------------------*/
+#ifdef UNITY_USE_COMMAND_LINE_ARGS
+
+char* UnityOptionIncludeNamed = NULL;
+char* UnityOptionExcludeNamed = NULL;
+int UnityVerbosity            = 1;
+
+/*-----------------------------------------------*/
+int UnityParseOptions(int argc, char** argv)
+{
+    UnityOptionIncludeNamed = NULL;
+    UnityOptionExcludeNamed = NULL;
+    int i;
+
+    for (i = 1; i < argc; i++)
+    {
+        if (argv[i][0] == '-')
+        {
+            switch (argv[i][1])
+            {
+                case 'l': /* list tests */
+                    return -1;
+                case 'n': /* include tests with name including this string */
+                case 'f': /* an alias for -n */
+                    if (argv[i][2] == '=')
+                    {
+                        UnityOptionIncludeNamed = &argv[i][3];
+                    }
+                    else if (++i < argc)
+                    {
+                        UnityOptionIncludeNamed = argv[i];
+                    }
+                    else
+                    {
+                        UnityPrint("ERROR: No Test String to Include Matches For");
+                        UNITY_PRINT_EOL();
+                        return 1;
+                    }
+                    break;
+                case 'q': /* quiet */
+                    UnityVerbosity = 0;
+                    break;
+                case 'v': /* verbose */
+                    UnityVerbosity = 2;
+                    break;
+                case 'x': /* exclude tests with name including this string */
+                    if (argv[i][2] == '=')
+                    {
+                        UnityOptionExcludeNamed = &argv[i][3];
+                    }
+                    else if (++i < argc)
+                    {
+                        UnityOptionExcludeNamed = argv[i];
+                    }
+                    else
+                    {
+                        UnityPrint("ERROR: No Test String to Exclude Matches For");
+                        UNITY_PRINT_EOL();
+                        return 1;
+                    }
+                    break;
+                default:
+                    UnityPrint("ERROR: Unknown Option ");
+                    UNITY_OUTPUT_CHAR(argv[i][1]);
+                    UNITY_PRINT_EOL();
+                    return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+/*-----------------------------------------------*/
+int IsStringInBiggerString(const char* longstring, const char* shortstring)
+{
+    const char* lptr = longstring;
+    const char* sptr = shortstring;
+    const char* lnext = lptr;
+
+    if (*sptr == '*')
+    {
+        return 1;
+    }
+
+    while (*lptr)
+    {
+        lnext = lptr + 1;
+
+        /* If they current bytes match, go on to the next bytes */
+        while (*lptr && *sptr && (*lptr == *sptr))
+        {
+            lptr++;
+            sptr++;
+
+            /* We're done if we match the entire string or up to a wildcard */
+            if (*sptr == '*')
+                return 1;
+            if (*sptr == ',')
+                return 1;
+            if (*sptr == '"')
+                return 1;
+            if (*sptr == '\'')
+                return 1;
+            if (*sptr == ':')
+                return 2;
+            if (*sptr == 0)
+                return 1;
+        }
+
+        /* Otherwise we start in the long pointer 1 character further and try again */
+        lptr = lnext;
+        sptr = shortstring;
+    }
+
+    return 0;
+}
+
+/*-----------------------------------------------*/
+int UnityStringArgumentMatches(const char* str)
+{
+    int retval;
+    const char* ptr1;
+    const char* ptr2;
+    const char* ptrf;
+
+    /* Go through the options and get the substrings for matching one at a time */
+    ptr1 = str;
+    while (ptr1[0] != 0)
+    {
+        if ((ptr1[0] == '"') || (ptr1[0] == '\''))
+        {
+            ptr1++;
+        }
+
+        /* look for the start of the next partial */
+        ptr2 = ptr1;
+        ptrf = 0;
+        do
+        {
+            ptr2++;
+            if ((ptr2[0] == ':') && (ptr2[1] != 0) && (ptr2[0] != '\'') && (ptr2[0] != '"') && (ptr2[0] != ','))
+            {
+                ptrf = &ptr2[1];
+            }
+        } while ((ptr2[0] != 0) && (ptr2[0] != '\'') && (ptr2[0] != '"') && (ptr2[0] != ','));
+
+        while ((ptr2[0] != 0) && ((ptr2[0] == ':') || (ptr2[0] == '\'') || (ptr2[0] == '"') || (ptr2[0] == ',')))
+        {
+            ptr2++;
+        }
+
+        /* done if complete filename match */
+        retval = IsStringInBiggerString(Unity.TestFile, ptr1);
+        if (retval == 1)
+        {
+            return retval;
+        }
+
+        /* done if testname match after filename partial match */
+        if ((retval == 2) && (ptrf != 0))
+        {
+            if (IsStringInBiggerString(Unity.CurrentTestName, ptrf))
+            {
+                return 1;
+            }
+        }
+
+        /* done if complete testname match */
+        if (IsStringInBiggerString(Unity.CurrentTestName, ptr1) == 1)
+        {
+            return 1;
+        }
+
+        ptr1 = ptr2;
+    }
+
+    /* we couldn't find a match for any substrings */
+    return 0;
+}
+
+/*-----------------------------------------------*/
+int UnityTestMatches(void)
+{
+    /* Check if this test name matches the included test pattern */
+    int retval;
+    if (UnityOptionIncludeNamed)
+    {
+        retval = UnityStringArgumentMatches(UnityOptionIncludeNamed);
+    }
+    else
+    {
+        retval = 1;
+    }
+
+    /* Check if this test name matches the excluded test pattern */
+    if (UnityOptionExcludeNamed)
+    {
+        if (UnityStringArgumentMatches(UnityOptionExcludeNamed))
+        {
+            retval = 0;
+        }
+    }
+
+    return retval;
+}
+
+#endif /* UNITY_USE_COMMAND_LINE_ARGS */
+/*-----------------------------------------------*/

--- a/exercises/concept/production-line/vendor/unity.h
+++ b/exercises/concept/production-line/vendor/unity.h
@@ -1,0 +1,506 @@
+/* ==========================================
+    Unity Project - A Test Framework for C
+    Copyright (c) 2007-14 Mike Karlesky, Mark VanderVoord, Greg Williams
+    [Released under MIT License. Please refer to license.txt for details]
+========================================== */
+
+#ifndef UNITY_FRAMEWORK_H
+#define UNITY_FRAMEWORK_H
+#define UNITY
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define UNITY_INCLUDE_DOUBLE 1
+#define UNITY_DOUBLE_PRECISION 0.000001
+
+#include "unity_internals.h"
+
+/*-------------------------------------------------------
+ * Test Setup / Teardown
+ *-------------------------------------------------------*/
+
+/* These functions are intended to be called before and after each test. */
+void setUp(void);
+void tearDown(void);
+
+/* These functions are intended to be called at the beginning and end of an
+ * entire test suite.  suiteTearDown() is passed the number of tests that
+ * failed, and its return value becomes the exit code of main(). */
+void suiteSetUp(void);
+int suiteTearDown(int num_failures);
+
+/* If the compiler supports it, the following block provides stub
+ * implementations of the above functions as weak symbols.  Note that on
+ * some platforms (MinGW for example), weak function implementations need
+ * to be in the same translation unit they are called from.  This can be
+ * achieved by defining UNITY_INCLUDE_SETUP_STUBS before including unity.h. */
+#ifdef UNITY_INCLUDE_SETUP_STUBS
+  #ifdef UNITY_WEAK_ATTRIBUTE
+    UNITY_WEAK_ATTRIBUTE void setUp(void) { }
+    UNITY_WEAK_ATTRIBUTE void tearDown(void) { }
+    UNITY_WEAK_ATTRIBUTE void suiteSetUp(void) { }
+    UNITY_WEAK_ATTRIBUTE int suiteTearDown(int num_failures) { return num_failures; }
+  #elif defined(UNITY_WEAK_PRAGMA)
+    #pragma weak setUp
+    void setUp(void) { }
+    #pragma weak tearDown
+    void tearDown(void) { }
+    #pragma weak suiteSetUp
+    void suiteSetUp(void) { }
+    #pragma weak suiteTearDown
+    int suiteTearDown(int num_failures) { return num_failures; }
+  #endif
+#endif
+
+/*-------------------------------------------------------
+ * Configuration Options
+ *-------------------------------------------------------
+ * All options described below should be passed as a compiler flag to all files using Unity. If you must add #defines, place them BEFORE the #include above.
+
+ * Integers/longs/pointers
+ *     - Unity attempts to automatically discover your integer sizes
+ *       - define UNITY_EXCLUDE_STDINT_H to stop attempting to look in <stdint.h>
+ *       - define UNITY_EXCLUDE_LIMITS_H to stop attempting to look in <limits.h>
+ *     - If you cannot use the automatic methods above, you can force Unity by using these options:
+ *       - define UNITY_SUPPORT_64
+ *       - set UNITY_INT_WIDTH
+ *       - set UNITY_LONG_WIDTH
+ *       - set UNITY_POINTER_WIDTH
+
+ * Floats
+ *     - define UNITY_EXCLUDE_FLOAT to disallow floating point comparisons
+ *     - define UNITY_FLOAT_PRECISION to specify the precision to use when doing TEST_ASSERT_EQUAL_FLOAT
+ *     - define UNITY_FLOAT_TYPE to specify doubles instead of single precision floats
+ *     - define UNITY_INCLUDE_DOUBLE to allow double floating point comparisons
+ *     - define UNITY_EXCLUDE_DOUBLE to disallow double floating point comparisons (default)
+ *     - define UNITY_DOUBLE_PRECISION to specify the precision to use when doing TEST_ASSERT_EQUAL_DOUBLE
+ *     - define UNITY_DOUBLE_TYPE to specify something other than double
+ *     - define UNITY_EXCLUDE_FLOAT_PRINT to trim binary size, won't print floating point values in errors
+
+ * Output
+ *     - by default, Unity prints to standard out with putchar.  define UNITY_OUTPUT_CHAR(a) with a different function if desired
+ *     - define UNITY_DIFFERENTIATE_FINAL_FAIL to print FAILED (vs. FAIL) at test end summary - for automated search for failure
+
+ * Optimization
+ *     - by default, line numbers are stored in unsigned shorts.  Define UNITY_LINE_TYPE with a different type if your files are huge
+ *     - by default, test and failure counters are unsigned shorts.  Define UNITY_COUNTER_TYPE with a different type if you want to save space or have more than 65535 Tests.
+
+ * Test Cases
+ *     - define UNITY_SUPPORT_TEST_CASES to include the TEST_CASE macro, though really it's mostly about the runner generator script
+
+ * Parameterized Tests
+ *     - you'll want to create a define of TEST_CASE(...) which basically evaluates to nothing
+
+ * Tests with Arguments
+ *     - you'll want to define UNITY_USE_COMMAND_LINE_ARGS if you have the test runner passing arguments to Unity
+
+ *-------------------------------------------------------
+ * Basic Fail and Ignore
+ *-------------------------------------------------------*/
+
+#define TEST_FAIL_MESSAGE(message)                                                                 UNITY_TEST_FAIL(__LINE__, (message))
+#define TEST_FAIL()                                                                                UNITY_TEST_FAIL(__LINE__, NULL)
+#define TEST_IGNORE_MESSAGE(message)                                                               UNITY_TEST_IGNORE(__LINE__, (message))
+#define TEST_IGNORE()                                                                              UNITY_TEST_IGNORE(__LINE__, NULL)
+#define TEST_ONLY()
+
+/* It is not necessary for you to call PASS. A PASS condition is assumed if nothing fails.
+ * This method allows you to abort a test immediately with a PASS state, ignoring the remainder of the test. */
+#define TEST_PASS()                                                                                TEST_ABORT()
+
+/* This macro does nothing, but it is useful for build tools (like Ceedling) to make use of this to figure out
+ * which files should be linked to in order to perform a test. Use it like TEST_FILE("sandwiches.c") */
+#define TEST_FILE(a)
+
+/*-------------------------------------------------------
+ * Test Asserts (simple)
+ *-------------------------------------------------------*/
+
+/* Boolean */
+#define TEST_ASSERT(condition)                                                                     UNITY_TEST_ASSERT(       (condition), __LINE__, " Expression Evaluated To FALSE")
+#define TEST_ASSERT_TRUE(condition)                                                                UNITY_TEST_ASSERT(       (condition), __LINE__, " Expected TRUE Was FALSE")
+#define TEST_ASSERT_UNLESS(condition)                                                              UNITY_TEST_ASSERT(      !(condition), __LINE__, " Expression Evaluated To TRUE")
+#define TEST_ASSERT_FALSE(condition)                                                               UNITY_TEST_ASSERT(      !(condition), __LINE__, " Expected FALSE Was TRUE")
+#define TEST_ASSERT_NULL(pointer)                                                                  UNITY_TEST_ASSERT_NULL(    (pointer), __LINE__, " Expected NULL")
+#define TEST_ASSERT_NOT_NULL(pointer)                                                              UNITY_TEST_ASSERT_NOT_NULL((pointer), __LINE__, " Expected Non-NULL")
+
+/* Integers (of all sizes) */
+#define TEST_ASSERT_EQUAL_INT(expected, actual)                                                    UNITY_TEST_ASSERT_EQUAL_INT((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT8(expected, actual)                                                   UNITY_TEST_ASSERT_EQUAL_INT8((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT16(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_INT16((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT32(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_INT32((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT64(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_INT64((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL(expected, actual)                                                        UNITY_TEST_ASSERT_EQUAL_INT((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL(expected, actual)                                                    UNITY_TEST_ASSERT(((expected) !=  (actual)), __LINE__, " Expected Not-Equal")
+#define TEST_ASSERT_EQUAL_UINT(expected, actual)                                                   UNITY_TEST_ASSERT_EQUAL_UINT( (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT8(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_UINT8( (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT16(expected, actual)                                                 UNITY_TEST_ASSERT_EQUAL_UINT16( (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT32(expected, actual)                                                 UNITY_TEST_ASSERT_EQUAL_UINT32( (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT64(expected, actual)                                                 UNITY_TEST_ASSERT_EQUAL_UINT64( (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX(expected, actual)                                                    UNITY_TEST_ASSERT_EQUAL_HEX32((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX8(expected, actual)                                                   UNITY_TEST_ASSERT_EQUAL_HEX8( (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX16(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_HEX16((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX32(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_HEX32((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX64(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_HEX64((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_BITS(mask, expected, actual)                                                   UNITY_TEST_ASSERT_BITS((mask), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_BITS_HIGH(mask, actual)                                                        UNITY_TEST_ASSERT_BITS((mask), (UNITY_UINT32)(-1), (actual), __LINE__, NULL)
+#define TEST_ASSERT_BITS_LOW(mask, actual)                                                         UNITY_TEST_ASSERT_BITS((mask), (UNITY_UINT32)(0), (actual), __LINE__, NULL)
+#define TEST_ASSERT_BIT_HIGH(bit, actual)                                                          UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(-1), (actual), __LINE__, NULL)
+#define TEST_ASSERT_BIT_LOW(bit, actual)                                                           UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(0), (actual), __LINE__, NULL)
+
+/* Integer Greater Than/ Less Than (of all sizes) */
+#define TEST_ASSERT_GREATER_THAN(threshold, actual)                                                UNITY_TEST_ASSERT_GREATER_THAN_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_INT(threshold, actual)                                            UNITY_TEST_ASSERT_GREATER_THAN_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_INT8(threshold, actual)                                           UNITY_TEST_ASSERT_GREATER_THAN_INT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_INT16(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_INT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_INT32(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_INT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_INT64(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_INT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_UINT(threshold, actual)                                           UNITY_TEST_ASSERT_GREATER_THAN_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_UINT8(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_UINT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_UINT16(threshold, actual)                                         UNITY_TEST_ASSERT_GREATER_THAN_UINT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_UINT32(threshold, actual)                                         UNITY_TEST_ASSERT_GREATER_THAN_UINT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_UINT64(threshold, actual)                                         UNITY_TEST_ASSERT_GREATER_THAN_UINT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_HEX8(threshold, actual)                                           UNITY_TEST_ASSERT_GREATER_THAN_HEX8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_HEX16(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_HEX16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_HEX32(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_HEX32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_HEX64(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_HEX64((threshold), (actual), __LINE__, NULL)
+
+#define TEST_ASSERT_LESS_THAN(threshold, actual)                                                   UNITY_TEST_ASSERT_SMALLER_THAN_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_INT(threshold, actual)                                               UNITY_TEST_ASSERT_SMALLER_THAN_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_INT8(threshold, actual)                                              UNITY_TEST_ASSERT_SMALLER_THAN_INT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_INT16(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_INT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_INT32(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_INT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_INT64(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_INT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_UINT(threshold, actual)                                              UNITY_TEST_ASSERT_SMALLER_THAN_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_UINT8(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_UINT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_UINT16(threshold, actual)                                            UNITY_TEST_ASSERT_SMALLER_THAN_UINT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_UINT32(threshold, actual)                                            UNITY_TEST_ASSERT_SMALLER_THAN_UINT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_UINT64(threshold, actual)                                            UNITY_TEST_ASSERT_SMALLER_THAN_UINT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_HEX8(threshold, actual)                                              UNITY_TEST_ASSERT_SMALLER_THAN_HEX8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_HEX16(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_HEX16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_HEX32(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_HEX32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_HEX64(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_HEX64((threshold), (actual), __LINE__, NULL)
+
+#define TEST_ASSERT_GREATER_OR_EQUAL(threshold, actual)                                            UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT(threshold, actual)                                        UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT8(threshold, actual)                                       UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT16(threshold, actual)                                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT32(threshold, actual)                                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT64(threshold, actual)                                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT(threshold, actual)                                       UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT8(threshold, actual)                                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT16(threshold, actual)                                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT32(threshold, actual)                                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT64(threshold, actual)                                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX8(threshold, actual)                                       UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX16(threshold, actual)                                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX32(threshold, actual)                                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX64(threshold, actual)                                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX64((threshold), (actual), __LINE__, NULL)
+
+#define TEST_ASSERT_LESS_OR_EQUAL(threshold, actual)                                               UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_INT(threshold, actual)                                           UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_INT8(threshold, actual)                                          UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_INT16(threshold, actual)                                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_INT32(threshold, actual)                                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_INT64(threshold, actual)                                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT(threshold, actual)                                          UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT8(threshold, actual)                                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT16(threshold, actual)                                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT32(threshold, actual)                                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT64(threshold, actual)                                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX8(threshold, actual)                                          UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX16(threshold, actual)                                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX32(threshold, actual)                                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX64(threshold, actual)                                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX64((threshold), (actual), __LINE__, NULL)
+
+/* Integer Ranges (of all sizes) */
+#define TEST_ASSERT_INT_WITHIN(delta, expected, actual)                                            UNITY_TEST_ASSERT_INT_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_INT8_WITHIN(delta, expected, actual)                                           UNITY_TEST_ASSERT_INT8_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_INT16_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_INT16_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_INT32_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_INT32_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_INT64_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_INT64_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_UINT_WITHIN(delta, expected, actual)                                           UNITY_TEST_ASSERT_UINT_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_UINT8_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_UINT8_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_UINT16_WITHIN(delta, expected, actual)                                         UNITY_TEST_ASSERT_UINT16_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_UINT32_WITHIN(delta, expected, actual)                                         UNITY_TEST_ASSERT_UINT32_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_UINT64_WITHIN(delta, expected, actual)                                         UNITY_TEST_ASSERT_UINT64_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_HEX_WITHIN(delta, expected, actual)                                            UNITY_TEST_ASSERT_HEX32_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_HEX8_WITHIN(delta, expected, actual)                                           UNITY_TEST_ASSERT_HEX8_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_HEX16_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_HEX16_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_HEX32_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_HEX32_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_HEX64_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_HEX64_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+
+/* Structs and Strings */
+#define TEST_ASSERT_EQUAL_PTR(expected, actual)                                                    UNITY_TEST_ASSERT_EQUAL_PTR((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_STRING(expected, actual)                                                 UNITY_TEST_ASSERT_EQUAL_STRING((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len)                                        UNITY_TEST_ASSERT_EQUAL_STRING_LEN((expected), (actual), (len), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_MEMORY(expected, actual, len)                                            UNITY_TEST_ASSERT_EQUAL_MEMORY((expected), (actual), (len), __LINE__, NULL)
+
+/* Arrays */
+#define TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, num_elements)                                UNITY_TEST_ASSERT_EQUAL_INT_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT8_ARRAY(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EQUAL_INT8_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT16_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_INT16_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT32_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_INT32_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT64_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_INT64_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT_ARRAY(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EQUAL_UINT_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_UINT8_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT16_ARRAY(expected, actual, num_elements)                             UNITY_TEST_ASSERT_EQUAL_UINT16_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT32_ARRAY(expected, actual, num_elements)                             UNITY_TEST_ASSERT_EQUAL_UINT32_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT64_ARRAY(expected, actual, num_elements)                             UNITY_TEST_ASSERT_EQUAL_UINT64_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX_ARRAY(expected, actual, num_elements)                                UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EQUAL_HEX8_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX16_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_HEX16_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX32_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX64_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_HEX64_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_PTR_ARRAY(expected, actual, num_elements)                                UNITY_TEST_ASSERT_EQUAL_PTR_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_STRING_ARRAY(expected, actual, num_elements)                             UNITY_TEST_ASSERT_EQUAL_STRING_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_MEMORY_ARRAY(expected, actual, len, num_elements)                        UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY((expected), (actual), (len), (num_elements), __LINE__, NULL)
+
+/* Arrays Compared To Single Value */
+#define TEST_ASSERT_EACH_EQUAL_INT(expected, actual, num_elements)                                 UNITY_TEST_ASSERT_EACH_EQUAL_INT((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_INT8(expected, actual, num_elements)                                UNITY_TEST_ASSERT_EACH_EQUAL_INT8((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_INT16(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_INT16((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_INT32(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_INT32((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_INT64(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_INT64((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_UINT(expected, actual, num_elements)                                UNITY_TEST_ASSERT_EACH_EQUAL_UINT((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_UINT8(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_UINT8((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_UINT16(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EACH_EQUAL_UINT16((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_UINT32(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EACH_EQUAL_UINT32((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_UINT64(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EACH_EQUAL_UINT64((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_HEX(expected, actual, num_elements)                                 UNITY_TEST_ASSERT_EACH_EQUAL_HEX32((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_HEX8(expected, actual, num_elements)                                UNITY_TEST_ASSERT_EACH_EQUAL_HEX8((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_HEX16(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_HEX16((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_HEX32(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_HEX32((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_HEX64(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_HEX64((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_PTR(expected, actual, num_elements)                                 UNITY_TEST_ASSERT_EACH_EQUAL_PTR((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_STRING(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EACH_EQUAL_STRING((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_MEMORY(expected, actual, len, num_elements)                         UNITY_TEST_ASSERT_EACH_EQUAL_MEMORY((expected), (actual), (len), (num_elements), __LINE__, NULL)
+
+/* Floating Point (If Enabled) */
+#define TEST_ASSERT_FLOAT_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_FLOAT_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_FLOAT(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_FLOAT((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_FLOAT_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_FLOAT(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_FLOAT((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_INF(actual)                                                           UNITY_TEST_ASSERT_FLOAT_IS_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_NEG_INF(actual)                                                       UNITY_TEST_ASSERT_FLOAT_IS_NEG_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_NAN(actual)                                                           UNITY_TEST_ASSERT_FLOAT_IS_NAN((actual), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_DETERMINATE(actual)                                                   UNITY_TEST_ASSERT_FLOAT_IS_DETERMINATE((actual), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_NOT_INF(actual)                                                       UNITY_TEST_ASSERT_FLOAT_IS_NOT_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_NOT_NEG_INF(actual)                                                   UNITY_TEST_ASSERT_FLOAT_IS_NOT_NEG_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_NOT_NAN(actual)                                                       UNITY_TEST_ASSERT_FLOAT_IS_NOT_NAN((actual), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE(actual)                                               UNITY_TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE((actual), __LINE__, NULL)
+
+/* Double (If Enabled) */
+#define TEST_ASSERT_DOUBLE_WITHIN(delta, expected, actual)                                         UNITY_TEST_ASSERT_DOUBLE_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_DOUBLE(expected, actual)                                                 UNITY_TEST_ASSERT_EQUAL_DOUBLE((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_DOUBLE_ARRAY(expected, actual, num_elements)                             UNITY_TEST_ASSERT_EQUAL_DOUBLE_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_DOUBLE(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EACH_EQUAL_DOUBLE((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_INF(actual)                                                          UNITY_TEST_ASSERT_DOUBLE_IS_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_NEG_INF(actual)                                                      UNITY_TEST_ASSERT_DOUBLE_IS_NEG_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_NAN(actual)                                                          UNITY_TEST_ASSERT_DOUBLE_IS_NAN((actual), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_DETERMINATE(actual)                                                  UNITY_TEST_ASSERT_DOUBLE_IS_DETERMINATE((actual), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_NOT_INF(actual)                                                      UNITY_TEST_ASSERT_DOUBLE_IS_NOT_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF(actual)                                                  UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_NOT_NAN(actual)                                                      UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN((actual), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE(actual)                                              UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE((actual), __LINE__, NULL)
+
+/*-------------------------------------------------------
+ * Test Asserts (with additional messages)
+ *-------------------------------------------------------*/
+
+/* Boolean */
+#define TEST_ASSERT_MESSAGE(condition, message)                                                    UNITY_TEST_ASSERT(       (condition), __LINE__, (message))
+#define TEST_ASSERT_TRUE_MESSAGE(condition, message)                                               UNITY_TEST_ASSERT(       (condition), __LINE__, (message))
+#define TEST_ASSERT_UNLESS_MESSAGE(condition, message)                                             UNITY_TEST_ASSERT(      !(condition), __LINE__, (message))
+#define TEST_ASSERT_FALSE_MESSAGE(condition, message)                                              UNITY_TEST_ASSERT(      !(condition), __LINE__, (message))
+#define TEST_ASSERT_NULL_MESSAGE(pointer, message)                                                 UNITY_TEST_ASSERT_NULL(    (pointer), __LINE__, (message))
+#define TEST_ASSERT_NOT_NULL_MESSAGE(pointer, message)                                             UNITY_TEST_ASSERT_NOT_NULL((pointer), __LINE__, (message))
+
+/* Integers (of all sizes) */
+#define TEST_ASSERT_EQUAL_INT_MESSAGE(expected, actual, message)                                   UNITY_TEST_ASSERT_EQUAL_INT((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT8_MESSAGE(expected, actual, message)                                  UNITY_TEST_ASSERT_EQUAL_INT8((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT16_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_INT16((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT32_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_INT32((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT64_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_INT64((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_MESSAGE(expected, actual, message)                                       UNITY_TEST_ASSERT_EQUAL_INT((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_MESSAGE(expected, actual, message)                                   UNITY_TEST_ASSERT(((expected) !=  (actual)), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT_MESSAGE(expected, actual, message)                                  UNITY_TEST_ASSERT_EQUAL_UINT( (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT8_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_UINT8( (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT16_MESSAGE(expected, actual, message)                                UNITY_TEST_ASSERT_EQUAL_UINT16( (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT32_MESSAGE(expected, actual, message)                                UNITY_TEST_ASSERT_EQUAL_UINT32( (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT64_MESSAGE(expected, actual, message)                                UNITY_TEST_ASSERT_EQUAL_UINT64( (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX_MESSAGE(expected, actual, message)                                   UNITY_TEST_ASSERT_EQUAL_HEX32((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX8_MESSAGE(expected, actual, message)                                  UNITY_TEST_ASSERT_EQUAL_HEX8( (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX16_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_HEX16((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX32_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_HEX32((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX64_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_HEX64((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_BITS_MESSAGE(mask, expected, actual, message)                                  UNITY_TEST_ASSERT_BITS((mask), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_BITS_HIGH_MESSAGE(mask, actual, message)                                       UNITY_TEST_ASSERT_BITS((mask), (UNITY_UINT32)(-1), (actual), __LINE__, (message))
+#define TEST_ASSERT_BITS_LOW_MESSAGE(mask, actual, message)                                        UNITY_TEST_ASSERT_BITS((mask), (UNITY_UINT32)(0), (actual), __LINE__, (message))
+#define TEST_ASSERT_BIT_HIGH_MESSAGE(bit, actual, message)                                         UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(-1), (actual), __LINE__, (message))
+#define TEST_ASSERT_BIT_LOW_MESSAGE(bit, actual, message)                                          UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(0), (actual), __LINE__, (message))
+
+/* Integer Greater Than/ Less Than (of all sizes) */
+#define TEST_ASSERT_GREATER_THAN_MESSAGE(threshold, actual, message)                               UNITY_TEST_ASSERT_GREATER_THAN_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_INT_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_GREATER_THAN_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_INT8_MESSAGE(threshold, actual, message)                          UNITY_TEST_ASSERT_GREATER_THAN_INT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_INT16_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_INT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_INT32_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_INT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_INT64_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_INT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_UINT_MESSAGE(threshold, actual, message)                          UNITY_TEST_ASSERT_GREATER_THAN_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_UINT8_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_UINT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_UINT16_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_GREATER_THAN_UINT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_UINT32_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_GREATER_THAN_UINT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_UINT64_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_GREATER_THAN_UINT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_HEX8_MESSAGE(threshold, actual, message)                          UNITY_TEST_ASSERT_GREATER_THAN_HEX8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_HEX16_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_HEX16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_HEX32_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_HEX32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_HEX64_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_HEX64((threshold), (actual), __LINE__, (message))
+
+#define TEST_ASSERT_LESS_THAN_MESSAGE(threshold, actual, message)                                  UNITY_TEST_ASSERT_SMALLER_THAN_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_INT_MESSAGE(threshold, actual, message)                              UNITY_TEST_ASSERT_SMALLER_THAN_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_INT8_MESSAGE(threshold, actual, message)                             UNITY_TEST_ASSERT_SMALLER_THAN_INT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_INT16_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_INT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_INT32_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_INT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_INT64_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_INT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_UINT_MESSAGE(threshold, actual, message)                             UNITY_TEST_ASSERT_SMALLER_THAN_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_UINT8_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_UINT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_UINT16_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_SMALLER_THAN_UINT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_UINT32_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_SMALLER_THAN_UINT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_UINT64_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_SMALLER_THAN_UINT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_HEX8_MESSAGE(threshold, actual, message)                             UNITY_TEST_ASSERT_SMALLER_THAN_HEX8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_HEX16_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_HEX16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_HEX32_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_HEX32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_HEX64_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_HEX64((threshold), (actual), __LINE__, (message))
+
+#define TEST_ASSERT_GREATER_OR_EQUAL_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT_MESSAGE(threshold, actual, message)                       UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT8_MESSAGE(threshold, actual, message)                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT16_MESSAGE(threshold, actual, message)                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT32_MESSAGE(threshold, actual, message)                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT64_MESSAGE(threshold, actual, message)                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT_MESSAGE(threshold, actual, message)                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT8_MESSAGE(threshold, actual, message)                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT16_MESSAGE(threshold, actual, message)                    UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT32_MESSAGE(threshold, actual, message)                    UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT64_MESSAGE(threshold, actual, message)                    UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX8_MESSAGE(threshold, actual, message)                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX16_MESSAGE(threshold, actual, message)                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX32_MESSAGE(threshold, actual, message)                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX64_MESSAGE(threshold, actual, message)                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX64((threshold), (actual), __LINE__, (message))
+
+#define TEST_ASSERT_LESS_OR_EQUAL_MESSAGE(threshold, actual, message)                              UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_INT_MESSAGE(threshold, actual, message)                          UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_INT8_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_INT16_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_INT32_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_INT64_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT8_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT16_MESSAGE(threshold, actual, message)                       UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT32_MESSAGE(threshold, actual, message)                       UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT64_MESSAGE(threshold, actual, message)                       UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX8_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX16_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX32_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX64_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX64((threshold), (actual), __LINE__, (message))
+
+/* Integer Ranges (of all sizes) */
+#define TEST_ASSERT_INT_WITHIN_MESSAGE(delta, expected, actual, message)                           UNITY_TEST_ASSERT_INT_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_INT8_WITHIN_MESSAGE(delta, expected, actual, message)                          UNITY_TEST_ASSERT_INT8_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_INT16_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_INT16_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_INT32_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_INT32_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_INT64_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_INT64_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_UINT_WITHIN_MESSAGE(delta, expected, actual, message)                          UNITY_TEST_ASSERT_UINT_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_UINT8_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_UINT8_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_UINT16_WITHIN_MESSAGE(delta, expected, actual, message)                        UNITY_TEST_ASSERT_UINT16_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_UINT32_WITHIN_MESSAGE(delta, expected, actual, message)                        UNITY_TEST_ASSERT_UINT32_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_UINT64_WITHIN_MESSAGE(delta, expected, actual, message)                        UNITY_TEST_ASSERT_UINT64_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_HEX_WITHIN_MESSAGE(delta, expected, actual, message)                           UNITY_TEST_ASSERT_HEX32_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_HEX8_WITHIN_MESSAGE(delta, expected, actual, message)                          UNITY_TEST_ASSERT_HEX8_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_HEX16_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_HEX16_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_HEX32_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_HEX32_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_HEX64_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_HEX64_WITHIN((delta), (expected), (actual), __LINE__, (message))
+
+/* Structs and Strings */
+#define TEST_ASSERT_EQUAL_PTR_MESSAGE(expected, actual, message)                                   UNITY_TEST_ASSERT_EQUAL_PTR((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, actual, message)                                UNITY_TEST_ASSERT_EQUAL_STRING((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_STRING_LEN_MESSAGE(expected, actual, len, message)                       UNITY_TEST_ASSERT_EQUAL_STRING_LEN((expected), (actual), (len), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_MEMORY_MESSAGE(expected, actual, len, message)                           UNITY_TEST_ASSERT_EQUAL_MEMORY((expected), (actual), (len), __LINE__, (message))
+
+/* Arrays */
+#define TEST_ASSERT_EQUAL_INT_ARRAY_MESSAGE(expected, actual, num_elements, message)               UNITY_TEST_ASSERT_EQUAL_INT_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT8_ARRAY_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EQUAL_INT8_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT16_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_INT16_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT32_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_INT32_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT64_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_INT64_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT_ARRAY_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EQUAL_UINT_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_UINT8_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT16_ARRAY_MESSAGE(expected, actual, num_elements, message)            UNITY_TEST_ASSERT_EQUAL_UINT16_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT32_ARRAY_MESSAGE(expected, actual, num_elements, message)            UNITY_TEST_ASSERT_EQUAL_UINT32_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT64_ARRAY_MESSAGE(expected, actual, num_elements, message)            UNITY_TEST_ASSERT_EQUAL_UINT64_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX_ARRAY_MESSAGE(expected, actual, num_elements, message)               UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EQUAL_HEX8_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX16_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_HEX16_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX32_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX64_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_HEX64_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_PTR_ARRAY_MESSAGE(expected, actual, num_elements, message)               UNITY_TEST_ASSERT_EQUAL_PTR_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_STRING_ARRAY_MESSAGE(expected, actual, num_elements, message)            UNITY_TEST_ASSERT_EQUAL_STRING_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_MEMORY_ARRAY_MESSAGE(expected, actual, len, num_elements, message)       UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY((expected), (actual), (len), (num_elements), __LINE__, (message))
+
+/* Arrays Compared To Single Value*/
+#define TEST_ASSERT_EACH_EQUAL_INT_MESSAGE(expected, actual, num_elements, message)                UNITY_TEST_ASSERT_EACH_EQUAL_INT((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_INT8_MESSAGE(expected, actual, num_elements, message)               UNITY_TEST_ASSERT_EACH_EQUAL_INT8((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_INT16_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_INT16((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_INT32_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_INT32((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_INT64_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_INT64((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_UINT_MESSAGE(expected, actual, num_elements, message)               UNITY_TEST_ASSERT_EACH_EQUAL_UINT((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_UINT8_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_UINT8((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_UINT16_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EACH_EQUAL_UINT16((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_UINT32_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EACH_EQUAL_UINT32((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_UINT64_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EACH_EQUAL_UINT64((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_HEX_MESSAGE(expected, actual, num_elements, message)                UNITY_TEST_ASSERT_EACH_EQUAL_HEX32((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_HEX8_MESSAGE(expected, actual, num_elements, message)               UNITY_TEST_ASSERT_EACH_EQUAL_HEX8((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_HEX16_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_HEX16((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_HEX32_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_HEX32((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_HEX64_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_HEX64((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_PTR_MESSAGE(expected, actual, num_elements, message)                UNITY_TEST_ASSERT_EACH_EQUAL_PTR((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_STRING_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EACH_EQUAL_STRING((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_MEMORY_MESSAGE(expected, actual, len, num_elements, message)        UNITY_TEST_ASSERT_EACH_EQUAL_MEMORY((expected), (actual), (len), (num_elements), __LINE__, (message))
+
+/* Floating Point (If Enabled) */
+#define TEST_ASSERT_FLOAT_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_FLOAT_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_FLOAT((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_FLOAT_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_FLOAT_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_FLOAT_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_FLOAT((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_INF_MESSAGE(actual, message)                                          UNITY_TEST_ASSERT_FLOAT_IS_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_NEG_INF_MESSAGE(actual, message)                                      UNITY_TEST_ASSERT_FLOAT_IS_NEG_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_NAN_MESSAGE(actual, message)                                          UNITY_TEST_ASSERT_FLOAT_IS_NAN((actual), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_DETERMINATE_MESSAGE(actual, message)                                  UNITY_TEST_ASSERT_FLOAT_IS_DETERMINATE((actual), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_NOT_INF_MESSAGE(actual, message)                                      UNITY_TEST_ASSERT_FLOAT_IS_NOT_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_NOT_NEG_INF_MESSAGE(actual, message)                                  UNITY_TEST_ASSERT_FLOAT_IS_NOT_NEG_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_NOT_NAN_MESSAGE(actual, message)                                      UNITY_TEST_ASSERT_FLOAT_IS_NOT_NAN((actual), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE_MESSAGE(actual, message)                              UNITY_TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE((actual), __LINE__, (message))
+
+/* Double (If Enabled) */
+#define TEST_ASSERT_DOUBLE_WITHIN_MESSAGE(delta, expected, actual, message)                        UNITY_TEST_ASSERT_DOUBLE_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected, actual, message)                                UNITY_TEST_ASSERT_EQUAL_DOUBLE((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_DOUBLE_ARRAY_MESSAGE(expected, actual, num_elements, message)            UNITY_TEST_ASSERT_EQUAL_DOUBLE_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_DOUBLE_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EACH_EQUAL_DOUBLE((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_INF_MESSAGE(actual, message)                                         UNITY_TEST_ASSERT_DOUBLE_IS_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_NEG_INF_MESSAGE(actual, message)                                     UNITY_TEST_ASSERT_DOUBLE_IS_NEG_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_NAN_MESSAGE(actual, message)                                         UNITY_TEST_ASSERT_DOUBLE_IS_NAN((actual), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_DETERMINATE_MESSAGE(actual, message)                                 UNITY_TEST_ASSERT_DOUBLE_IS_DETERMINATE((actual), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_NOT_INF_MESSAGE(actual, message)                                     UNITY_TEST_ASSERT_DOUBLE_IS_NOT_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF_MESSAGE(actual, message)                                 UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_NOT_NAN_MESSAGE(actual, message)                                     UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN((actual), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE_MESSAGE(actual, message)                             UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE((actual), __LINE__, (message))
+
+/* end of UNITY_FRAMEWORK_H */
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/exercises/concept/production-line/vendor/unity_internals.h
+++ b/exercises/concept/production-line/vendor/unity_internals.h
@@ -1,0 +1,939 @@
+/* ==========================================
+    Unity Project - A Test Framework for C
+    Copyright (c) 2007-14 Mike Karlesky, Mark VanderVoord, Greg Williams
+    [Released under MIT License. Please refer to license.txt for details]
+========================================== */
+
+#ifndef UNITY_INTERNALS_H
+#define UNITY_INTERNALS_H
+
+#ifdef UNITY_INCLUDE_CONFIG_H
+#include "unity_config.h"
+#endif
+
+#ifndef UNITY_EXCLUDE_SETJMP_H
+#include <setjmp.h>
+#endif
+
+#ifndef UNITY_EXCLUDE_MATH_H
+#include <math.h>
+#endif
+
+#ifndef UNITY_EXCLUDE_STDDEF_H
+#include <stddef.h>
+#endif
+
+#ifdef UNITY_INCLUDE_PRINT_FORMATTED
+#include <stdarg.h>
+#endif
+
+/* Unity Attempts to Auto-Detect Integer Types
+ * Attempt 1: UINT_MAX, ULONG_MAX in <limits.h>, or default to 32 bits
+ * Attempt 2: UINTPTR_MAX in <stdint.h>, or default to same size as long
+ * The user may override any of these derived constants:
+ * UNITY_INT_WIDTH, UNITY_LONG_WIDTH, UNITY_POINTER_WIDTH */
+#ifndef UNITY_EXCLUDE_STDINT_H
+#include <stdint.h>
+#endif
+
+#ifndef UNITY_EXCLUDE_LIMITS_H
+#include <limits.h>
+#endif
+
+#ifndef UNITY_EXCLUDE_TIME_H
+#include <time.h>
+#endif
+
+/*-------------------------------------------------------
+ * Guess Widths If Not Specified
+ *-------------------------------------------------------*/
+
+/* Determine the size of an int, if not already specified.
+ * We cannot use sizeof(int), because it is not yet defined
+ * at this stage in the translation of the C program.
+ * Therefore, infer it from UINT_MAX if possible. */
+#ifndef UNITY_INT_WIDTH
+  #ifdef UINT_MAX
+    #if (UINT_MAX == 0xFFFF)
+      #define UNITY_INT_WIDTH (16)
+    #elif (UINT_MAX == 0xFFFFFFFF)
+      #define UNITY_INT_WIDTH (32)
+    #elif (UINT_MAX == 0xFFFFFFFFFFFFFFFF)
+      #define UNITY_INT_WIDTH (64)
+    #endif
+  #else /* Set to default */
+    #define UNITY_INT_WIDTH (32)
+  #endif /* UINT_MAX */
+#endif
+
+/* Determine the size of a long, if not already specified. */
+#ifndef UNITY_LONG_WIDTH
+  #ifdef ULONG_MAX
+    #if (ULONG_MAX == 0xFFFF)
+      #define UNITY_LONG_WIDTH (16)
+    #elif (ULONG_MAX == 0xFFFFFFFF)
+      #define UNITY_LONG_WIDTH (32)
+    #elif (ULONG_MAX == 0xFFFFFFFFFFFFFFFF)
+      #define UNITY_LONG_WIDTH (64)
+    #endif
+  #else /* Set to default */
+    #define UNITY_LONG_WIDTH (32)
+  #endif /* ULONG_MAX */
+#endif
+
+/* Determine the size of a pointer, if not already specified. */
+#ifndef UNITY_POINTER_WIDTH
+  #ifdef UINTPTR_MAX
+    #if (UINTPTR_MAX <= 0xFFFF)
+      #define UNITY_POINTER_WIDTH (16)
+    #elif (UINTPTR_MAX <= 0xFFFFFFFF)
+      #define UNITY_POINTER_WIDTH (32)
+    #elif (UINTPTR_MAX <= 0xFFFFFFFFFFFFFFFF)
+      #define UNITY_POINTER_WIDTH (64)
+    #endif
+  #else /* Set to default */
+    #define UNITY_POINTER_WIDTH UNITY_LONG_WIDTH
+  #endif /* UINTPTR_MAX */
+#endif
+
+/*-------------------------------------------------------
+ * Int Support (Define types based on detected sizes)
+ *-------------------------------------------------------*/
+
+#if (UNITY_INT_WIDTH == 32)
+    typedef unsigned char   UNITY_UINT8;
+    typedef unsigned short  UNITY_UINT16;
+    typedef unsigned int    UNITY_UINT32;
+    typedef signed char     UNITY_INT8;
+    typedef signed short    UNITY_INT16;
+    typedef signed int      UNITY_INT32;
+#elif (UNITY_INT_WIDTH == 16)
+    typedef unsigned char   UNITY_UINT8;
+    typedef unsigned int    UNITY_UINT16;
+    typedef unsigned long   UNITY_UINT32;
+    typedef signed char     UNITY_INT8;
+    typedef signed int      UNITY_INT16;
+    typedef signed long     UNITY_INT32;
+#else
+    #error Invalid UNITY_INT_WIDTH specified! (16 or 32 are supported)
+#endif
+
+/*-------------------------------------------------------
+ * 64-bit Support
+ *-------------------------------------------------------*/
+
+#ifndef UNITY_SUPPORT_64
+  #if UNITY_LONG_WIDTH == 64 || UNITY_POINTER_WIDTH == 64
+    #define UNITY_SUPPORT_64
+  #endif
+#endif
+
+#ifndef UNITY_SUPPORT_64
+    /* No 64-bit Support */
+    typedef UNITY_UINT32 UNITY_UINT;
+    typedef UNITY_INT32 UNITY_INT;
+#else
+
+  /* 64-bit Support */
+  #if (UNITY_LONG_WIDTH == 32)
+    typedef unsigned long long UNITY_UINT64;
+    typedef signed long long   UNITY_INT64;
+  #elif (UNITY_LONG_WIDTH == 64)
+    typedef unsigned long      UNITY_UINT64;
+    typedef signed long        UNITY_INT64;
+  #else
+    #error Invalid UNITY_LONG_WIDTH specified! (32 or 64 are supported)
+  #endif
+    typedef UNITY_UINT64 UNITY_UINT;
+    typedef UNITY_INT64 UNITY_INT;
+
+#endif
+
+/*-------------------------------------------------------
+ * Pointer Support
+ *-------------------------------------------------------*/
+
+#if (UNITY_POINTER_WIDTH == 32)
+#define UNITY_PTR_TO_INT UNITY_INT32
+#define UNITY_DISPLAY_STYLE_POINTER UNITY_DISPLAY_STYLE_HEX32
+#elif (UNITY_POINTER_WIDTH == 64)
+#define UNITY_PTR_TO_INT UNITY_INT64
+#define UNITY_DISPLAY_STYLE_POINTER UNITY_DISPLAY_STYLE_HEX64
+#elif (UNITY_POINTER_WIDTH == 16)
+#define UNITY_PTR_TO_INT UNITY_INT16
+#define UNITY_DISPLAY_STYLE_POINTER UNITY_DISPLAY_STYLE_HEX16
+#else
+    #error Invalid UNITY_POINTER_WIDTH specified! (16, 32 or 64 are supported)
+#endif
+
+#ifndef UNITY_PTR_ATTRIBUTE
+#define UNITY_PTR_ATTRIBUTE
+#endif
+
+#ifndef UNITY_INTERNAL_PTR
+#define UNITY_INTERNAL_PTR UNITY_PTR_ATTRIBUTE const void*
+#endif
+
+/*-------------------------------------------------------
+ * Float Support
+ *-------------------------------------------------------*/
+
+#ifdef UNITY_EXCLUDE_FLOAT
+
+/* No Floating Point Support */
+#ifndef UNITY_EXCLUDE_DOUBLE
+#define UNITY_EXCLUDE_DOUBLE /* Remove double when excluding float support */
+#endif
+#ifndef UNITY_EXCLUDE_FLOAT_PRINT
+#define UNITY_EXCLUDE_FLOAT_PRINT
+#endif
+
+#else
+
+/* Floating Point Support */
+#ifndef UNITY_FLOAT_PRECISION
+#define UNITY_FLOAT_PRECISION (0.00001f)
+#endif
+#ifndef UNITY_FLOAT_TYPE
+#define UNITY_FLOAT_TYPE float
+#endif
+typedef UNITY_FLOAT_TYPE UNITY_FLOAT;
+
+/* isinf & isnan macros should be provided by math.h */
+#ifndef isinf
+/* The value of Inf - Inf is NaN */
+#define isinf(n) (isnan((n) - (n)) && !isnan(n))
+#endif
+
+#ifndef isnan
+/* NaN is the only floating point value that does NOT equal itself.
+ * Therefore if n != n, then it is NaN. */
+#define isnan(n) ((n != n) ? 1 : 0)
+#endif
+
+#endif
+
+/*-------------------------------------------------------
+ * Double Float Support
+ *-------------------------------------------------------*/
+
+/* unlike float, we DON'T include by default */
+#if defined(UNITY_EXCLUDE_DOUBLE) || !defined(UNITY_INCLUDE_DOUBLE)
+
+  /* No Floating Point Support */
+  #ifndef UNITY_EXCLUDE_DOUBLE
+  #define UNITY_EXCLUDE_DOUBLE
+  #else
+    #undef UNITY_INCLUDE_DOUBLE
+  #endif
+
+  #ifndef UNITY_EXCLUDE_FLOAT
+    #ifndef UNITY_DOUBLE_TYPE
+    #define UNITY_DOUBLE_TYPE double
+    #endif
+  typedef UNITY_FLOAT UNITY_DOUBLE;
+  /* For parameter in UnityPrintFloat(UNITY_DOUBLE), which aliases to double or float */
+  #endif
+
+#else
+
+  /* Double Floating Point Support */
+  #ifndef UNITY_DOUBLE_PRECISION
+  #define UNITY_DOUBLE_PRECISION (1e-12)
+  #endif
+
+  #ifndef UNITY_DOUBLE_TYPE
+  #define UNITY_DOUBLE_TYPE double
+  #endif
+  typedef UNITY_DOUBLE_TYPE UNITY_DOUBLE;
+
+#endif
+
+/*-------------------------------------------------------
+ * Output Method: stdout (DEFAULT)
+ *-------------------------------------------------------*/
+#ifndef UNITY_OUTPUT_CHAR
+  /* Default to using putchar, which is defined in stdio.h */
+  #include <stdio.h>
+  #define UNITY_OUTPUT_CHAR(a) (void)putchar(a)
+#else
+  /* If defined as something else, make sure we declare it here so it's ready for use */
+  #ifdef UNITY_OUTPUT_CHAR_HEADER_DECLARATION
+    extern void UNITY_OUTPUT_CHAR_HEADER_DECLARATION;
+  #endif
+#endif
+
+#ifndef UNITY_OUTPUT_FLUSH
+  #ifdef UNITY_USE_FLUSH_STDOUT
+    /* We want to use the stdout flush utility */
+    #include <stdio.h>
+    #define UNITY_OUTPUT_FLUSH() (void)fflush(stdout)
+  #else
+    /* We've specified nothing, therefore flush should just be ignored */
+    #define UNITY_OUTPUT_FLUSH()
+  #endif
+#else
+  /* If defined as something else, make sure we declare it here so it's ready for use */
+  #ifdef UNITY_OUTPUT_FLUSH_HEADER_DECLARATION
+    extern void UNITY_OUTPUT_FLUSH_HEADER_DECLARATION;
+  #endif
+#endif
+
+#ifndef UNITY_OUTPUT_FLUSH
+#define UNITY_FLUSH_CALL()
+#else
+#define UNITY_FLUSH_CALL() UNITY_OUTPUT_FLUSH()
+#endif
+
+#ifndef UNITY_PRINT_EOL
+#define UNITY_PRINT_EOL()    UNITY_OUTPUT_CHAR('\n')
+#endif
+
+#ifndef UNITY_OUTPUT_START
+#define UNITY_OUTPUT_START()
+#endif
+
+#ifndef UNITY_OUTPUT_COMPLETE
+#define UNITY_OUTPUT_COMPLETE()
+#endif
+
+#ifndef UNITY_EXEC_TIME_RESET
+#ifdef UNITY_INCLUDE_EXEC_TIME
+#define UNITY_EXEC_TIME_RESET()\
+    Unity.CurrentTestStartTime = 0;\
+    Unity.CurrentTestStopTime = 0;
+#else
+#define UNITY_EXEC_TIME_RESET()
+#endif
+#endif
+
+#ifndef UNITY_EXEC_TIME_START
+#ifdef UNITY_INCLUDE_EXEC_TIME
+#define UNITY_EXEC_TIME_START() Unity.CurrentTestStartTime = UNITY_CLOCK_MS();
+#else
+#define UNITY_EXEC_TIME_START()
+#endif
+#endif
+
+#ifndef UNITY_EXEC_TIME_STOP
+#ifdef UNITY_INCLUDE_EXEC_TIME
+#define UNITY_EXEC_TIME_STOP() Unity.CurrentTestStopTime = UNITY_CLOCK_MS();
+#else
+#define UNITY_EXEC_TIME_STOP()
+#endif
+#endif
+
+#ifndef UNITY_PRINT_EXEC_TIME
+#ifdef UNITY_INCLUDE_EXEC_TIME
+#define UNITY_PRINT_EXEC_TIME() \
+	UnityPrint(" (");\
+	UNITY_COUNTER_TYPE execTimeMs = (Unity.CurrentTestStopTime - Unity.CurrentTestStartTime);\
+    UnityPrintNumberUnsigned(execTimeMs);\
+    UnityPrint(" ms)");
+#else
+#define UNITY_PRINT_EXEC_TIME()
+#endif
+#endif
+
+/*-------------------------------------------------------
+ * Footprint
+ *-------------------------------------------------------*/
+
+#ifndef UNITY_LINE_TYPE
+#define UNITY_LINE_TYPE UNITY_UINT
+#endif
+
+#ifndef UNITY_COUNTER_TYPE
+#define UNITY_COUNTER_TYPE UNITY_UINT
+#endif
+
+/*-------------------------------------------------------
+ * Language Features Available
+ *-------------------------------------------------------*/
+#if !defined(UNITY_WEAK_ATTRIBUTE) && !defined(UNITY_WEAK_PRAGMA)
+#   if defined(__GNUC__) || defined(__ghs__) /* __GNUC__ includes clang */
+#       if !(defined(__WIN32__) && defined(__clang__)) && !defined(__TMS470__)
+#           define UNITY_WEAK_ATTRIBUTE __attribute__((weak))
+#       endif
+#   endif
+#endif
+
+#ifdef UNITY_NO_WEAK
+#   undef UNITY_WEAK_ATTRIBUTE
+#   undef UNITY_WEAK_PRAGMA
+#endif
+
+/*-------------------------------------------------------
+ * Internal Structs Needed
+ *-------------------------------------------------------*/
+
+typedef void (*UnityTestFunction)(void);
+
+#define UNITY_DISPLAY_RANGE_INT  (0x10)
+#define UNITY_DISPLAY_RANGE_UINT (0x20)
+#define UNITY_DISPLAY_RANGE_HEX  (0x40)
+
+typedef enum
+{
+UNITY_DISPLAY_STYLE_INT = sizeof(int)+ UNITY_DISPLAY_RANGE_INT,
+    UNITY_DISPLAY_STYLE_INT8     = 1 + UNITY_DISPLAY_RANGE_INT,
+    UNITY_DISPLAY_STYLE_INT16    = 2 + UNITY_DISPLAY_RANGE_INT,
+    UNITY_DISPLAY_STYLE_INT32    = 4 + UNITY_DISPLAY_RANGE_INT,
+#ifdef UNITY_SUPPORT_64
+    UNITY_DISPLAY_STYLE_INT64    = 8 + UNITY_DISPLAY_RANGE_INT,
+#endif
+
+UNITY_DISPLAY_STYLE_UINT = sizeof(unsigned) + UNITY_DISPLAY_RANGE_UINT,
+    UNITY_DISPLAY_STYLE_UINT8    = 1 + UNITY_DISPLAY_RANGE_UINT,
+    UNITY_DISPLAY_STYLE_UINT16   = 2 + UNITY_DISPLAY_RANGE_UINT,
+    UNITY_DISPLAY_STYLE_UINT32   = 4 + UNITY_DISPLAY_RANGE_UINT,
+#ifdef UNITY_SUPPORT_64
+    UNITY_DISPLAY_STYLE_UINT64   = 8 + UNITY_DISPLAY_RANGE_UINT,
+#endif
+
+    UNITY_DISPLAY_STYLE_HEX8     = 1 + UNITY_DISPLAY_RANGE_HEX,
+    UNITY_DISPLAY_STYLE_HEX16    = 2 + UNITY_DISPLAY_RANGE_HEX,
+    UNITY_DISPLAY_STYLE_HEX32    = 4 + UNITY_DISPLAY_RANGE_HEX,
+#ifdef UNITY_SUPPORT_64
+    UNITY_DISPLAY_STYLE_HEX64    = 8 + UNITY_DISPLAY_RANGE_HEX,
+#endif
+
+    UNITY_DISPLAY_STYLE_UNKNOWN
+} UNITY_DISPLAY_STYLE_T;
+
+typedef enum
+{
+    UNITY_WITHIN           = 0x0,
+    UNITY_EQUAL_TO         = 0x1,
+    UNITY_GREATER_THAN     = 0x2,
+    UNITY_GREATER_OR_EQUAL = 0x2 + UNITY_EQUAL_TO,
+    UNITY_SMALLER_THAN     = 0x4,
+    UNITY_SMALLER_OR_EQUAL = 0x4 + UNITY_EQUAL_TO,
+    UNITY_UNKNOWN
+} UNITY_COMPARISON_T;
+
+#ifndef UNITY_EXCLUDE_FLOAT
+typedef enum UNITY_FLOAT_TRAIT
+{
+    UNITY_FLOAT_IS_NOT_INF       = 0,
+    UNITY_FLOAT_IS_INF,
+    UNITY_FLOAT_IS_NOT_NEG_INF,
+    UNITY_FLOAT_IS_NEG_INF,
+    UNITY_FLOAT_IS_NOT_NAN,
+    UNITY_FLOAT_IS_NAN,
+    UNITY_FLOAT_IS_NOT_DET,
+    UNITY_FLOAT_IS_DET,
+    UNITY_FLOAT_INVALID_TRAIT
+} UNITY_FLOAT_TRAIT_T;
+#endif
+
+typedef enum
+{
+    UNITY_ARRAY_TO_VAL = 0,
+    UNITY_ARRAY_TO_ARRAY,
+    UNITY_ARRAY_UNKNOWN
+} UNITY_FLAGS_T;
+
+struct UNITY_STORAGE_T
+{
+    const char* TestFile;
+    const char* CurrentTestName;
+#ifndef UNITY_EXCLUDE_DETAILS
+    const char* CurrentDetail1;
+    const char* CurrentDetail2;
+#endif
+    UNITY_LINE_TYPE CurrentTestLineNumber;
+    UNITY_COUNTER_TYPE NumberOfTests;
+    UNITY_COUNTER_TYPE TestFailures;
+    UNITY_COUNTER_TYPE TestIgnores;
+    UNITY_COUNTER_TYPE CurrentTestFailed;
+    UNITY_COUNTER_TYPE CurrentTestIgnored;
+#ifdef UNITY_INCLUDE_EXEC_TIME
+    UNITY_COUNTER_TYPE CurrentTestStartTime;
+    UNITY_COUNTER_TYPE CurrentTestStopTime;
+#endif
+#ifndef UNITY_EXCLUDE_SETJMP_H
+    jmp_buf AbortFrame;
+#endif
+};
+
+extern struct UNITY_STORAGE_T Unity;
+
+/*-------------------------------------------------------
+ * Test Suite Management
+ *-------------------------------------------------------*/
+
+void UnityBegin(const char* filename);
+int  UnityEnd(void);
+void UnityConcludeTest(void);
+void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int FuncLineNum);
+
+/*-------------------------------------------------------
+ * Details Support
+ *-------------------------------------------------------*/
+
+#ifdef UNITY_EXCLUDE_DETAILS
+#define UNITY_CLR_DETAILS()
+#define UNITY_SET_DETAIL(d1)
+#define UNITY_SET_DETAILS(d1,d2)
+#else
+#define UNITY_CLR_DETAILS()      { Unity.CurrentDetail1 = 0;   Unity.CurrentDetail2 = 0;  }
+#define UNITY_SET_DETAIL(d1)     { Unity.CurrentDetail1 = (d1);  Unity.CurrentDetail2 = 0;  }
+#define UNITY_SET_DETAILS(d1,d2) { Unity.CurrentDetail1 = (d1);  Unity.CurrentDetail2 = (d2); }
+
+#ifndef UNITY_DETAIL1_NAME
+#define UNITY_DETAIL1_NAME "Function"
+#endif
+
+#ifndef UNITY_DETAIL2_NAME
+#define UNITY_DETAIL2_NAME "Argument"
+#endif
+#endif
+
+/*-------------------------------------------------------
+ * Test Output
+ *-------------------------------------------------------*/
+
+void UnityPrint(const char* string);
+
+#ifdef UNITY_INCLUDE_PRINT_FORMATTED
+void UnityPrintFormatted(const char* format, ...);
+#endif
+
+void UnityPrintLen(const char* string, const UNITY_UINT32 length);
+void UnityPrintMask(const UNITY_UINT mask, const UNITY_UINT number);
+void UnityPrintNumberByStyle(const UNITY_INT number, const UNITY_DISPLAY_STYLE_T style);
+void UnityPrintNumber(const UNITY_INT number_to_print);
+void UnityPrintNumberUnsigned(const UNITY_UINT number);
+void UnityPrintNumberHex(const UNITY_UINT number, const char nibbles_to_print);
+
+#ifndef UNITY_EXCLUDE_FLOAT_PRINT
+void UnityPrintFloat(const UNITY_DOUBLE input_number);
+#endif
+
+/*-------------------------------------------------------
+ * Test Assertion Functions
+ *-------------------------------------------------------
+ *  Use the macros below this section instead of calling
+ *  these directly. The macros have a consistent naming
+ *  convention and will pull in file and line information
+ *  for you. */
+
+void UnityAssertEqualNumber(const UNITY_INT expected,
+                            const UNITY_INT actual,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber,
+                            const UNITY_DISPLAY_STYLE_T style);
+
+void UnityAssertGreaterOrLessOrEqualNumber(const UNITY_INT threshold,
+                                           const UNITY_INT actual,
+                                           const UNITY_COMPARISON_T compare,
+                                           const char *msg,
+                                           const UNITY_LINE_TYPE lineNumber,
+                                           const UNITY_DISPLAY_STYLE_T style);
+
+void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
+                              UNITY_INTERNAL_PTR actual,
+                              const UNITY_UINT32 num_elements,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber,
+                              const UNITY_DISPLAY_STYLE_T style,
+                              const UNITY_FLAGS_T flags);
+
+void UnityAssertBits(const UNITY_INT mask,
+                     const UNITY_INT expected,
+                     const UNITY_INT actual,
+                     const char* msg,
+                     const UNITY_LINE_TYPE lineNumber);
+
+void UnityAssertEqualString(const char* expected,
+                            const char* actual,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber);
+
+void UnityAssertEqualStringLen(const char* expected,
+                            const char* actual,
+                            const UNITY_UINT32 length,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber);
+
+void UnityAssertEqualStringArray( UNITY_INTERNAL_PTR expected,
+                                  const char** actual,
+                                  const UNITY_UINT32 num_elements,
+                                  const char* msg,
+                                  const UNITY_LINE_TYPE lineNumber,
+                                  const UNITY_FLAGS_T flags);
+
+void UnityAssertEqualMemory( UNITY_INTERNAL_PTR expected,
+                             UNITY_INTERNAL_PTR actual,
+                             const UNITY_UINT32 length,
+                             const UNITY_UINT32 num_elements,
+                             const char* msg,
+                             const UNITY_LINE_TYPE lineNumber,
+                             const UNITY_FLAGS_T flags);
+
+void UnityAssertNumbersWithin(const UNITY_UINT delta,
+                              const UNITY_INT expected,
+                              const UNITY_INT actual,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber,
+                              const UNITY_DISPLAY_STYLE_T style);
+
+void UnityFail(const char* message, const UNITY_LINE_TYPE line);
+
+void UnityIgnore(const char* message, const UNITY_LINE_TYPE line);
+
+#ifndef UNITY_EXCLUDE_FLOAT
+void UnityAssertFloatsWithin(const UNITY_FLOAT delta,
+                             const UNITY_FLOAT expected,
+                             const UNITY_FLOAT actual,
+                             const char* msg,
+                             const UNITY_LINE_TYPE lineNumber);
+
+void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* expected,
+                                UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* actual,
+                                const UNITY_UINT32 num_elements,
+                                const char* msg,
+                                const UNITY_LINE_TYPE lineNumber,
+                                const UNITY_FLAGS_T flags);
+
+void UnityAssertFloatSpecial(const UNITY_FLOAT actual,
+                             const char* msg,
+                             const UNITY_LINE_TYPE lineNumber,
+                             const UNITY_FLOAT_TRAIT_T style);
+#endif
+
+#ifndef UNITY_EXCLUDE_DOUBLE
+void UnityAssertDoublesWithin(const UNITY_DOUBLE delta,
+                              const UNITY_DOUBLE expected,
+                              const UNITY_DOUBLE actual,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber);
+
+void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* expected,
+                                 UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* actual,
+                                 const UNITY_UINT32 num_elements,
+                                 const char* msg,
+                                 const UNITY_LINE_TYPE lineNumber,
+                                 const UNITY_FLAGS_T flags);
+
+void UnityAssertDoubleSpecial(const UNITY_DOUBLE actual,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber,
+                              const UNITY_FLOAT_TRAIT_T style);
+#endif
+
+/*-------------------------------------------------------
+ * Helpers
+ *-------------------------------------------------------*/
+
+UNITY_INTERNAL_PTR UnityNumToPtr(const UNITY_INT num, const UNITY_UINT8 size);
+#ifndef UNITY_EXCLUDE_FLOAT
+UNITY_INTERNAL_PTR UnityFloatToPtr(const float num);
+#endif
+#ifndef UNITY_EXCLUDE_DOUBLE
+UNITY_INTERNAL_PTR UnityDoubleToPtr(const double num);
+#endif
+
+/*-------------------------------------------------------
+ * Error Strings We Might Need
+ *-------------------------------------------------------*/
+
+extern const char UnityStrErrFloat[];
+extern const char UnityStrErrDouble[];
+extern const char UnityStrErr64[];
+
+/*-------------------------------------------------------
+ * Test Running Macros
+ *-------------------------------------------------------*/
+
+#ifndef UNITY_EXCLUDE_SETJMP_H
+#define TEST_PROTECT() (setjmp(Unity.AbortFrame) == 0)
+#define TEST_ABORT() longjmp(Unity.AbortFrame, 1)
+#else
+#define TEST_PROTECT() 1
+#define TEST_ABORT() return
+#endif
+
+#ifndef UNITY_EXCLUDE_TIME_H
+#define UNITY_CLOCK_MS() (UNITY_COUNTER_TYPE)((clock() * 1000) / CLOCKS_PER_SEC)
+#else
+#define UNITY_CLOCK_MS()
+#endif
+
+/* This tricky series of macros gives us an optional line argument to treat it as RUN_TEST(func, num=__LINE__) */
+#ifndef RUN_TEST
+#ifdef __STDC_VERSION__
+#if __STDC_VERSION__ >= 199901L
+#define RUN_TEST(...) UnityDefaultTestRun(RUN_TEST_FIRST(__VA_ARGS__), RUN_TEST_SECOND(__VA_ARGS__))
+#define RUN_TEST_FIRST(...) RUN_TEST_FIRST_HELPER(__VA_ARGS__, throwaway)
+#define RUN_TEST_FIRST_HELPER(first, ...) (first), #first
+#define RUN_TEST_SECOND(...) RUN_TEST_SECOND_HELPER(__VA_ARGS__, __LINE__, throwaway)
+#define RUN_TEST_SECOND_HELPER(first, second, ...) (second)
+#endif
+#endif
+#endif
+
+/* If we can't do the tricky version, we'll just have to require them to always include the line number */
+#ifndef RUN_TEST
+#ifdef CMOCK
+#define RUN_TEST(func, num) UnityDefaultTestRun(func, #func, num)
+#else
+#define RUN_TEST(func) UnityDefaultTestRun(func, #func, __LINE__)
+#endif
+#endif
+
+#define TEST_LINE_NUM (Unity.CurrentTestLineNumber)
+#define TEST_IS_IGNORED (Unity.CurrentTestIgnored)
+#define UNITY_NEW_TEST(a) \
+    Unity.CurrentTestName = (a); \
+    Unity.CurrentTestLineNumber = (UNITY_LINE_TYPE)(__LINE__); \
+    Unity.NumberOfTests++;
+
+#ifndef UNITY_BEGIN
+#define UNITY_BEGIN() UnityBegin(__FILE__)
+#endif
+
+#ifndef UNITY_END
+#define UNITY_END() UnityEnd()
+#endif
+
+/*-----------------------------------------------
+ * Command Line Argument Support
+ *-----------------------------------------------*/
+
+#ifdef UNITY_USE_COMMAND_LINE_ARGS
+int UnityParseOptions(int argc, char** argv);
+int UnityTestMatches(void);
+#endif
+
+/*-------------------------------------------------------
+ * Basic Fail and Ignore
+ *-------------------------------------------------------*/
+
+#define UNITY_TEST_FAIL(line, message)   UnityFail(   (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_IGNORE(line, message) UnityIgnore( (message), (UNITY_LINE_TYPE)(line))
+
+/*-------------------------------------------------------
+ * Test Asserts
+ *-------------------------------------------------------*/
+
+#define UNITY_TEST_ASSERT(condition, line, message)                                              if (condition) {} else {UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), (message));}
+#define UNITY_TEST_ASSERT_NULL(pointer, line, message)                                           UNITY_TEST_ASSERT(((pointer) == NULL),  (UNITY_LINE_TYPE)(line), (message))
+#define UNITY_TEST_ASSERT_NOT_NULL(pointer, line, message)                                       UNITY_TEST_ASSERT(((pointer) != NULL),  (UNITY_LINE_TYPE)(line), (message))
+
+#define UNITY_TEST_ASSERT_EQUAL_INT(expected, actual, line, message)                             UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_EQUAL_INT8(expected, actual, line, message)                            UnityAssertEqualNumber((UNITY_INT)(UNITY_INT8 )(expected), (UNITY_INT)(UNITY_INT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_EQUAL_INT16(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_INT16)(expected), (UNITY_INT)(UNITY_INT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_EQUAL_INT32(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_INT32)(expected), (UNITY_INT)(UNITY_INT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_EQUAL_UINT(expected, actual, line, message)                            UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_EQUAL_UINT8(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_UINT8 )(expected), (UNITY_INT)(UNITY_UINT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_EQUAL_UINT16(expected, actual, line, message)                          UnityAssertEqualNumber((UNITY_INT)(UNITY_UINT16)(expected), (UNITY_INT)(UNITY_UINT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_EQUAL_UINT32(expected, actual, line, message)                          UnityAssertEqualNumber((UNITY_INT)(UNITY_UINT32)(expected), (UNITY_INT)(UNITY_UINT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_EQUAL_HEX8(expected, actual, line, message)                            UnityAssertEqualNumber((UNITY_INT)(UNITY_INT8 )(expected), (UNITY_INT)(UNITY_INT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_EQUAL_HEX16(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_INT16)(expected), (UNITY_INT)(UNITY_INT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_EQUAL_HEX32(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_INT32)(expected), (UNITY_INT)(UNITY_INT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+#define UNITY_TEST_ASSERT_BITS(mask, expected, actual, line, message)                            UnityAssertBits((UNITY_INT)(mask), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line))
+
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT(threshold, actual, line, message)                     UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold),              (UNITY_INT)(actual),              UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT8(threshold, actual, line, message)                    UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT8 )(threshold), (UNITY_INT)(UNITY_INT8 )(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT16(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT16)(threshold), (UNITY_INT)(UNITY_INT16)(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT32(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT32)(threshold), (UNITY_INT)(UNITY_INT32)(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT(threshold, actual, line, message)                    UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold),              (UNITY_INT)(actual),              UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT8(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT16(threshold, actual, line, message)                  UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT32(threshold, actual, line, message)                  UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_GREATER_THAN_HEX8(threshold, actual, line, message)                    UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_GREATER_THAN_HEX16(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_GREATER_THAN_HEX32(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT(threshold, actual, line, message)                     UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold),              (UNITY_INT)(actual),              UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT8(threshold, actual, line, message)                    UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT8 )(threshold), (UNITY_INT)(UNITY_INT8 )(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT16(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT16)(threshold), (UNITY_INT)(UNITY_INT16)(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT32(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT32)(threshold), (UNITY_INT)(UNITY_INT32)(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT(threshold, actual, line, message)                    UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold),              (UNITY_INT)(actual),              UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT8(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT16(threshold, actual, line, message)                  UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT32(threshold, actual, line, message)                  UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_HEX8(threshold, actual, line, message)                    UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_HEX16(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_HEX32(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT(threshold, actual, line, message)                 UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold),              (UNITY_INT)(actual),              UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT8(threshold, actual, line, message)                UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT8 )(threshold), (UNITY_INT)(UNITY_INT8 )(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT16(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT16)(threshold), (UNITY_INT)(UNITY_INT16)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT32(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT32)(threshold), (UNITY_INT)(UNITY_INT32)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT(threshold, actual, line, message)                UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold),              (UNITY_INT)(actual),              UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT8(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT16(threshold, actual, line, message)              UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT32(threshold, actual, line, message)              UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX8(threshold, actual, line, message)                UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX16(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX32(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT(threshold, actual, line, message)                 UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold),              (UNITY_INT)(actual),              UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT8(threshold, actual, line, message)                UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT8 )(threshold), (UNITY_INT)(UNITY_INT8 )(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT16(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT16)(threshold), (UNITY_INT)(UNITY_INT16)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT32(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT32)(threshold), (UNITY_INT)(UNITY_INT32)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT(threshold, actual, line, message)                UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold),              (UNITY_INT)(actual),              UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT8(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT16(threshold, actual, line, message)              UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT32(threshold, actual, line, message)              UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX8(threshold, actual, line, message)                UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX16(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX32(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+
+#define UNITY_TEST_ASSERT_INT_WITHIN(delta, expected, actual, line, message)                     UnityAssertNumbersWithin((delta), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_INT8_WITHIN(delta, expected, actual, line, message)                    UnityAssertNumbersWithin((UNITY_UINT8 )(delta), (UNITY_INT)(UNITY_INT8 )(expected), (UNITY_INT)(UNITY_INT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_INT16_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT16)(delta), (UNITY_INT)(UNITY_INT16)(expected), (UNITY_INT)(UNITY_INT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_INT32_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT32)(delta), (UNITY_INT)(UNITY_INT32)(expected), (UNITY_INT)(UNITY_INT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_UINT_WITHIN(delta, expected, actual, line, message)                    UnityAssertNumbersWithin((delta), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_UINT8_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT8 )(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT8 )(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_UINT16_WITHIN(delta, expected, actual, line, message)                  UnityAssertNumbersWithin((UNITY_UINT16)(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT16)(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_UINT32_WITHIN(delta, expected, actual, line, message)                  UnityAssertNumbersWithin((UNITY_UINT32)(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT32)(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_HEX8_WITHIN(delta, expected, actual, line, message)                    UnityAssertNumbersWithin((UNITY_UINT8 )(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT8 )(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_HEX16_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT16)(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT16)(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_HEX32_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT32)(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT32)(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+
+#define UNITY_TEST_ASSERT_EQUAL_PTR(expected, actual, line, message)                             UnityAssertEqualNumber((UNITY_PTR_TO_INT)(expected), (UNITY_PTR_TO_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_POINTER)
+#define UNITY_TEST_ASSERT_EQUAL_STRING(expected, actual, line, message)                          UnityAssertEqualString((const char*)(expected), (const char*)(actual), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len, line, message)                 UnityAssertEqualStringLen((const char*)(expected), (const char*)(actual), (UNITY_UINT32)(len), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_EQUAL_MEMORY(expected, actual, len, line, message)                     UnityAssertEqualMemory((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(len), 1, (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_ARRAY)
+
+#define UNITY_TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT,     UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_INT8_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8,    UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_INT16_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16,   UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_INT32_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32,   UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_UINT_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT,    UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8,   UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_UINT16_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16,  UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_UINT32_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32,  UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8,    UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_HEX16_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16,   UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32,   UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_PTR_ARRAY(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_POINTER, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_STRING_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualStringArray((UNITY_INTERNAL_PTR)(expected), (const char**)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY(expected, actual, len, num_elements, line, message) UnityAssertEqualMemory((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(len), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_ARRAY)
+
+#define UNITY_TEST_ASSERT_EACH_EQUAL_INT(expected, actual, num_elements, line, message)          UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)              (expected), sizeof(int)),  (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT,     UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_INT8(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT8  )(expected), 1),            (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8,    UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_INT16(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT16 )(expected), 2),            (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16,   UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_INT32(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT32 )(expected), 4),            (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32,   UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_UINT(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)              (expected), sizeof(unsigned int)), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT,    UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_UINT8(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_UINT8 )(expected), 1),            (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8,   UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_UINT16(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_UINT16)(expected), 2),            (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16,  UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_UINT32(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_UINT32)(expected), 4),            (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32,  UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_HEX8(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT8  )(expected), 1),            (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8,    UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_HEX16(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT16 )(expected), 2),            (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16,   UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_HEX32(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT32 )(expected), 4),            (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32,   UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_PTR(expected, actual, num_elements, line, message)          UnityAssertEqualIntArray(UnityNumToPtr((UNITY_PTR_TO_INT)       (expected), sizeof(int*)), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_POINTER, UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_STRING(expected, actual, num_elements, line, message)       UnityAssertEqualStringArray((UNITY_INTERNAL_PTR)(expected), (const char**)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_MEMORY(expected, actual, len, num_elements, line, message)  UnityAssertEqualMemory((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(len), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_VAL)
+
+#ifdef UNITY_SUPPORT_64
+#define UNITY_TEST_ASSERT_EQUAL_INT64(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_EQUAL_UINT64(expected, actual, line, message)                          UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_EQUAL_HEX64(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_EQUAL_INT64_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64,  UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_UINT64_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_HEX64_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64,  UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_INT64(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT64)(expected), 8), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64,  UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_UINT64(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_UINT64)(expected), 8), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64, UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_HEX64(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT64)(expected), 8), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64,  UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_INT64_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((delta), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_UINT64_WITHIN(delta, expected, actual, line, message)                  UnityAssertNumbersWithin((delta), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_HEX64_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((delta), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT64(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_GREATER_THAN,     (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT64(threshold, actual, line, message)                  UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_GREATER_THAN,     (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_GREATER_THAN_HEX64(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_GREATER_THAN,     (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT64(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT64(threshold, actual, line, message)              UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX64(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT64(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_SMALLER_THAN,     (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT64(threshold, actual, line, message)                  UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_SMALLER_THAN,     (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_HEX64(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_SMALLER_THAN,     (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT64(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT64(threshold, actual, line, message)              UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX64(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#else
+#define UNITY_TEST_ASSERT_EQUAL_INT64(expected, actual, line, message)                           UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_EQUAL_UINT64(expected, actual, line, message)                          UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_EQUAL_HEX64(expected, actual, line, message)                           UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_EQUAL_INT64_ARRAY(expected, actual, num_elements, line, message)       UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_EQUAL_UINT64_ARRAY(expected, actual, num_elements, line, message)      UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_EQUAL_HEX64_ARRAY(expected, actual, num_elements, line, message)       UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_INT64_WITHIN(delta, expected, actual, line, message)                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_UINT64_WITHIN(delta, expected, actual, line, message)                  UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_HEX64_WITHIN(delta, expected, actual, line, message)                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT64(threshold, actual, line, message)                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT64(threshold, actual, line, message)                  UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_GREATER_THAN_HEX64(threshold, actual, line, message)                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT64(threshold, actual, line, message)               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT64(threshold, actual, line, message)              UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX64(threshold, actual, line, message)               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT64(threshold, actual, line, message)                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT64(threshold, actual, line, message)                  UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_HEX64(threshold, actual, line, message)                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT64(threshold, actual, line, message)               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT64(threshold, actual, line, message)              UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX64(threshold, actual, line, message)               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#endif
+
+#ifdef UNITY_EXCLUDE_FLOAT
+#define UNITY_TEST_ASSERT_FLOAT_WITHIN(delta, expected, actual, line, message)                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_EQUAL_FLOAT(expected, actual, line, message)                           UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, actual, num_elements, line, message)       UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_FLOAT(expected, actual, num_elements, line, message)        UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_INF(actual, line, message)                                    UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NEG_INF(actual, line, message)                                UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NAN(actual, line, message)                                    UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_DETERMINATE(actual, line, message)                            UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_INF(actual, line, message)                                UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_NEG_INF(actual, line, message)                            UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_NAN(actual, line, message)                                UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE(actual, line, message)                        UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#else
+#define UNITY_TEST_ASSERT_FLOAT_WITHIN(delta, expected, actual, line, message)                   UnityAssertFloatsWithin((UNITY_FLOAT)(delta), (UNITY_FLOAT)(expected), (UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_EQUAL_FLOAT(expected, actual, line, message)                           UNITY_TEST_ASSERT_FLOAT_WITHIN((UNITY_FLOAT)(expected) * (UNITY_FLOAT)UNITY_FLOAT_PRECISION, (UNITY_FLOAT)(expected), (UNITY_FLOAT)(actual), (UNITY_LINE_TYPE)(line), (message))
+#define UNITY_TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualFloatArray((UNITY_FLOAT*)(expected), (UNITY_FLOAT*)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_FLOAT(expected, actual, num_elements, line, message)        UnityAssertEqualFloatArray(UnityFloatToPtr(expected), (UNITY_FLOAT*)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_FLOAT_IS_INF(actual, line, message)                                    UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_INF)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NEG_INF(actual, line, message)                                UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NEG_INF)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NAN(actual, line, message)                                    UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NAN)
+#define UNITY_TEST_ASSERT_FLOAT_IS_DETERMINATE(actual, line, message)                            UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_DET)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_INF(actual, line, message)                                UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_INF)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_NEG_INF(actual, line, message)                            UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NEG_INF)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_NAN(actual, line, message)                                UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NAN)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE(actual, line, message)                        UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_DET)
+#endif
+
+#ifdef UNITY_EXCLUDE_DOUBLE
+#define UNITY_TEST_ASSERT_DOUBLE_WITHIN(delta, expected, actual, line, message)                  UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_EQUAL_DOUBLE(expected, actual, line, message)                          UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_EQUAL_DOUBLE_ARRAY(expected, actual, num_elements, line, message)      UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_DOUBLE(expected, actual, num_elements, line, message)       UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_INF(actual, line, message)                                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NEG_INF(actual, line, message)                               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NAN(actual, line, message)                                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_DETERMINATE(actual, line, message)                           UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_INF(actual, line, message)                               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF(actual, line, message)                           UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN(actual, line, message)                               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE(actual, line, message)                       UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#else
+#define UNITY_TEST_ASSERT_DOUBLE_WITHIN(delta, expected, actual, line, message)                  UnityAssertDoublesWithin((UNITY_DOUBLE)(delta), (UNITY_DOUBLE)(expected), (UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_EQUAL_DOUBLE(expected, actual, line, message)                          UNITY_TEST_ASSERT_DOUBLE_WITHIN((UNITY_DOUBLE)(expected) * (UNITY_DOUBLE)UNITY_DOUBLE_PRECISION, (UNITY_DOUBLE)(expected), (UNITY_DOUBLE)(actual), (UNITY_LINE_TYPE)(line), (message))
+#define UNITY_TEST_ASSERT_EQUAL_DOUBLE_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualDoubleArray((UNITY_DOUBLE*)(expected), (UNITY_DOUBLE*)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_DOUBLE(expected, actual, num_elements, line, message)       UnityAssertEqualDoubleArray(UnityDoubleToPtr(expected), (UNITY_DOUBLE*)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_INF(actual, line, message)                                   UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_INF)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NEG_INF(actual, line, message)                               UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NEG_INF)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NAN(actual, line, message)                                   UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NAN)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_DETERMINATE(actual, line, message)                           UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_DET)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_INF(actual, line, message)                               UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_INF)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF(actual, line, message)                           UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NEG_INF)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN(actual, line, message)                               UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NAN)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE(actual, line, message)                       UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_DET)
+#endif
+
+/* End of UNITY_INTERNALS_H */
+#endif

--- a/generators/exercises/production_line.py
+++ b/generators/exercises/production_line.py
@@ -1,0 +1,334 @@
+FUNC_PROTO = """\
+#include "vendor/unity.h"
+
+#include <stdalign.h>
+#include <stddef.h>
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
+extern void sum_yields(const float line_a[4], const float line_b[4], float result[4]);
+extern void scaled_deviation(const double measured[], const double target[], const double sensitivity[], double result[]);
+extern void calibrate_batch(const float raw[], const double reference[2], const double offset[2], double result[2]);
+extern void normalize_scores(double scores[], const double gains[], const double scale[2], size_t n);
+"""
+
+
+def extra_cases():
+    return [
+        {
+            "task_id": 1,
+            "description": "sum_yields_example",
+            "property": "sum_yields",
+            "input": [[10.0, 20.0, 30.0, 40.0], [5.0, 15.0, 25.0, 35.0]],
+            "expected": [15.0, 35.0, 55.0, 75.0],
+        },
+        {
+            "task_id": 1,
+            "description": "sum_yields_all_zeros",
+            "property": "sum_yields",
+            "input": [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
+            "expected": [0.0, 0.0, 0.0, 0.0],
+        },
+        {
+            "task_id": 1,
+            "description": "sum_yields_cancels_to_zero",
+            "property": "sum_yields",
+            "input": [[-1.0, -2.0, -3.0, -4.0], [1.0, 2.0, 3.0, 4.0]],
+            "expected": [0.0, 0.0, 0.0, 0.0],
+        },
+        {
+            "task_id": 1,
+            "description": "sum_yields_mixed_signs",
+            "property": "sum_yields",
+            "input": [[1.5, -2.5, 3.5, -4.5], [-0.5, 2.5, -1.5, 4.5]],
+            "expected": [1.0, 0.0, 2.0, 0.0],
+        },
+        {
+            "task_id": 1,
+            "description": "sum_yields_fractional",
+            "property": "sum_yields",
+            "input": [[0.5, 0.25, 0.125, 0.75], [0.5, 0.75, 0.875, 0.25]],
+            "expected": [1.0, 1.0, 1.0, 1.0],
+        },
+        {
+            "task_id": 1,
+            "description": "sum_yields_large_values",
+            "property": "sum_yields",
+            "input": [
+                [1000000.0, 2000000.0, 3000000.0, 4000000.0],
+                [500000.0, 500000.0, 500000.0, 500000.0],
+            ],
+            "expected": [1500000.0, 2500000.0, 3500000.0, 4500000.0],
+        },
+        {
+            "task_id": 1,
+            "description": "sum_yields_one_operand_zero",
+            "property": "sum_yields",
+            "input": [[7.0, 8.0, 9.0, 10.0], [0.0, 0.0, 0.0, 0.0]],
+            "expected": [7.0, 8.0, 9.0, 10.0],
+        },
+        {
+            "task_id": 1,
+            "description": "sum_yields_both_negative",
+            "property": "sum_yields",
+            "input": [[-10.0, -20.0, -30.0, -40.0], [-5.0, -15.0, -25.0, -35.0]],
+            "expected": [-15.0, -35.0, -55.0, -75.0],
+        },
+        {
+            "task_id": 2,
+            "description": "scaled_deviation_example",
+            "property": "scaled_deviation",
+            "input": [[10.5, 20.5], [10.0, 20.0], [2.0, 4.0]],
+            "expected": [1.0, 2.0],
+        },
+        {
+            "task_id": 2,
+            "description": "scaled_deviation_zero_deviation",
+            "property": "scaled_deviation",
+            "input": [[5.0, 5.0], [5.0, 5.0], [2.0, 2.0]],
+            "expected": [0.0, 0.0],
+        },
+        {
+            "task_id": 2,
+            "description": "scaled_deviation_negative_deviation",
+            "property": "scaled_deviation",
+            "input": [[1.0, 2.0], [3.0, 5.0], [1.0, 1.0]],
+            "expected": [-2.0, -3.0],
+        },
+        {
+            "task_id": 2,
+            "description": "scaled_deviation_zero_sensitivity",
+            "property": "scaled_deviation",
+            "input": [[100.0, 200.0], [50.0, 50.0], [0.0, 0.0]],
+            "expected": [0.0, 0.0],
+        },
+        {
+            "task_id": 2,
+            "description": "scaled_deviation_fractional_sensitivity",
+            "property": "scaled_deviation",
+            "input": [[4.0, 8.0], [2.0, 4.0], [0.5, 0.25]],
+            "expected": [1.0, 1.0],
+        },
+        {
+            "task_id": 2,
+            "description": "scaled_deviation_negative_target",
+            "property": "scaled_deviation",
+            "input": [[0.0, 0.0], [-3.0, -7.0], [1.0, 1.0]],
+            "expected": [3.0, 7.0],
+        },
+        {
+            "task_id": 2,
+            "description": "scaled_deviation_negative_sensitivity",
+            "property": "scaled_deviation",
+            "input": [[10.0, 10.0], [5.0, 5.0], [-2.0, -3.0]],
+            "expected": [-10.0, -15.0],
+        },
+        {
+            "task_id": 2,
+            "description": "scaled_deviation_larger_values",
+            "property": "scaled_deviation",
+            "input": [[1000.0, 2000.0], [1000.0, 1500.0], [3.0, 2.0]],
+            "expected": [0.0, 1000.0],
+        },
+        {
+            "task_id": 3,
+            "description": "calibrate_batch_example",
+            "property": "calibrate_batch",
+            "input": [[10.0, 20.0, 25.0, 50.0], [100.0, 100.0], [5.0, 10.0]],
+            "expected": [10.0, 5.0, 2.5, 1.25],
+        },
+        {
+            "task_id": 3,
+            "description": "calibrate_batch_uniform",
+            "property": "calibrate_batch",
+            "input": [[6.0, 6.0, 6.0, 6.0], [12.0, 12.0], [2.0, 2.0]],
+            "expected": [1.5, 1.5, 1.5, 1.5],
+        },
+        {
+            "task_id": 3,
+            "description": "calibrate_batch_different_offset_per_lane",
+            "property": "calibrate_batch",
+            "input": [[10.0, 10.0, 10.0, 10.0], [20.0, 20.0], [5.0, 8.0]],
+            "expected": [2.0, 5.0, 2.0, 5.0],
+        },
+        {
+            "task_id": 3,
+            "description": "calibrate_batch_negative_raw",
+            "property": "calibrate_batch",
+            "input": [[-2.0, -4.0, -8.0, -16.0], [16.0, 16.0], [0.0, 0.0]],
+            "expected": [-4.0, -2.0, -1.0, -0.5],
+        },
+        {
+            "task_id": 3,
+            "description": "calibrate_batch_different_reference_per_lane",
+            "property": "calibrate_batch",
+            "input": [[10.0, 10.0, 10.0, 10.0], [100.0, 50.0], [0.0, 0.0]],
+            "expected": [5.0, 2.5, 5.0, 2.5],
+        },
+        {
+            "task_id": 3,
+            "description": "calibrate_batch_fractional_raw",
+            "property": "calibrate_batch",
+            "input": [[0.5, 1.0, 2.0, 4.0], [4.0, 4.0], [0.0, 0.0]],
+            "expected": [4.0, 2.0, 1.0, 0.5],
+        },
+        {
+            "task_id": 3,
+            "description": "calibrate_batch_offset_exceeds_raw",
+            "property": "calibrate_batch",
+            "input": [[2.0, 2.0, 6.0, 8.0], [8.0, 8.0], [10.0, 10.0]],
+            "expected": [-0.5, -0.5, -1.0, -2.0],
+        },
+        {
+            "task_id": 3,
+            "description": "calibrate_batch_mixed_reference_offset",
+            "property": "calibrate_batch",
+            "input": [[3.0, 5.0, 9.0, 17.0], [2.0, 4.0], [1.0, 1.0]],
+            "expected": [0.5, 0.5, 0.125, 0.125],
+        },
+        {
+            "task_id": 4,
+            "description": "normalize_scores_example",
+            "property": "normalize_scores",
+            "input": [[10.0, 20.0, 30.0, 40.0], [2.0, 1.5, 1.0, 0.5], [2.0, 4.0], 4],
+            "expected": [10.0, 7.5, 15.0, 5.0],
+        },
+        {
+            "task_id": 4,
+            "description": "normalize_scores_single_iteration",
+            "property": "normalize_scores",
+            "input": [[8.0, 16.0], [2.0, 2.0], [4.0, 8.0], 2],
+            "expected": [4.0, 4.0],
+        },
+        {
+            "task_id": 4,
+            "description": "normalize_scores_identity",
+            "property": "normalize_scores",
+            "input": [[1.0, 2.0, 3.0, 4.0], [1.0, 1.0, 1.0, 1.0], [1.0, 1.0], 4],
+            "expected": [1.0, 2.0, 3.0, 4.0],
+        },
+        {
+            "task_id": 4,
+            "description": "normalize_scores_three_iterations",
+            "property": "normalize_scores",
+            "input": [
+                [2.0, 4.0, 6.0, 8.0, 10.0, 12.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [2.0, 4.0],
+                6,
+            ],
+            "expected": [1.0, 1.0, 3.0, 2.0, 5.0, 3.0],
+        },
+        {
+            "task_id": 4,
+            "description": "normalize_scores_negative_scores",
+            "property": "normalize_scores",
+            "input": [[-4.0, -8.0, -12.0, -16.0], [1.0, 1.0, 1.0, 1.0], [2.0, 4.0], 4],
+            "expected": [-2.0, -2.0, -6.0, -4.0],
+        },
+        {
+            "task_id": 4,
+            "description": "normalize_scores_negative_gains",
+            "property": "normalize_scores",
+            "input": [[10.0, 10.0], [-2.0, -4.0], [1.0, 1.0], 2],
+            "expected": [-20.0, -40.0],
+        },
+        {
+            "task_id": 4,
+            "description": "normalize_scores_fractional_gains",
+            "property": "normalize_scores",
+            "input": [[8.0, 8.0, 8.0, 8.0], [0.5, 0.25, 0.125, 0.5], [1.0, 1.0], 4],
+            "expected": [4.0, 2.0, 1.0, 4.0],
+        },
+        {
+            "task_id": 4,
+            "description": "normalize_scores_negative_scale",
+            "property": "normalize_scores",
+            "input": [[6.0, 8.0], [2.0, 2.0], [-3.0, -4.0], 2],
+            "expected": [-4.0, -4.0],
+        },
+    ]
+
+
+def array_literal(numbers):
+    return str(numbers).replace("[", "{").replace("]", "}")
+
+
+def gen_func_body(prop, inp, expected):
+    str_list = []
+    if prop == "sum_yields":
+        str_list.append(f"alignas(16) const float line_a[4] = {array_literal(inp[0])};")
+        str_list.append(f"alignas(16) const float line_b[4] = {array_literal(inp[1])};")
+        str_list.append("alignas(16) float result[4];")
+        str_list.append(f"{prop}(line_a, line_b, result);")
+        str_list.append(f"const float expected[4] = {array_literal(expected)};")
+        str_list.append(
+            'TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[0], result[0], "The 32-bit floating-point number at lane 0 is different from expected");'
+        )
+        str_list.append(
+            'TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[1], result[1], "The 32-bit floating-point number at lane 1 is different from expected");'
+        )
+        str_list.append(
+            'TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[2], result[2], "The 32-bit floating-point number at lane 2 is different from expected");'
+        )
+        str_list.append(
+            'TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected[3], result[3], "The 32-bit floating-point number at lane 3 is different from expected");'
+        )
+    elif prop == "scaled_deviation":
+        str_list.append(
+            f"alignas(16) const double measured[2] = {array_literal(inp[0])};"
+        )
+        str_list.append("const char x1 = 'X';")
+        str_list.append("(void)x1;")
+        str_list.append(f"alignas(8) const double target[2] = {array_literal(inp[1])};")
+        str_list.append("const char x2 = 'X';")
+        str_list.append("(void)x2;")
+        str_list.append(
+            f"alignas(8) const double sensitivity[2] = {array_literal(inp[2])};"
+        )
+        str_list.append("const char x3 = 'X';")
+        str_list.append("(void)x3;")
+        str_list.append("alignas(8) double result[2];")
+        str_list.append(f"{prop}(measured, target, sensitivity, result);")
+        str_list.append(f"const double expected[2] = {array_literal(expected)};")
+        str_list.append(
+            'TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0], "The 64-bit floating-point number at lane 0 is different from expected");'
+        )
+        str_list.append(
+            'TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1], "The 64-bit floating-point number at lane 1 is different from expected");'
+        )
+    elif prop == "calibrate_batch":
+        str_list.append("const char x = 'X';")
+        str_list.append("(void)x;")
+        str_list.append(f"alignas(4) const float raw[] = {array_literal(inp[0])};")
+        str_list.append(
+            f"alignas(16) const double reference[2] = {array_literal(inp[1])};"
+        )
+        str_list.append(
+            f"alignas(16) const double offset[2] = {array_literal(inp[2])};"
+        )
+        str_list.append("alignas(16) double result[4];")
+        str_list.append(f"{prop}(raw, reference, offset, result);")
+        str_list.append(f"const double expected[] = {array_literal(expected)};")
+        str_list.append(
+            'TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[0], result[0], "The 64-bit floating-point number at lane 0 of the first row is different from expected");'
+        )
+        str_list.append(
+            'TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1], "The 64-bit floating-point number at lane 1 of the first row is different from expected");'
+        )
+        str_list.append(
+            'TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[2], result[2], "The 64-bit floating-point number at lane 0 of the second row is different from expected");'
+        )
+        str_list.append(
+            'TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[3], result[3], "The 64-bit floating-point number at lane 1 of the second row is different from expected");'
+        )
+    elif prop == "normalize_scores":
+        str_list.append(f"alignas(16) double scores[] = {array_literal(inp[0])};")
+        str_list.append(f"alignas(16) const double gains[] = {array_literal(inp[1])};")
+        str_list.append(f"alignas(16) const double scale[2] = {array_literal(inp[2])};")
+        str_list.append(f"{prop}(scores, gains, scale, {inp[3]});")
+        str_list.append(f"const double expected[] = {array_literal(expected)};")
+        str_list.append(
+            'TEST_ASSERT_EQUAL_DOUBLE_ARRAY_MESSAGE(expected, scores, ARRAY_SIZE(expected), "The sequence of 64-bit floating-point numbers is different from expected");'
+        )
+    return "\n".join(str_list)


### PR DESCRIPTION
I thought a lot about how to organize the content about SIMD across different concepts. One question was: should we aim to teach the legacy SSE that is "guaranteed" to work everywhere, the balanced AVX/AVX2, or the newest AVX-512?

I decided against AVX-512 because its support is very inconsistent. For example, it was disabled on mainstream Intel CPUs from the 12th, 13th and 14th generation.

AVX has been present in basically every Intel and AMD CPU of the last 10 years, and even older. But it is not consistently supported by Rosetta 2, i.e., on ARM macOS. Dropping AVX support for Apple users probably wouldn't be a big deal anyway, since Apple migrated to ARM a while back and is already phasing Rosetta 2 out.

SSE, on the other hand, is supported by everything from the last 20 years, including Apple. It is also the "standard" the track has been using since the beginning (for example, in the Floating-Point Numbers concept).

Another point in favor of teaching SSE is that SSE and AVX have very similar syntax, and in fact most instructions are the same. AVX simply updates those instructions. So I could teach SSE and just mention AVX/AVX2 and how to use the updated versions of those instructions.

All in all, I went for SSE and added a section to mention AVX/AVX2 in this first concept.
