### PR TITLE
update `complex-numbers` solution and add test cases

### DIFF
--- a/config.json
+++ b/config.json
@@ -967,16 +967,6 @@
         "difficulty": 5
       },
       {
-        "slug": "complex-numbers",
-        "name": "Complex Numbers",
-        "uuid": "297841a7-396b-4fdd-bff0-2e16b6c1635a",
-        "practices": [],
-        "prerequisites": [
-          "interfacing-with-c-structs"
-        ],
-        "difficulty": 5
-      },
-      {
         "slug": "custom-set",
         "name": "Custom Set",
         "uuid": "d7270e9a-7d0f-45fa-bee2-ca7f6d6ea46b",
@@ -1294,6 +1284,16 @@
         "slug": "baffling-birthdays",
         "name": "Baffling Birthdays",
         "uuid": "28d1203e-e12a-49be-aba1-0571f54b3e39",
+        "practices": [],
+        "prerequisites": [
+          "interfacing-with-c-structs"
+        ],
+        "difficulty": 7
+      },
+      {
+        "slug": "complex-numbers",
+        "name": "Complex Numbers",
+        "uuid": "297841a7-396b-4fdd-bff0-2e16b6c1635a",
         "practices": [],
         "prerequisites": [
           "interfacing-with-c-structs"

--- a/exercises/practice/complex-numbers/.meta/example.asm
+++ b/exercises/practice/complex-numbers/.meta/example.asm
@@ -1,7 +1,34 @@
-default rel
+section .rodata
+align 16
 
-section .data
-    negate_mask dd 0x80000000
+SIGN_MASK: dd 0, 0x80000000, 0, 0
+
+C1:   dd -0.16666666666666667          ; - 1 / 3!
+      dd -0.5                          ; - 1 / 2!
+      dd 0.16666666666666667           ; 1 / 3!
+      dd 0.5                           ; 1 / 2!
+
+C2:   dd 0.008333333333333333          ; 1 / 5!
+      dd 0.04166666666666667           ; 1 / 4!
+      times 2 dd 0
+
+C3:   dd -0.0001984126984126984        ; - 1 / 7!
+      dd -0.001388888888888889         ; - 1 / 6!
+      dd 0.0001984126984126984         ;  1 / 7!
+      dd 0.001388888888888889          ;  1 / 6!
+
+C4:   dd 2.7557319223985893e-06        ; 1 / 9!
+      dd 2.4801587301587302e-05        ; 1 / 8!
+      times 2 dd 0
+
+TWO_DIV_PI: times 4 dd 0.6366197723675814     ; 2 / PI
+PI_DIV_TWO: times 4 dd 1.5707963705062866     ; PI / 2
+ONE: times 4 dd 1.0
+
+ONE_DIV_LOG2: dd 1.4426950408889634
+LN2: dd 0.693147180559
+
+FLOOR equ 1
 
 section .text
 
@@ -23,469 +50,256 @@ global real_complex_mul
 global complex_real_div
 global real_complex_div
 
-; Those functions work with a struct of 2 floats
-;
-; As is the case with structs, parameters are passed
-; in a single register, whenever possible
-;
-; Here, both parameters are in different lanes (32-bit)
-; of a single XMM register
-;
-; One of the ways to move bits from lanes,
-; in order to access those different members,
-; is shifting bytes (not bits) using psrldq or pslldq
-;
-; However, having the bits packed in two lanes of a single register
-; means we sometimes can use SIMD instructions,
-; which operate in all lanes in parallel.
-; This is of course much more efficient
+%macro exp_taylor 0
+    ; This macro calculates e^x
+    ;
+    ; For a large x, taylor expansion takes much longer to converge
+    ; so we first reduce x to a small r and to a power of two k
+    ;
+    ; We know that e^x = 2^(x * log2(e)) = 2^(x / ln2)
+    ;
+    ; let z = x / ln2 and z = k + f, where k = floor(z) and f < 1
+    ; then 2^z = 2^(k + f) = 2^k + 2^f
+    ;
+    ; let r = x - k*ln2 = z*ln2 - k*ln2 = ln2*(z - k) = ln2*f
+    ; then 2^f = e^(ln2*f) = e^r
+    ;
+    ; so e^x = 2^k * e^r
+    ;
+    ; r is small, so we can calculate e^r with taylor expansion
+    ; and 2^k can be applied directly to e^r with shifts on the raw IEE exponent field
 
-%macro extract_members 2
-    ; Below implementation depends on SSE2
-    movaps %1, %2
-    psrldq %1, 4
+    movaps xmm1, xmm4
+    mulss xmm1, [rel ONE_DIV_LOG2]   ; xmm1 = x * log2e = x / ln2 = z
+    roundss xmm1, xmm1, FLOOR        ; xmm1 = floor(z) = k
+    cvtss2si eax, xmm1               ; we save k to shift the result later
 
-    ; Alternative implementation
-    ; movq rax, %2
-    ; shr rax, 32
-    ; movd %1, eax
+    ; now we need to calculate r = x - k*ln2
+    movaps xmm2, xmm1
+    mulss xmm2, [rel LN2]            ; xmm2 = k*kn2
+    subss xmm4, xmm2                 ; xmm4 = x - k*ln2 = r
+
+    ; we are now calculating the taylor expansion of r with 7 factors:
+    ; e^r = 1 + (r^2)/2! + ... + (r^7)/7!
+    ;
+    ; we have the inverse of the factorials already precomputed and saved in memory
+    ; we start from 1/7! and continuously multiply x and add the next factorial inverse
+
+    movss xmm2, [rel ONE] ; cache 1.0 in xmm2 to be used later. This saves one memory load
+
+    movss xmm1, [rel C3 + 8]
+    mulss xmm1, xmm4
+    addss xmm1, [rel C3 + 12]
+    mulss xmm1, xmm4
+    addss xmm1, [rel C2]
+    mulss xmm1, xmm4
+    addss xmm1, [rel C2 + 4]
+    mulss xmm1, xmm4
+    addss xmm1, [rel C1 + 8]
+    mulss xmm1, xmm4
+    addss xmm1, [rel C1 + 12]
+    mulss xmm1, xmm4
+    addss xmm1, xmm2
+    mulss xmm1, xmm4
+    addss xmm1, xmm2
+
+    ; now xmm1 = e^r
+
+    add eax, 127
+    shl eax, 23
+    movd xmm2, eax ; now xmm2 is 2^k in IEEE format
+
+    mulss xmm1, xmm2 ; xmm1 = e^r * 2^k = e^x
+    pshufd xmm4, xmm1, 0b00_00_00_00 ; we pack e^x in the first two lanes of xmm4
 %endmacro
 
-%macro accumulate_members 3
-    ; Below implementation depends on SSE2
-    movaps %1, %3
-    pslldq %1, 4
-    movss %1, %2
+%macro sin_cos_taylor 0
+   insertps xmm0, xmm0, 0b01_00_1100
 
-    ; Alternative implementation
-    ; movd eax, %3
-    ; shl rax, 32
-    ; xor rdx, rdx
-    ; movd edx, %2
-    ; or rax, rdx
-    ; movq %1, rax
+   ; xmm0 now holds the angle on the two first lanes
+   ; we calculate sin and cos on both lanes in parallel using SIMD operations
+
+   movaps xmm2, [rel ONE]         ; 1.0f
+   movaps xmm1, [rel TWO_DIV_PI]  ; 2 / PI
+
+   mulps xmm1, xmm0               ; (2 / PI) * angle
+   roundps xmm1, xmm1, FLOOR      ; xmm1 = floor ((2 / PI) * angle) -> the whole number of quadrants
+   cvtss2si eax, xmm1             ; eax mod 4 indicates the quadrant
+
+   ; This follows from:
+   ;
+   ; let the angle be denoted as 2 * PI * r + k, where k < 2 * PI
+   ;
+   ; (2 * PI * r + k) * (2 / PI) = 4 * r + 2 * k / PI
+   ; 4 * r mod 4 == 0 -> (4 * r + 2 * k / PI) mod 4 = (2 * k / PI) mod 4
+   ;
+   ;
+   ; (2 * k / PI) mod 4 == 0 -> 2 * k < PI     -> k < PI / 2     (1º quadrant)
+   ; (2 * k / PI) mod 4 == 1 -> 2 * k < 2 * PI -> k < PI         (2º quadrant)
+   ; (2 * k / PI) mod 4 == 2 -> 2 * k < 3 * PI -> k < 3 * PI / 2 (3º quadrant)
+   ; (2 * k / PI) mod 4 == 3 -> 2 * k < 4 * PI -> k < 2 * PI     (4º quadrant)
+   ;
+   ; since k < 2 * PI, we've exhausted all options
+
+   mulps xmm1, [rel PI_DIV_TWO]  ; xmm1 = floor ((2 / PI) * angle) * (PI / 2)
+   ; now xmm1 holds the angle corresponding to the whole number of quadrants
+
+   subps xmm0, xmm1              ; xmm0 = angle - (floor ((2 / PI) * angle) * (PI / 2))
+   ; now xmm0 holds the residual angle x, reduced to the first quadrant
+
+   ; we go backwards from the last term in the taylor expansion, so that multiplication accumulates correctly
+   ; at the end the factor divided by n! will correspond to x^n
+   movaps xmm1, xmm0
+   mulps xmm1, xmm0
+   movaps xmm3, xmm1
+   ; xmm1 = x^2
+   mulps xmm3, [rel C4]
+   ; sin = (x^2 / 9!), cos = (x^2 / 8!)
+   addps xmm3, [rel C3]
+   ; sin = (x^2 / 9!) - (1 / 7!), cos = (x^2 / 8!) - (1 / 6!)
+   mulps xmm3, xmm1
+   ; sin = (x^4 / 9!) - (x^2 / 7!), cos = (x^4 / 8!) - (x^2 / 6!)
+   addps xmm3, [rel C2]
+   ; sin = (x^4 / 9!) - (x^2 / 7!) + 1 / 5!, cos = (x^4 / 8!) - (x^2 / 6!) + (1 / 4!)
+   mulps xmm3, xmm1
+   ; sin = (x^6 / 9!) - (x^4 / 7!) + (x^2 / 5!), cos = (x^6 / 8!) - (x^4 / 6!) + (x^2 / 4!)
+   addps xmm3, [rel C1]
+   ; sin = (x^6 / 9!) - (x^4 / 7!) + (x^2 / 5!) - (1 / 3!), cos = (x^6 / 8!) - (x^4 / 6!) + (x^2 / 4!) - (1 / 2!)
+   mulps xmm3, xmm1
+   ; sin = (x^8 / 9!) - (x^6 / 7!) + (x^4 / 5!) - (x^2 / 3!), cos = (x^8 / 8!) - (x^6 / 6!) + (x^4 / 4!) - (x^2 / 2!)
+   addps xmm3, xmm2
+   ; sin = (x^8 / 9!) - (x^6 / 7!) + (x^4 / 5!) - (x^2 / 3!) + 1, cos = (x^8 / 8!) - (x^6 / 6!) + (x^4 / 4!) - (x^2 / 2!) + 1
+   mulss xmm3, xmm0
+   ; cos is complete, sin requires one extra multiplication by x
+   ; Result: sin = (x^9 / 9!) - (x^7 / 7!) + (x^5 / 5!) - (x^3 / 3!) + x, cos = (x^8 / 8!) - (x^6 / 6!) + (x^4 / 4!) - (x^2 / 2!) + 1
+
+   ; We have calculated sin and cos for the reduced angle at the first quadrant
+   ; So this is our base case
+   ;
+   ; For the other quadrants, we rely on the following:
+   ; 1. on the second quadrant, cos is negative and sin is positive
+   ; 2. on the third quadrant, cos is negative and sin is negative
+   ; 3. on the fourth quadrant, cos is positive and sin is negative
+   ; 4. sin and cos change places on the second and fourth quadrants.
+   ;
+   ; This last statement follows geometrically, given that:
+   ; 1. sin is the vertical distance formed by the angle on the unit circle
+   ; 2. cos is the horizontal distance formed by the angle on the unit circle
+
+   ; we now save the two lanes of xmm0 and check the quadrant
+   movq rcx, xmm3
+   mov rdx, rcx
+   shr rdx, 32     ; cos
+   mov ecx, ecx    ; sin
+
+   ; ecx will hold the value of sin(x) at the end
+   ; edx will hold the value of cos(x) at the end
+
+   mov r8d, 1
+   shl r8d, 31
+   mov r9d, edx
+   xor r9d, r8d    ; -cos
+   xor r8d, ecx    ; -sin
+
+   and eax, 3      ; mod 4
+
+   ; 4° quadrant
+   cmp eax, 3
+   cmovz edx, ecx  ; sin
+   cmovz ecx, r9d  ; -cos
+
+   ; 3° quadrant
+   cmp eax, 2
+   cmovz ecx, r8d  ; -sin
+   cmovz edx, r9d  ; -cos
+
+   ; 2° quadrant
+   cmp eax, 1
+   cmovz ecx, edx  ; cos
+   cmovz edx, r8d  ; -sin
+
+   ; otherwise, 1° quadrant
+
+   shl rcx, 32     ; sin goes to second lane position
+   or rcx, rdx     ; we accumulate, rcx now holds [ cos, sin ]
+   movq xmm0, rcx  ; we restore in XMM0
 %endmacro
 
 complex_real:
-    ; both real and imag are in xmm0
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; return is real in xmm0's first lane
-    ; where it is already
+    ; result is already in xmm0
     ret
 
 complex_imaginary:
-    ; both real and imag are in xmm0
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; return is imag in xmm0's first lane
-
-    extract_members xmm0, xmm0
-    ret
-
-complex_mul:
-    ; both real and imag are in one single xmm
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; Since there are 2 structs, values are in xmm0 and xmm1
-    ; return is a new struct in xmm0's first two lanes
-
-    ; Below implementation depends on SSE3
-
-    movaps xmm6, xmm1
-    mulps xmm6, xmm0 ; xmm6's first 2 lanes are now:
-                     ; (a * c) and (b * d)
-
-    hsubps xmm6, xmm6 ; xmm6's first lane is now:
-                      ; a * c - d * d
-
-    extract_members xmm2, xmm0
-    extract_members xmm3, xmm1
-
-    mulss xmm2, xmm1 ; b * c
-    mulss xmm3, xmm0 ; a * d
-    addss xmm2, xmm3 ; b * c + a * d
-
-    accumulate_members xmm0, xmm6, xmm2
-
-    ; Alternative implementation
-    ; extract_members xmm2, xmm0
-    ; extract_members xmm3, xmm1
-
-    ; movss xmm4, xmm0
-    ; mulss xmm4, xmm1 ; a*c
-
-    ; movss xmm5, xmm2
-    ; mulss xmm5, xmm3 ; b*d
-
-    ; subss xmm4, xmm5 ; a*c - b*d
-
-    ; mulss xmm2, xmm1 ; b*c
-    ; mulss xmm3, xmm0 ; a*d
-    ; addss xmm2, xmm3 ; b*c + a*d
-
-    ; accumulate_members xmm0, xmm4, xmm2
-    ret
-
-complex_add:
-    ; both real and imag are in one single xmm
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; Since there are 2 structs, values are in xmm0 and xmm1
-    ; return is a new struct in xmm0's first two lanes
-
-    addps xmm0, xmm1
-    ret
-
-complex_sub:
-    ; both real and imag are in one single xmm
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; Since there are 2 structs, values are in xmm0 and xmm1
-    ; return is a new struct in xmm0's first two lanes
-
-    subps xmm0, xmm1
-    ret
-
-complex_div:
-    ; both real and imag are in one single xmm
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; Since there are 2 structs, values are in xmm0 and xmm1
-    ; return is a new struct in xmm0's first two lanes
-
-    ; Below implementation depends on SSE3
-
-    movaps xmm2, xmm1
-    mulps xmm2, xmm0 ; xmm2's first 2 lanes are now:
-                     ; (a * c) and (b * d)
-
-    haddps xmm2, xmm2 ; xmm2's first lane is now:
-                      ; a * c + b * d
-
-    movaps xmm3, xmm1
-    mulps xmm3, xmm3 ; xmm3's first 2 lanes are now:
-                     ; (c²) and (d²)
-
-    haddps xmm3, xmm3 ; xmm3's first lane is now:
-                      ; c² + d²
-
-    divss xmm2, xmm3 ; (a * c + b * d) / (c² + d²) -> real part
-
-    extract_members xmm4, xmm0
-    extract_members xmm5, xmm1
-
-    mulss xmm4, xmm1 ; b * c
-    mulss xmm5, xmm0 ; a * d
-    subss xmm4, xmm5 ; b * c - a * d
-    divss xmm4, xmm3 ; (b * c - a * d) / (c² + d²) -> imag part
-
-    accumulate_members xmm0, xmm2, xmm4
-
-    ; Alternative implementation
-    ;
-    ; extract_members xmm2, xmm0
-    ; extract_members xmm3, xmm1
-
-    ; movss xmm4, xmm1
-    ; mulss xmm4, xmm4 ; c²
-
-    ; movss xmm5, xmm3
-    ; mulss xmm5, xmm5 ; d²
-
-    ; addss xmm4, xmm5 ; c² + d²
-
-    ; movss xmm5, xmm0
-    ; mulss xmm5, xmm1 ; a * c
-
-    ; movss xmm6, xmm2
-    ; mulss xmm6, xmm3 ; b * d
-
-    ; addss xmm5, xmm6 ; a*c + b*d
-
-    ; divss xmm5, xmm4 ; (a*c + b*d) / (c² + d²) -> real part
-
-    ; mulss xmm2, xmm1 ; b*c
-    ; mulss xmm3, xmm0 ; a*d
-    ; subss xmm2, xmm3 ; b*c - a*d
-
-    ; divss xmm2, xmm4 ; (b * c - a * d) / (c² + d²) -> imag part
-
-    ; accumulate_members xmm0, xmm5, xmm2
+    insertps xmm0, xmm0, 0b01_00_1110
     ret
 
 complex_abs:
-    ; both real and imag are in one single xmm
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; return is a (real² + imag²)⁽⁰·⁵⁾ as a float in xmm0
-
-    ; Below implementation depends on SSE3
-
-    mulps xmm0, xmm0 ; xmm0's first 2 lanes are now:
-                     ; (a²) and (b²)
-
-    haddps xmm0, xmm0 ; xmm0's first lane is now:
-                      ; a² + b²
-
-    sqrtss xmm0, xmm0 ; xmm0's first lane is now:
-                      ; sqrt(a² + b²)
-
-    ; Alternative implementation
-    ; extract_members xmm1, xmm0
-    ; mulss xmm1, xmm1
-    ; mulss xmm0, xmm0
-    ; addss xmm0, xmm1
-    ; sqrtss xmm0, xmm0
+    mulps xmm0, xmm0
+    pshufd xmm1, xmm0, 0b00_00_00_01
+    addps xmm0, xmm1
+    sqrtss xmm0, xmm0
     ret
 
 complex_conjugate:
-    ; both real and imag are in one single xmm
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; return is a new struct with imag part negated, in xmm0
-
-    movss xmm1, dword [negate_mask]
-    pslldq xmm1, 4
-    xorps xmm0, xmm1
-    ret
-
-; 3 helpers for calculating complex_exp:
-; A-> exp_taylor: calculates e^a, where a is a float
-; B-> cos_taylor: calculates cos(x), where x is in radians (a float)
-; C-> sin_taylor: calculates sin(x), where x is in radians (a float)
-;
-; They all use a taylor expansion, but accumulating the factorial
-; to avoid unnecessary duplication of work
-;
-; Instead of checking for precision each iteration, they all loop
-; until the end of max iterations, which were set as 10
-
-exp_taylor:
-    mov rax, 1 ; n
-    cvtsi2ss xmm4, eax ; term
-    movss xmm5, xmm4 ; sum
-    mov rcx, 10 ; num of iterations
-.loop:
-    movss xmm6, xmm2
-    cvtsi2ss xmm7, eax
-
-    divss xmm6, xmm7 ; x / n
-    mulss xmm4, xmm6 ; term *= x / n
-    addss xmm5, xmm4 ; sum += term
-
-    inc eax ; n++
-    loop .loop
-
-    movss xmm2, xmm5 ; return sum
-    ret
-
-cos_taylor:
-    mov rax, 1 ; n
-    cvtsi2ss xmm4, eax ; term
-    movss xmm5, xmm4 ; sum
-    mov rcx, 10 ; num of iterations
-
-    movss xmm6, xmm2
-    mulss xmm6, xmm6 ; x²
-.loop:
-    mov r8, rax
-    shl r8, 1 ; 2*n
-    lea r9, [r8 - 1]
-    imul r9, r8 ; (2*n - 1) * 2*n
-    cvtsi2ss xmm7, r9d
-
-    movss xmm8, xmm6
-    divss xmm8, xmm7 ; x² / ((2*n - 1) * 2*n)
-
-    movss xmm7, dword [negate_mask]
-    xorps xmm8, xmm7 ; - x² / ((2*n - 1) * 2*n)
-
-    mulss xmm4, xmm8 ; term *= - x² / ((2*n - 1) * 2*n)
-    addss xmm5, xmm4 ; sum += term
-
-    inc eax ; n++
-    loop .loop
-
-    movss xmm2, xmm5 ; return sum
-    ret
-
-sin_taylor:
-    movmskps r10d, xmm2
-    bt r10d, 0
-    jnc .positive
-
-    movss xmm7, dword [negate_mask]
-    andps xmm2, xmm7
-
-.positive:
-    mov rax, 1 ; n
-    movss xmm4, xmm2 ; term
-    movss xmm5, xmm4 ; sum
-    mov rcx, 10 ; num of iterations
-
-    movss xmm6, xmm2
-    mulss xmm6, xmm6 ; x²
-.loop:
-    mov r8, rax
-    shl r8, 1 ; 2*n
-    lea r9, [r8 + 1] ; 2*n + 1
-    imul r9, r8 ; (2*n + 1) * 2*n
-    cvtsi2ss xmm7, r9d
-
-    movss xmm8, xmm6
-
-    divss xmm8, xmm7 ; x² / ((2*n + 1) * 2*n)
-
-    movss xmm7, dword [negate_mask]
-    xorps xmm8, xmm7 ; - x² / ((2*n + 1) * 2*n)
-
-    mulss xmm4, xmm8 ; term *= - x² / ((2*n + 1) * 2*n)
-    addss xmm5, xmm4 ; sum += term
-
-    inc eax ; n++
-    loop .loop
-
-    movss xmm2, xmm5
-
-    bt r10d, 0
-    jnc .end ; if sign not set, return sum
-    ; otherwise return -sum
-
-    movss xmm7, dword [negate_mask]
-    xorps xmm2, xmm7
-.end:
+    xorps xmm0, [rel SIGN_MASK]
     ret
 
 complex_exp:
-    ; both real and imag are in one single xmm
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; return is a new struct in xmm0
-
-    extract_members xmm1, xmm0
-
-    movss xmm2, xmm0 ; a
-    call exp_taylor
-    movss xmm0, xmm2 ; e^a
-
-    movss xmm2, xmm1 ; b
-    call cos_taylor
-    movss xmm3, xmm2
-    mulss xmm3, xmm0 ; e^a * cos(b) -> real part
-
-    movss xmm2, xmm1 ; b
-    call sin_taylor
-    mulss xmm2, xmm0 ; e^a * sin(b) -> imag part
-
-    accumulate_members xmm0, xmm3, xmm2
-    ret
-
-complex_real_add:
-    ; XMM0 - first number (as a complex_t)
-    ; XMM1 - second number (as a float)
-    ; both real and imag are in one single xmm
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; return is a complex in XMM0
-
-    xorps xmm2, xmm2
-    movss xmm2, xmm1
-    addps xmm0, xmm2
+    movaps xmm4, xmm0
+    exp_taylor
+    sin_cos_taylor
+    mulps xmm0, xmm4
     ret
 
 real_complex_add:
-    ; XMM0 - first number (as a float)
-    ; XMM1 - second number (as a complex_t)
-    ; both real and imag are in one single xmm
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; return is a complex in XMM0
-
-    xorps xmm2, xmm2
-    movss xmm2, xmm0
-    addps xmm2, xmm1
-    movaps xmm0, xmm2
-    ret
-
-complex_real_sub:
-    ; XMM0 - first number (as a complex_t)
-    ; XMM1 - second number (as a float)
-    ; both real and imag are in one single xmm
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; return is a complex in XMM0
-
-    xorps xmm2, xmm2
-    movss xmm2, xmm1
-    subps xmm0, xmm2
+    insertps xmm0, xmm0, 0b00_00_1110
+    jmp complex_add
+complex_real_add:
+    insertps xmm1, xmm1, 0b00_00_1110
+complex_add:
+    addps xmm0, xmm1
     ret
 
 real_complex_sub:
-    ; XMM0 - first number (as a float)
-    ; XMM1 - second number (as a complex_t)
-    ; both real and imag are in one single xmm
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; return is a complex in XMM0
-
-    xorps xmm2, xmm2
-    movss xmm2, xmm0
-    subps xmm2, xmm1
-    movaps xmm0, xmm2
+    insertps xmm0, xmm0, 0b00_00_1110
+    jmp complex_sub
+complex_real_sub:
+    insertps xmm1, xmm1, 0b00_00_1110
+complex_sub:
+    subps xmm0, xmm1
     ret
 
-complex_real_mul:
-    ; XMM0 - first number (as a complex_t)
-    ; XMM1 - second number (as a float)
-    ; both real and imag are in one single xmm
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; return is a complex in XMM0
-
-    xorps xmm2, xmm2
-    movss xmm2, xmm1
-    movaps xmm1, xmm2
-    jmp complex_mul
-
 real_complex_mul:
-    ; XMM0 - first number (as a float)
-    ; XMM1 - second number (as a complex_t)
-    ; both real and imag are in one single xmm
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; return is a complex in XMM0
-
-    xorps xmm2, xmm2
-    movss xmm2, xmm0
-    movaps xmm0, xmm2
+    insertps xmm0, xmm0, 0b00_00_1110
     jmp complex_mul
-
-complex_real_div:
-    ; XMM0 - first number (as a complex_t)
-    ; XMM1 - second number (as a float)
-    ; both real and imag are in one single xmm
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; return is a complex in XMM0
-
-    xorps xmm2, xmm2
-    movss xmm2, xmm1
-    movaps xmm1, xmm2
-    jmp complex_div
+complex_real_mul:
+    insertps xmm1, xmm1, 0b00_00_1110
+complex_mul:
+    pshufd xmm0, xmm0, 0b00_01_01_00 ; [a, b, b, a]
+    pshufd xmm1, xmm1, 0b01_01_00_00 ; [c, c, d, d]
+    mulps xmm0, xmm1                 ; [a*c, b*c, b*d, a*d]
+    pshufd xmm1, xmm0, 0b00_00_11_10 ; [b*d, a*d, _, _]
+    addsubps xmm0, xmm1
+    ret
 
 real_complex_div:
-    ; XMM0 - first number (as a float)
-    ; XMM1 - second number (as a complex_t)
-    ; both real and imag are in one single xmm
-    ; real -> first lane (32-bit)
-    ; imag -> second lane (32-bit)
-    ; return is a complex in XMM0
-
-    xorps xmm2, xmm2
-    movss xmm2, xmm0
-    movaps xmm0, xmm2
+    insertps xmm0, xmm0, 0b00_00_1110
     jmp complex_div
+complex_real_div:
+    insertps xmm1, xmm1, 0b00_00_1110
+complex_div:
+    movaps xmm2, xmm1
+    mulps xmm2, xmm1
+    pshufd xmm3, xmm2, 0b00_00_00_01
+    addps xmm2, xmm3
+    pshufd xmm0, xmm0, 0b01_00_00_01    ; [b, a, a, b]
+    pshufd xmm1, xmm1, 0b01_01_00_00    ; [c, c, d, d]
+    mulps xmm0, xmm1                    ; [b*c, a*c, a*d, b*d]
+    pshufd xmm1, xmm0, 0b00_00_11_10    ; [a*d, b*d, _, _]
+    addsubps xmm0, xmm1                 ; [b*c - a*d, a*c + b*d]
+    divps xmm0, xmm2                    ; [(b*c - a*d)/(c^2 + d^2), (a*c + b*d)/(c^2 + d^2)]
+    pshufd xmm0, xmm0, 0b00_00_00_01    ; swap -> [(a*c + b*d)/(c^2 + d^2), (b*c - a*d)/(c^2 + d^2)]
+    ret
 
 %ifidn __OUTPUT_FORMAT__,elf64
 section .note.GNU-stack noalloc noexec nowrite progbits

--- a/exercises/practice/complex-numbers/.meta/example.asm
+++ b/exercises/practice/complex-numbers/.meta/example.asm
@@ -21,8 +21,12 @@ C4:   dd 2.7557319223985893e-06        ; 1 / 9!
       dd 2.4801587301587302e-05        ; 1 / 8!
       times 2 dd 0
 
-TWO_DIV_PI: times 4 dd 0.6366197723675814     ; 2 / PI
-PI_DIV_TWO: times 4 dd 1.5707963705062866     ; PI / 2
+C5:   dd -2.5052108385441720e-08       ; -1 / 11!
+      dd -2.7557319223985890e-07       ; -1 / 10!
+      times 2 dd 0
+
+TWO_DIV_PI: times 4 dd 0.63661977236   ; 2 / PI
+PI_DIV_TWO: times 4 dd 1.57079632679   ; PI / 2
 ONE: times 4 dd 1.0
 
 ONE_DIV_LOG2: dd 1.4426950408889634
@@ -153,25 +157,21 @@ global real_complex_div
    mulps xmm1, xmm0
    movaps xmm3, xmm1
    ; xmm1 = x^2
-   mulps xmm3, [rel C4]
-   ; sin = (x^2 / 9!), cos = (x^2 / 8!)
+   mulps  xmm3, [rel C5]
+   ; sin = -(x^2 / 11!), cos = -(x^2 / 10!)
+   addps  xmm3, [rel C4]
+   ; sin = -(x^2 / 11!) + 1/9!, cos = -(x^2 / 10!) + 1/8!
+   mulps  xmm3, xmm1
+   ; sin = -(x^4 / 11!) + (x^2 / 9!), cos = -(x^4 / 10!) + (x^2 / 8!)
+   ; and so on...
    addps xmm3, [rel C3]
-   ; sin = (x^2 / 9!) - (1 / 7!), cos = (x^2 / 8!) - (1 / 6!)
    mulps xmm3, xmm1
-   ; sin = (x^4 / 9!) - (x^2 / 7!), cos = (x^4 / 8!) - (x^2 / 6!)
    addps xmm3, [rel C2]
-   ; sin = (x^4 / 9!) - (x^2 / 7!) + 1 / 5!, cos = (x^4 / 8!) - (x^2 / 6!) + (1 / 4!)
    mulps xmm3, xmm1
-   ; sin = (x^6 / 9!) - (x^4 / 7!) + (x^2 / 5!), cos = (x^6 / 8!) - (x^4 / 6!) + (x^2 / 4!)
    addps xmm3, [rel C1]
-   ; sin = (x^6 / 9!) - (x^4 / 7!) + (x^2 / 5!) - (1 / 3!), cos = (x^6 / 8!) - (x^4 / 6!) + (x^2 / 4!) - (1 / 2!)
    mulps xmm3, xmm1
-   ; sin = (x^8 / 9!) - (x^6 / 7!) + (x^4 / 5!) - (x^2 / 3!), cos = (x^8 / 8!) - (x^6 / 6!) + (x^4 / 4!) - (x^2 / 2!)
    addps xmm3, xmm2
-   ; sin = (x^8 / 9!) - (x^6 / 7!) + (x^4 / 5!) - (x^2 / 3!) + 1, cos = (x^8 / 8!) - (x^6 / 6!) + (x^4 / 4!) - (x^2 / 2!) + 1
-   mulss xmm3, xmm0
-   ; cos is complete, sin requires one extra multiplication by x
-   ; Result: sin = (x^9 / 9!) - (x^7 / 7!) + (x^5 / 5!) - (x^3 / 3!) + x, cos = (x^8 / 8!) - (x^6 / 6!) + (x^4 / 4!) - (x^2 / 2!) + 1
+   mulss xmm3, xmm0 ; cos is complete, sin requires one extra multiplication by x
 
    ; We have calculated sin and cos for the reduced angle at the first quadrant
    ; So this is our base case

--- a/exercises/practice/complex-numbers/complex_numbers_test.c
+++ b/exercises/practice/complex-numbers/complex_numbers_test.c
@@ -9,6 +9,17 @@
         TEST_ASSERT_FLOAT_WITHIN(_tl, (x), (y));      \
     } while (0)
 
+#define ASSERT_COMPLEX(xr, xi, yr, yi)               \
+    do {                                             \
+        float _abxr = (xr) < 0 ? -(xr) : (xr);       \
+        float _abxi = (xi) < 0 ? -(xi) : (xi);       \
+        float _dist = _abxr > _abxi ? _abxr : _abxi; \
+        float _dt = 0.0001f * _dist;                 \
+        float _tl = _dt > 0.00001f ? _dt : 0.00001f; \
+        TEST_ASSERT_FLOAT_WITHIN(_tl, (xr), (yr));   \
+        TEST_ASSERT_FLOAT_WITHIN(_tl, (xi), (yi));   \
+    } while (0)
+
 typedef struct {
     float real;
     float imag;
@@ -104,8 +115,7 @@ void test_imaginary_unit(void) {
     const complex_t result = complex_mul(z1, z2);
     const complex_t expected = {-1, 0};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_add_purely_real_numbers(void) {
@@ -116,8 +126,7 @@ void test_add_purely_real_numbers(void) {
     const complex_t result = complex_add(z1, z2);
     const complex_t expected = {3, 0};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_add_purely_imaginary_numbers(void) {
@@ -128,8 +137,7 @@ void test_add_purely_imaginary_numbers(void) {
     const complex_t result = complex_add(z1, z2);
     const complex_t expected = {0, 3};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_add_numbers_with_real_and_imaginary_part(void) {
@@ -140,8 +148,7 @@ void test_add_numbers_with_real_and_imaginary_part(void) {
     const complex_t result = complex_add(z1, z2);
     const complex_t expected = {4, 6};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_subtract_purely_real_numbers(void) {
@@ -152,8 +159,7 @@ void test_subtract_purely_real_numbers(void) {
     const complex_t result = complex_sub(z1, z2);
     const complex_t expected = {-1, 0};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_subtract_purely_imaginary_numbers(void) {
@@ -164,8 +170,7 @@ void test_subtract_purely_imaginary_numbers(void) {
     const complex_t result = complex_sub(z1, z2);
     const complex_t expected = {0, -1};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_subtract_numbers_with_real_and_imaginary_part(void) {
@@ -176,8 +181,7 @@ void test_subtract_numbers_with_real_and_imaginary_part(void) {
     const complex_t result = complex_sub(z1, z2);
     const complex_t expected = {-2, -2};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_multiply_purely_real_numbers(void) {
@@ -188,8 +192,7 @@ void test_multiply_purely_real_numbers(void) {
     const complex_t result = complex_mul(z1, z2);
     const complex_t expected = {2, 0};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_multiply_purely_imaginary_numbers(void) {
@@ -200,8 +203,7 @@ void test_multiply_purely_imaginary_numbers(void) {
     const complex_t result = complex_mul(z1, z2);
     const complex_t expected = {-2, 0};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_multiply_numbers_with_real_and_imaginary_part(void) {
@@ -212,8 +214,7 @@ void test_multiply_numbers_with_real_and_imaginary_part(void) {
     const complex_t result = complex_mul(z1, z2);
     const complex_t expected = {-5, 10};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_divide_purely_real_numbers(void) {
@@ -224,8 +225,7 @@ void test_divide_purely_real_numbers(void) {
     const complex_t result = complex_div(z1, z2);
     const complex_t expected = {0.5, 0};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_divide_purely_imaginary_numbers(void) {
@@ -236,8 +236,7 @@ void test_divide_purely_imaginary_numbers(void) {
     const complex_t result = complex_div(z1, z2);
     const complex_t expected = {0.5, 0};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_divide_numbers_with_real_and_imaginary_part(void) {
@@ -248,8 +247,7 @@ void test_divide_numbers_with_real_and_imaginary_part(void) {
     const complex_t result = complex_div(z1, z2);
     const complex_t expected = {0.44, 0.08};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_absolute_value_of_a_positive_purely_real_number(void) {
@@ -309,8 +307,7 @@ void test_conjugate_a_purely_real_number(void) {
     const complex_t result = complex_conjugate(z);
     const complex_t expected = {5, 0};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_conjugate_a_purely_imaginary_number(void) {
@@ -320,8 +317,7 @@ void test_conjugate_a_purely_imaginary_number(void) {
     const complex_t result = complex_conjugate(z);
     const complex_t expected = {0, -5};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_conjugate_a_number_with_real_and_imaginary_part(void) {
@@ -331,8 +327,7 @@ void test_conjugate_a_number_with_real_and_imaginary_part(void) {
     const complex_t result = complex_conjugate(z);
     const complex_t expected = {1, -1};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_eulers_identityformula(void) {
@@ -342,8 +337,7 @@ void test_eulers_identityformula(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {-1, 0};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_exponential_of_0(void) {
@@ -353,8 +347,7 @@ void test_exponential_of_0(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {1, 0};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_exponential_of_a_purely_real_number(void) {
@@ -364,8 +357,7 @@ void test_exponential_of_a_purely_real_number(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {2.718281828459045, 0};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_exponential_of_a_number_with_real_and_imaginary_part(void) {
@@ -375,8 +367,7 @@ void test_exponential_of_a_number_with_real_and_imaginary_part(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {-2, 0};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_exponential_resulting_in_a_number_with_real_and_imaginary_part(void) {
@@ -386,8 +377,7 @@ void test_exponential_resulting_in_a_number_with_real_and_imaginary_part(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {1, 1};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_add_real_number_to_complex_number(void) {
@@ -398,8 +388,7 @@ void test_add_real_number_to_complex_number(void) {
     const complex_t result = complex_real_add(z1, z2);
     const complex_t expected = {6, 2};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_add_complex_number_to_real_number(void) {
@@ -410,8 +399,7 @@ void test_add_complex_number_to_real_number(void) {
     const complex_t result = real_complex_add(z1, z2);
     const complex_t expected = {6, 2};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_subtract_real_number_from_complex_number(void) {
@@ -422,8 +410,7 @@ void test_subtract_real_number_from_complex_number(void) {
     const complex_t result = complex_real_sub(z1, z2);
     const complex_t expected = {1, 7};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_subtract_complex_number_from_real_number(void) {
@@ -434,8 +421,7 @@ void test_subtract_complex_number_from_real_number(void) {
     const complex_t result = real_complex_sub(z1, z2);
     const complex_t expected = {-1, -7};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_multiply_complex_number_by_real_number(void) {
@@ -446,8 +432,7 @@ void test_multiply_complex_number_by_real_number(void) {
     const complex_t result = complex_real_mul(z1, z2);
     const complex_t expected = {10, 25};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_multiply_real_number_by_complex_number(void) {
@@ -458,8 +443,7 @@ void test_multiply_real_number_by_complex_number(void) {
     const complex_t result = real_complex_mul(z1, z2);
     const complex_t expected = {10, 25};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_divide_complex_number_by_real_number(void) {
@@ -470,8 +454,7 @@ void test_divide_complex_number_by_real_number(void) {
     const complex_t result = complex_real_div(z1, z2);
     const complex_t expected = {1, 10};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_divide_real_number_by_complex_number(void) {
@@ -482,8 +465,7 @@ void test_divide_real_number_by_complex_number(void) {
     const complex_t result = real_complex_div(z1, z2);
     const complex_t expected = {2.5, -2.5};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_exponential_with_a_large_real_part_magnitude_e5_both_components_sizable(void) {
@@ -493,8 +475,7 @@ void test_exponential_with_a_large_real_part_magnitude_e5_both_components_sizabl
     const complex_t result = complex_exp(z);
     const complex_t expected = {80.187972, 124.885367};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_exponential_with_a_large_real_part_magnitude_e7_secondquadrant_angle(void) {
@@ -504,8 +485,7 @@ void test_exponential_with_a_large_real_part_magnitude_e7_secondquadrant_angle(v
     const complex_t result = complex_exp(z);
     const complex_t expected = {-456.36042, 997.165709};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_exponential_with_a_large_real_part_magnitude_e6_negative_angle(void) {
@@ -515,8 +495,7 @@ void test_exponential_with_a_large_real_part_magnitude_e6_negative_angle(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {-167.885616, -366.836764};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 void test_exponential_with_a_large_real_part_magnitude_e4_fourthquadrant_angle(void) {
@@ -526,8 +505,47 @@ void test_exponential_with_a_large_real_part_magnitude_e4_fourthquadrant_angle(v
     const complex_t result = complex_exp(z);
     const complex_t expected = {-43.740959, -32.675472};
 
-    ASSERT_FLOAT(expected.real, result.real);
-    ASSERT_FLOAT(expected.imag, result.imag);
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
+}
+
+void test_regression_residual_angle_near_pi2_failed_before_sincos_fix(void) {
+    TEST_IGNORE();
+
+    const complex_t z = {-0.3, 1.5};
+    const complex_t result = complex_exp(z);
+    const complex_t expected = {0.052403, 0.738962};
+
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
+}
+
+void test_regression_residual_angle_near_pi2_second_case(void) {
+    TEST_IGNORE();
+
+    const complex_t z = {-0.2, 1.5};
+    const complex_t result = complex_exp(z);
+    const complex_t expected = {0.057915, 0.81668};
+
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
+}
+
+void test_regression_thirdquadrant_angle_nearzero_second_component(void) {
+    TEST_IGNORE();
+
+    const complex_t z = {-0.1, -3.25};
+    const complex_t result = complex_exp(z);
+    const complex_t expected = {-0.899526, 0.097899};
+
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
+}
+
+void test_regression_residual_angle_near_pi2_third_case(void) {
+    TEST_IGNORE();
+
+    const complex_t z = {-0.1, 1.5};
+    const complex_t result = complex_exp(z);
+    const complex_t expected = {0.064006, 0.902571};
+
+    ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 }
 
 int main(void) {
@@ -576,5 +594,9 @@ int main(void) {
     RUN_TEST(test_exponential_with_a_large_real_part_magnitude_e7_secondquadrant_angle);
     RUN_TEST(test_exponential_with_a_large_real_part_magnitude_e6_negative_angle);
     RUN_TEST(test_exponential_with_a_large_real_part_magnitude_e4_fourthquadrant_angle);
+    RUN_TEST(test_regression_residual_angle_near_pi2_failed_before_sincos_fix);
+    RUN_TEST(test_regression_residual_angle_near_pi2_second_case);
+    RUN_TEST(test_regression_thirdquadrant_angle_nearzero_second_component);
+    RUN_TEST(test_regression_residual_angle_near_pi2_third_case);
     return UNITY_END();
 }

--- a/exercises/practice/complex-numbers/complex_numbers_test.c
+++ b/exercises/practice/complex-numbers/complex_numbers_test.c
@@ -2,6 +2,13 @@
 
 #include <stddef.h>
 
+#define ASSERT_FLOAT(x, y)                            \
+    do {                                              \
+        float _dt = 0.0001f * ((x) < 0 ? -(x) : (x)); \
+        float _tl = _dt > 0.00001f ? _dt : 0.00001f;  \
+        TEST_ASSERT_FLOAT_WITHIN(_tl, (x), (y));      \
+    } while (0)
+
 typedef struct {
     float real;
     float imag;
@@ -34,8 +41,9 @@ void tearDown(void) {
 void test_real_part_of_a_purely_real_number(void) {
     const complex_t z = {1, 0};
     const float result = complex_real(z);
+    const float expected = 1;
 
-    TEST_ASSERT_EQUAL_FLOAT(1, result);
+    ASSERT_FLOAT(expected, result);
 }
 
 void test_real_part_of_a_purely_imaginary_number(void) {
@@ -43,8 +51,9 @@ void test_real_part_of_a_purely_imaginary_number(void) {
 
     const complex_t z = {0, 1};
     const float result = complex_real(z);
+    const float expected = 0;
 
-    TEST_ASSERT_EQUAL_FLOAT(0, result);
+    ASSERT_FLOAT(expected, result);
 }
 
 void test_real_part_of_a_number_with_real_and_imaginary_part(void) {
@@ -52,8 +61,9 @@ void test_real_part_of_a_number_with_real_and_imaginary_part(void) {
 
     const complex_t z = {1, 2};
     const float result = complex_real(z);
+    const float expected = 1;
 
-    TEST_ASSERT_EQUAL_FLOAT(1, result);
+    ASSERT_FLOAT(expected, result);
 }
 
 void test_imaginary_part_of_a_purely_real_number(void) {
@@ -61,8 +71,9 @@ void test_imaginary_part_of_a_purely_real_number(void) {
 
     const complex_t z = {1, 0};
     const float result = complex_imaginary(z);
+    const float expected = 0;
 
-    TEST_ASSERT_EQUAL_FLOAT(0, result);
+    ASSERT_FLOAT(expected, result);
 }
 
 void test_imaginary_part_of_a_purely_imaginary_number(void) {
@@ -70,8 +81,9 @@ void test_imaginary_part_of_a_purely_imaginary_number(void) {
 
     const complex_t z = {0, 1};
     const float result = complex_imaginary(z);
+    const float expected = 1;
 
-    TEST_ASSERT_EQUAL_FLOAT(1, result);
+    ASSERT_FLOAT(expected, result);
 }
 
 void test_imaginary_part_of_a_number_with_real_and_imaginary_part(void) {
@@ -79,8 +91,9 @@ void test_imaginary_part_of_a_number_with_real_and_imaginary_part(void) {
 
     const complex_t z = {1, 2};
     const float result = complex_imaginary(z);
+    const float expected = 2;
 
-    TEST_ASSERT_EQUAL_FLOAT(2, result);
+    ASSERT_FLOAT(expected, result);
 }
 
 void test_imaginary_unit(void) {
@@ -91,8 +104,8 @@ void test_imaginary_unit(void) {
     const complex_t result = complex_mul(z1, z2);
     const complex_t expected = {-1, 0};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_add_purely_real_numbers(void) {
@@ -103,8 +116,8 @@ void test_add_purely_real_numbers(void) {
     const complex_t result = complex_add(z1, z2);
     const complex_t expected = {3, 0};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_add_purely_imaginary_numbers(void) {
@@ -115,8 +128,8 @@ void test_add_purely_imaginary_numbers(void) {
     const complex_t result = complex_add(z1, z2);
     const complex_t expected = {0, 3};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_add_numbers_with_real_and_imaginary_part(void) {
@@ -127,8 +140,8 @@ void test_add_numbers_with_real_and_imaginary_part(void) {
     const complex_t result = complex_add(z1, z2);
     const complex_t expected = {4, 6};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_subtract_purely_real_numbers(void) {
@@ -139,8 +152,8 @@ void test_subtract_purely_real_numbers(void) {
     const complex_t result = complex_sub(z1, z2);
     const complex_t expected = {-1, 0};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_subtract_purely_imaginary_numbers(void) {
@@ -151,8 +164,8 @@ void test_subtract_purely_imaginary_numbers(void) {
     const complex_t result = complex_sub(z1, z2);
     const complex_t expected = {0, -1};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_subtract_numbers_with_real_and_imaginary_part(void) {
@@ -163,8 +176,8 @@ void test_subtract_numbers_with_real_and_imaginary_part(void) {
     const complex_t result = complex_sub(z1, z2);
     const complex_t expected = {-2, -2};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_multiply_purely_real_numbers(void) {
@@ -175,8 +188,8 @@ void test_multiply_purely_real_numbers(void) {
     const complex_t result = complex_mul(z1, z2);
     const complex_t expected = {2, 0};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_multiply_purely_imaginary_numbers(void) {
@@ -187,8 +200,8 @@ void test_multiply_purely_imaginary_numbers(void) {
     const complex_t result = complex_mul(z1, z2);
     const complex_t expected = {-2, 0};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_multiply_numbers_with_real_and_imaginary_part(void) {
@@ -199,8 +212,8 @@ void test_multiply_numbers_with_real_and_imaginary_part(void) {
     const complex_t result = complex_mul(z1, z2);
     const complex_t expected = {-5, 10};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_divide_purely_real_numbers(void) {
@@ -211,8 +224,8 @@ void test_divide_purely_real_numbers(void) {
     const complex_t result = complex_div(z1, z2);
     const complex_t expected = {0.5, 0};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_divide_purely_imaginary_numbers(void) {
@@ -223,8 +236,8 @@ void test_divide_purely_imaginary_numbers(void) {
     const complex_t result = complex_div(z1, z2);
     const complex_t expected = {0.5, 0};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_divide_numbers_with_real_and_imaginary_part(void) {
@@ -235,8 +248,8 @@ void test_divide_numbers_with_real_and_imaginary_part(void) {
     const complex_t result = complex_div(z1, z2);
     const complex_t expected = {0.44, 0.08};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_absolute_value_of_a_positive_purely_real_number(void) {
@@ -244,8 +257,9 @@ void test_absolute_value_of_a_positive_purely_real_number(void) {
 
     const complex_t z = {5, 0};
     const float result = complex_abs(z);
+    const float expected = 5;
 
-    TEST_ASSERT_EQUAL_FLOAT(5, result);
+    ASSERT_FLOAT(expected, result);
 }
 
 void test_absolute_value_of_a_negative_purely_real_number(void) {
@@ -253,8 +267,9 @@ void test_absolute_value_of_a_negative_purely_real_number(void) {
 
     const complex_t z = {-5, 0};
     const float result = complex_abs(z);
+    const float expected = 5;
 
-    TEST_ASSERT_EQUAL_FLOAT(5, result);
+    ASSERT_FLOAT(expected, result);
 }
 
 void test_absolute_value_of_a_purely_imaginary_number_with_positive_imaginary_part(void) {
@@ -262,8 +277,9 @@ void test_absolute_value_of_a_purely_imaginary_number_with_positive_imaginary_pa
 
     const complex_t z = {0, 5};
     const float result = complex_abs(z);
+    const float expected = 5;
 
-    TEST_ASSERT_EQUAL_FLOAT(5, result);
+    ASSERT_FLOAT(expected, result);
 }
 
 void test_absolute_value_of_a_purely_imaginary_number_with_negative_imaginary_part(void) {
@@ -271,8 +287,9 @@ void test_absolute_value_of_a_purely_imaginary_number_with_negative_imaginary_pa
 
     const complex_t z = {0, -5};
     const float result = complex_abs(z);
+    const float expected = 5;
 
-    TEST_ASSERT_EQUAL_FLOAT(5, result);
+    ASSERT_FLOAT(expected, result);
 }
 
 void test_absolute_value_of_a_number_with_real_and_imaginary_part(void) {
@@ -280,8 +297,9 @@ void test_absolute_value_of_a_number_with_real_and_imaginary_part(void) {
 
     const complex_t z = {3, 4};
     const float result = complex_abs(z);
+    const float expected = 5;
 
-    TEST_ASSERT_EQUAL_FLOAT(5, result);
+    ASSERT_FLOAT(expected, result);
 }
 
 void test_conjugate_a_purely_real_number(void) {
@@ -291,8 +309,8 @@ void test_conjugate_a_purely_real_number(void) {
     const complex_t result = complex_conjugate(z);
     const complex_t expected = {5, 0};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_conjugate_a_purely_imaginary_number(void) {
@@ -302,8 +320,8 @@ void test_conjugate_a_purely_imaginary_number(void) {
     const complex_t result = complex_conjugate(z);
     const complex_t expected = {0, -5};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_conjugate_a_number_with_real_and_imaginary_part(void) {
@@ -313,8 +331,8 @@ void test_conjugate_a_number_with_real_and_imaginary_part(void) {
     const complex_t result = complex_conjugate(z);
     const complex_t expected = {1, -1};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_eulers_identityformula(void) {
@@ -324,8 +342,8 @@ void test_eulers_identityformula(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {-1, 0};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_exponential_of_0(void) {
@@ -335,8 +353,8 @@ void test_exponential_of_0(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {1, 0};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_exponential_of_a_purely_real_number(void) {
@@ -346,8 +364,8 @@ void test_exponential_of_a_purely_real_number(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {2.718281828459045, 0};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_exponential_of_a_number_with_real_and_imaginary_part(void) {
@@ -357,8 +375,8 @@ void test_exponential_of_a_number_with_real_and_imaginary_part(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {-2, 0};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_exponential_resulting_in_a_number_with_real_and_imaginary_part(void) {
@@ -368,8 +386,8 @@ void test_exponential_resulting_in_a_number_with_real_and_imaginary_part(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {1, 1};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_add_real_number_to_complex_number(void) {
@@ -380,8 +398,8 @@ void test_add_real_number_to_complex_number(void) {
     const complex_t result = complex_real_add(z1, z2);
     const complex_t expected = {6, 2};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_add_complex_number_to_real_number(void) {
@@ -392,8 +410,8 @@ void test_add_complex_number_to_real_number(void) {
     const complex_t result = real_complex_add(z1, z2);
     const complex_t expected = {6, 2};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_subtract_real_number_from_complex_number(void) {
@@ -404,8 +422,8 @@ void test_subtract_real_number_from_complex_number(void) {
     const complex_t result = complex_real_sub(z1, z2);
     const complex_t expected = {1, 7};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_subtract_complex_number_from_real_number(void) {
@@ -416,8 +434,8 @@ void test_subtract_complex_number_from_real_number(void) {
     const complex_t result = real_complex_sub(z1, z2);
     const complex_t expected = {-1, -7};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_multiply_complex_number_by_real_number(void) {
@@ -428,8 +446,8 @@ void test_multiply_complex_number_by_real_number(void) {
     const complex_t result = complex_real_mul(z1, z2);
     const complex_t expected = {10, 25};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_multiply_real_number_by_complex_number(void) {
@@ -440,8 +458,8 @@ void test_multiply_real_number_by_complex_number(void) {
     const complex_t result = real_complex_mul(z1, z2);
     const complex_t expected = {10, 25};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_divide_complex_number_by_real_number(void) {
@@ -452,8 +470,8 @@ void test_divide_complex_number_by_real_number(void) {
     const complex_t result = complex_real_div(z1, z2);
     const complex_t expected = {1, 10};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_divide_real_number_by_complex_number(void) {
@@ -464,8 +482,8 @@ void test_divide_real_number_by_complex_number(void) {
     const complex_t result = real_complex_div(z1, z2);
     const complex_t expected = {2.5, -2.5};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_exponential_with_a_large_real_part_magnitude_e5_both_components_sizable(void) {
@@ -475,8 +493,8 @@ void test_exponential_with_a_large_real_part_magnitude_e5_both_components_sizabl
     const complex_t result = complex_exp(z);
     const complex_t expected = {80.187972, 124.885367};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_exponential_with_a_large_real_part_magnitude_e7_secondquadrant_angle(void) {
@@ -486,8 +504,8 @@ void test_exponential_with_a_large_real_part_magnitude_e7_secondquadrant_angle(v
     const complex_t result = complex_exp(z);
     const complex_t expected = {-456.36042, 997.165709};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_exponential_with_a_large_real_part_magnitude_e6_negative_angle(void) {
@@ -497,8 +515,8 @@ void test_exponential_with_a_large_real_part_magnitude_e6_negative_angle(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {-167.885616, -366.836764};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 void test_exponential_with_a_large_real_part_magnitude_e4_fourthquadrant_angle(void) {
@@ -508,8 +526,8 @@ void test_exponential_with_a_large_real_part_magnitude_e4_fourthquadrant_angle(v
     const complex_t result = complex_exp(z);
     const complex_t expected = {-43.740959, -32.675472};
 
-    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+    ASSERT_FLOAT(expected.real, result.real);
+    ASSERT_FLOAT(expected.imag, result.imag);
 }
 
 int main(void) {

--- a/exercises/practice/complex-numbers/complex_numbers_test.c
+++ b/exercises/practice/complex-numbers/complex_numbers_test.c
@@ -35,7 +35,7 @@ void test_real_part_of_a_purely_real_number(void) {
     const complex_t z = {1, 0};
     const float result = complex_real(z);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, 1, result);
+    TEST_ASSERT_EQUAL_FLOAT(1, result);
 }
 
 void test_real_part_of_a_purely_imaginary_number(void) {
@@ -44,7 +44,7 @@ void test_real_part_of_a_purely_imaginary_number(void) {
     const complex_t z = {0, 1};
     const float result = complex_real(z);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, 0, result);
+    TEST_ASSERT_EQUAL_FLOAT(0, result);
 }
 
 void test_real_part_of_a_number_with_real_and_imaginary_part(void) {
@@ -53,7 +53,7 @@ void test_real_part_of_a_number_with_real_and_imaginary_part(void) {
     const complex_t z = {1, 2};
     const float result = complex_real(z);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, 1, result);
+    TEST_ASSERT_EQUAL_FLOAT(1, result);
 }
 
 void test_imaginary_part_of_a_purely_real_number(void) {
@@ -62,7 +62,7 @@ void test_imaginary_part_of_a_purely_real_number(void) {
     const complex_t z = {1, 0};
     const float result = complex_imaginary(z);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, 0, result);
+    TEST_ASSERT_EQUAL_FLOAT(0, result);
 }
 
 void test_imaginary_part_of_a_purely_imaginary_number(void) {
@@ -71,7 +71,7 @@ void test_imaginary_part_of_a_purely_imaginary_number(void) {
     const complex_t z = {0, 1};
     const float result = complex_imaginary(z);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, 1, result);
+    TEST_ASSERT_EQUAL_FLOAT(1, result);
 }
 
 void test_imaginary_part_of_a_number_with_real_and_imaginary_part(void) {
@@ -80,7 +80,7 @@ void test_imaginary_part_of_a_number_with_real_and_imaginary_part(void) {
     const complex_t z = {1, 2};
     const float result = complex_imaginary(z);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, 2, result);
+    TEST_ASSERT_EQUAL_FLOAT(2, result);
 }
 
 void test_imaginary_unit(void) {
@@ -91,8 +91,8 @@ void test_imaginary_unit(void) {
     const complex_t result = complex_mul(z1, z2);
     const complex_t expected = {-1, 0};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_add_purely_real_numbers(void) {
@@ -103,8 +103,8 @@ void test_add_purely_real_numbers(void) {
     const complex_t result = complex_add(z1, z2);
     const complex_t expected = {3, 0};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_add_purely_imaginary_numbers(void) {
@@ -115,8 +115,8 @@ void test_add_purely_imaginary_numbers(void) {
     const complex_t result = complex_add(z1, z2);
     const complex_t expected = {0, 3};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_add_numbers_with_real_and_imaginary_part(void) {
@@ -127,8 +127,8 @@ void test_add_numbers_with_real_and_imaginary_part(void) {
     const complex_t result = complex_add(z1, z2);
     const complex_t expected = {4, 6};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_subtract_purely_real_numbers(void) {
@@ -139,8 +139,8 @@ void test_subtract_purely_real_numbers(void) {
     const complex_t result = complex_sub(z1, z2);
     const complex_t expected = {-1, 0};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_subtract_purely_imaginary_numbers(void) {
@@ -151,8 +151,8 @@ void test_subtract_purely_imaginary_numbers(void) {
     const complex_t result = complex_sub(z1, z2);
     const complex_t expected = {0, -1};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_subtract_numbers_with_real_and_imaginary_part(void) {
@@ -163,8 +163,8 @@ void test_subtract_numbers_with_real_and_imaginary_part(void) {
     const complex_t result = complex_sub(z1, z2);
     const complex_t expected = {-2, -2};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_multiply_purely_real_numbers(void) {
@@ -175,8 +175,8 @@ void test_multiply_purely_real_numbers(void) {
     const complex_t result = complex_mul(z1, z2);
     const complex_t expected = {2, 0};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_multiply_purely_imaginary_numbers(void) {
@@ -187,8 +187,8 @@ void test_multiply_purely_imaginary_numbers(void) {
     const complex_t result = complex_mul(z1, z2);
     const complex_t expected = {-2, 0};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_multiply_numbers_with_real_and_imaginary_part(void) {
@@ -199,8 +199,8 @@ void test_multiply_numbers_with_real_and_imaginary_part(void) {
     const complex_t result = complex_mul(z1, z2);
     const complex_t expected = {-5, 10};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_divide_purely_real_numbers(void) {
@@ -211,8 +211,8 @@ void test_divide_purely_real_numbers(void) {
     const complex_t result = complex_div(z1, z2);
     const complex_t expected = {0.5, 0};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_divide_purely_imaginary_numbers(void) {
@@ -223,8 +223,8 @@ void test_divide_purely_imaginary_numbers(void) {
     const complex_t result = complex_div(z1, z2);
     const complex_t expected = {0.5, 0};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_divide_numbers_with_real_and_imaginary_part(void) {
@@ -235,8 +235,8 @@ void test_divide_numbers_with_real_and_imaginary_part(void) {
     const complex_t result = complex_div(z1, z2);
     const complex_t expected = {0.44, 0.08};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_absolute_value_of_a_positive_purely_real_number(void) {
@@ -245,7 +245,7 @@ void test_absolute_value_of_a_positive_purely_real_number(void) {
     const complex_t z = {5, 0};
     const float result = complex_abs(z);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, 5, result);
+    TEST_ASSERT_EQUAL_FLOAT(5, result);
 }
 
 void test_absolute_value_of_a_negative_purely_real_number(void) {
@@ -254,7 +254,7 @@ void test_absolute_value_of_a_negative_purely_real_number(void) {
     const complex_t z = {-5, 0};
     const float result = complex_abs(z);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, 5, result);
+    TEST_ASSERT_EQUAL_FLOAT(5, result);
 }
 
 void test_absolute_value_of_a_purely_imaginary_number_with_positive_imaginary_part(void) {
@@ -263,7 +263,7 @@ void test_absolute_value_of_a_purely_imaginary_number_with_positive_imaginary_pa
     const complex_t z = {0, 5};
     const float result = complex_abs(z);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, 5, result);
+    TEST_ASSERT_EQUAL_FLOAT(5, result);
 }
 
 void test_absolute_value_of_a_purely_imaginary_number_with_negative_imaginary_part(void) {
@@ -272,7 +272,7 @@ void test_absolute_value_of_a_purely_imaginary_number_with_negative_imaginary_pa
     const complex_t z = {0, -5};
     const float result = complex_abs(z);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, 5, result);
+    TEST_ASSERT_EQUAL_FLOAT(5, result);
 }
 
 void test_absolute_value_of_a_number_with_real_and_imaginary_part(void) {
@@ -281,7 +281,7 @@ void test_absolute_value_of_a_number_with_real_and_imaginary_part(void) {
     const complex_t z = {3, 4};
     const float result = complex_abs(z);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, 5, result);
+    TEST_ASSERT_EQUAL_FLOAT(5, result);
 }
 
 void test_conjugate_a_purely_real_number(void) {
@@ -291,8 +291,8 @@ void test_conjugate_a_purely_real_number(void) {
     const complex_t result = complex_conjugate(z);
     const complex_t expected = {5, 0};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_conjugate_a_purely_imaginary_number(void) {
@@ -302,8 +302,8 @@ void test_conjugate_a_purely_imaginary_number(void) {
     const complex_t result = complex_conjugate(z);
     const complex_t expected = {0, -5};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_conjugate_a_number_with_real_and_imaginary_part(void) {
@@ -313,8 +313,8 @@ void test_conjugate_a_number_with_real_and_imaginary_part(void) {
     const complex_t result = complex_conjugate(z);
     const complex_t expected = {1, -1};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_eulers_identityformula(void) {
@@ -324,8 +324,8 @@ void test_eulers_identityformula(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {-1, 0};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_exponential_of_0(void) {
@@ -335,8 +335,8 @@ void test_exponential_of_0(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {1, 0};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_exponential_of_a_purely_real_number(void) {
@@ -346,8 +346,8 @@ void test_exponential_of_a_purely_real_number(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {2.718281828459045, 0};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_exponential_of_a_number_with_real_and_imaginary_part(void) {
@@ -357,8 +357,8 @@ void test_exponential_of_a_number_with_real_and_imaginary_part(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {-2, 0};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_exponential_resulting_in_a_number_with_real_and_imaginary_part(void) {
@@ -368,8 +368,8 @@ void test_exponential_resulting_in_a_number_with_real_and_imaginary_part(void) {
     const complex_t result = complex_exp(z);
     const complex_t expected = {1, 1};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_add_real_number_to_complex_number(void) {
@@ -380,8 +380,8 @@ void test_add_real_number_to_complex_number(void) {
     const complex_t result = complex_real_add(z1, z2);
     const complex_t expected = {6, 2};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_add_complex_number_to_real_number(void) {
@@ -392,8 +392,8 @@ void test_add_complex_number_to_real_number(void) {
     const complex_t result = real_complex_add(z1, z2);
     const complex_t expected = {6, 2};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_subtract_real_number_from_complex_number(void) {
@@ -404,8 +404,8 @@ void test_subtract_real_number_from_complex_number(void) {
     const complex_t result = complex_real_sub(z1, z2);
     const complex_t expected = {1, 7};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_subtract_complex_number_from_real_number(void) {
@@ -416,8 +416,8 @@ void test_subtract_complex_number_from_real_number(void) {
     const complex_t result = real_complex_sub(z1, z2);
     const complex_t expected = {-1, -7};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_multiply_complex_number_by_real_number(void) {
@@ -428,8 +428,8 @@ void test_multiply_complex_number_by_real_number(void) {
     const complex_t result = complex_real_mul(z1, z2);
     const complex_t expected = {10, 25};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_multiply_real_number_by_complex_number(void) {
@@ -440,8 +440,8 @@ void test_multiply_real_number_by_complex_number(void) {
     const complex_t result = real_complex_mul(z1, z2);
     const complex_t expected = {10, 25};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_divide_complex_number_by_real_number(void) {
@@ -452,8 +452,8 @@ void test_divide_complex_number_by_real_number(void) {
     const complex_t result = complex_real_div(z1, z2);
     const complex_t expected = {1, 10};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 void test_divide_real_number_by_complex_number(void) {
@@ -464,8 +464,52 @@ void test_divide_real_number_by_complex_number(void) {
     const complex_t result = real_complex_div(z1, z2);
     const complex_t expected = {2.5, -2.5};
 
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-    TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+}
+
+void test_exponential_with_a_large_real_part_magnitude_e5_both_components_sizable(void) {
+    TEST_IGNORE();
+
+    const complex_t z = {5, 1};
+    const complex_t result = complex_exp(z);
+    const complex_t expected = {80.187972, 124.885367};
+
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+}
+
+void test_exponential_with_a_large_real_part_magnitude_e7_secondquadrant_angle(void) {
+    TEST_IGNORE();
+
+    const complex_t z = {7, 2};
+    const complex_t result = complex_exp(z);
+    const complex_t expected = {-456.36042, 997.165709};
+
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+}
+
+void test_exponential_with_a_large_real_part_magnitude_e6_negative_angle(void) {
+    TEST_IGNORE();
+
+    const complex_t z = {6, -2};
+    const complex_t result = complex_exp(z);
+    const complex_t expected = {-167.885616, -366.836764};
+
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+}
+
+void test_exponential_with_a_large_real_part_magnitude_e4_fourthquadrant_angle(void) {
+    TEST_IGNORE();
+
+    const complex_t z = {4, -2.5};
+    const complex_t result = complex_exp(z);
+    const complex_t expected = {-43.740959, -32.675472};
+
+    TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+    TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 }
 
 int main(void) {
@@ -510,5 +554,9 @@ int main(void) {
     RUN_TEST(test_multiply_real_number_by_complex_number);
     RUN_TEST(test_divide_complex_number_by_real_number);
     RUN_TEST(test_divide_real_number_by_complex_number);
+    RUN_TEST(test_exponential_with_a_large_real_part_magnitude_e5_both_components_sizable);
+    RUN_TEST(test_exponential_with_a_large_real_part_magnitude_e7_secondquadrant_angle);
+    RUN_TEST(test_exponential_with_a_large_real_part_magnitude_e6_negative_angle);
+    RUN_TEST(test_exponential_with_a_large_real_part_magnitude_e4_fourthquadrant_angle);
     return UNITY_END();
 }

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -13,5 +13,5 @@
       ".meta/example.asm"
     ]
   },
-  "blurb": "Write a function to determine if a list is a sublist of another list."
+  "blurb": "Determine if a list is a sublist of another list."
 }

--- a/generators/exercises/complex_numbers.py
+++ b/generators/exercises/complex_numbers.py
@@ -6,6 +6,13 @@ FUNC_PROTO = """\
 
 #include <stddef.h>
 
+#define ASSERT_FLOAT(x, y)                              \
+    do {                                                \
+        float _dt = 0.0001f * ((x) < 0 ? -(x) : (x));   \
+        float _tl = _dt > 0.00001f ? _dt : 0.00001f;    \
+        TEST_ASSERT_FLOAT_WITHIN(_tl, (x), (y));        \
+    } while (0)
+
 typedef struct {
     float real;
     float imag;
@@ -36,8 +43,8 @@ const ${type2} z2 = ${z2};
 const complex_t result = ${prop}(z1, z2);
 const complex_t expected = ${expected};
 
-TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+ASSERT_FLOAT(expected.real, result.real);
+ASSERT_FLOAT(expected.imag, result.imag);
 """)
 
 UNARY_COMPLEX_RESULT_TEMPLATE = Template("""
@@ -45,15 +52,16 @@ const complex_t z = ${z};
 const complex_t result = ${prop}(z);
 const complex_t expected = ${expected};
 
-TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
-TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
+ASSERT_FLOAT(expected.real, result.real);
+ASSERT_FLOAT(expected.imag, result.imag);
 """)
 
 UNARY_FLOAT_RESULT_TEMPLATE = Template("""
 const complex_t z = ${z};
 const float result = ${prop}(z);
+const float expected = ${expected};
 
-TEST_ASSERT_EQUAL_FLOAT(${expected}, result);
+ASSERT_FLOAT(expected, result);
 """)
 
 

--- a/generators/exercises/complex_numbers.py
+++ b/generators/exercises/complex_numbers.py
@@ -36,8 +36,8 @@ const ${type2} z2 = ${z2};
 const complex_t result = ${prop}(z1, z2);
 const complex_t expected = ${expected};
 
-TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 """)
 
 UNARY_COMPLEX_RESULT_TEMPLATE = Template("""
@@ -45,16 +45,45 @@ const complex_t z = ${z};
 const complex_t result = ${prop}(z);
 const complex_t expected = ${expected};
 
-TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.real, result.real);
-TEST_ASSERT_FLOAT_WITHIN(0.0001, expected.imag, result.imag);
+TEST_ASSERT_EQUAL_FLOAT(expected.real, result.real);
+TEST_ASSERT_EQUAL_FLOAT(expected.imag, result.imag);
 """)
 
 UNARY_FLOAT_RESULT_TEMPLATE = Template("""
 const complex_t z = ${z};
 const float result = ${prop}(z);
 
-TEST_ASSERT_FLOAT_WITHIN(0.0001, ${expected}, result);
+TEST_ASSERT_EQUAL_FLOAT(${expected}, result);
 """)
+
+
+def extra_cases():
+    return [
+        {
+            "description": "exponential with a large real part: magnitude e^5, both components sizable",
+            "property": "exp",
+            "input": {"z": [5, 1]},
+            "expected": [80.187972, 124.885367],
+        },
+        {
+            "description": "exponential with a large real part: magnitude e^7, second-quadrant angle",
+            "property": "exp",
+            "input": {"z": [7, 2]},
+            "expected": [-456.360420, 997.165709],
+        },
+        {
+            "description": "exponential with a large real part: magnitude e^6, negative angle",
+            "property": "exp",
+            "input": {"z": [6, -2]},
+            "expected": [-167.885616, -366.836764],
+        },
+        {
+            "description": "exponential with a large real part: magnitude e^4, fourth-quadrant angle",
+            "property": "exp",
+            "input": {"z": [4, -2.5]},
+            "expected": [-43.740959, -32.675472],
+        },
+    ]
 
 
 def get_type(x):

--- a/generators/exercises/complex_numbers.py
+++ b/generators/exercises/complex_numbers.py
@@ -13,6 +13,17 @@ FUNC_PROTO = """\
         TEST_ASSERT_FLOAT_WITHIN(_tl, (x), (y));        \
     } while (0)
 
+#define ASSERT_COMPLEX(xr, xi, yr, yi)                  \
+    do {                                                \
+        float _abxr = (xr) < 0 ? -(xr) : (xr);          \
+        float _abxi = (xi) < 0 ? -(xi) : (xi);          \
+        float _dist = _abxr > _abxi ? _abxr : _abxi;    \
+        float _dt  = 0.0001f * _dist;                   \
+        float _tl  = _dt > 0.00001f ? _dt : 0.00001f;   \
+        TEST_ASSERT_FLOAT_WITHIN(_tl, (xr), (yr));      \
+        TEST_ASSERT_FLOAT_WITHIN(_tl, (xi), (yi));      \
+    } while (0)
+
 typedef struct {
     float real;
     float imag;
@@ -43,8 +54,7 @@ const ${type2} z2 = ${z2};
 const complex_t result = ${prop}(z1, z2);
 const complex_t expected = ${expected};
 
-ASSERT_FLOAT(expected.real, result.real);
-ASSERT_FLOAT(expected.imag, result.imag);
+ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 """)
 
 UNARY_COMPLEX_RESULT_TEMPLATE = Template("""
@@ -52,8 +62,7 @@ const complex_t z = ${z};
 const complex_t result = ${prop}(z);
 const complex_t expected = ${expected};
 
-ASSERT_FLOAT(expected.real, result.real);
-ASSERT_FLOAT(expected.imag, result.imag);
+ASSERT_COMPLEX(expected.real, expected.imag, result.real, result.imag);
 """)
 
 UNARY_FLOAT_RESULT_TEMPLATE = Template("""
@@ -90,6 +99,30 @@ def extra_cases():
             "property": "exp",
             "input": {"z": [4, -2.5]},
             "expected": [-43.740959, -32.675472],
+        },
+        {
+            "description": "regression: residual angle near pi/2 (failed before sin/cos fix)",
+            "property": "exp",
+            "input": {"z": [-0.3, 1.5]},
+            "expected": [0.052403, 0.738962],
+        },
+        {
+            "description": "regression: residual angle near pi/2, second case",
+            "property": "exp",
+            "input": {"z": [-0.2, 1.5]},
+            "expected": [0.057915, 0.816680],
+        },
+        {
+            "description": "regression: third-quadrant angle, near-zero second component",
+            "property": "exp",
+            "input": {"z": [-0.1, -3.25]},
+            "expected": [-0.899526, 0.097899],
+        },
+        {
+            "description": "regression: residual angle near pi/2, third case",
+            "property": "exp",
+            "input": {"z": [-0.1, 1.5]},
+            "expected": [0.064006, 0.902571],
         },
     ]
 


### PR DESCRIPTION
I mentioned on https://github.com/exercism/x86-64-assembly/pull/444 that:

> While solving prism, I initially tried to use the same implementation of cos and sin that I used in complex-numbers. However, it didn't always work.
> After research, I found out that we are supposed to reduce the angle, otherwise the floating-point imprecision accumulates for larger values. The same is true for exp.
> Later this week, I'll update the example solution for complex-numbers to use a more correct algorithm for all of those functions.

This PR addresses that by:

1. using a correct and stable algorithm for `sin`, `cos` and `exp`. 
2. adding new test cases that would fail on the previous solution.
3. improving the tests to use a relative tolerance.
4. increasing the difficulty of the exercise, considering the higher level of precision necessary to pass the tests.

About `3`:  `TEST_ASSERT_EQUAL_FLOAT` is too strict on a number close to 0 (it requires equality). The reference solution actually passes even if using `TEST_ASSERT_EQUAL_FLOAT`, but solutions using `cexpf` or a combination of `expf`, `sinf` and `cosf` would fail. So I used a custom relative tolerance that is at least 1e-05f. I tested it against all three options (reference solution, `cexpf` and the combination) and they all passed. 