### PR TITLE
tasks in `bird-watcher` are sequential

### DIFF
--- a/exercises/concept/bird-watcher/bird_watcher_test.c
+++ b/exercises/concept/bird-watcher/bird_watcher_test.c
@@ -60,11 +60,11 @@ void tearDown(void) {
 
 // TASK: 1
 void test_last_week_default(void) {
-    const uint64_t actual = last_week_counts();
+    const uint64_t last = last_week_counts();
     char exp_buffer_last[BUFFER_SIZE] = {0};
     char actual_buffer_last[BUFFER_SIZE] = {0};
     generate_bitstring(exp_buffer_last, 1134726115295744);
-    generate_bitstring(actual_buffer_last, actual);
+    generate_bitstring(actual_buffer_last, last);
     TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_last, actual_buffer_last, "Counts for last week are different than expected.");
 }
 
@@ -84,11 +84,11 @@ void test_current_week_default(void) {
 void test_save_count_first_day(void) {
     TEST_IGNORE();
     save_count(5);
-    const uint64_t actual = last_week_counts();
+    const uint64_t last = last_week_counts();
     char exp_buffer_last[BUFFER_SIZE] = {0};
     char actual_buffer_last[BUFFER_SIZE] = {0};
     generate_bitstring(exp_buffer_last, 1134726115295744);
-    generate_bitstring(actual_buffer_last, actual);
+    generate_bitstring(actual_buffer_last, last);
     TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_last, actual_buffer_last, "Counts for last week are different than expected.");
     current_week_t crt = current_week_counts();
     char exp_buffer_current[BUFFER_SIZE] = {0};
@@ -99,22 +99,6 @@ void test_save_count_first_day(void) {
     TEST_ASSERT_EQUAL_UINT64_MESSAGE(1, crt.length, "The number of counts is different than expected.");
 }
 
-// TASK: 4
-void test_today_count_first_entry(void) {
-    TEST_IGNORE();
-    const uint8_t actual = today_count();
-    TEST_ASSERT_EQUAL_UINT8_MESSAGE(5, actual, "Today's count is different than expected.");
-}
-
-// TASK: 5
-void test_update_today_count_first_entry(void) {
-    TEST_IGNORE();
-    update_today_count(2);
-    const uint8_t actual = today_count();
-    TEST_ASSERT_EQUAL_UINT8_MESSAGE(7, actual, "Today's count is different than expected.");
-}
-
-// TASK: 3
 void test_save_count_finish_week(void) {
     TEST_IGNORE();
     save_count(13);
@@ -123,45 +107,29 @@ void test_save_count_finish_week(void) {
     save_count(0);
     save_count(34);
     save_count(42);
-    const uint64_t actual = last_week_counts();
+    const uint64_t last = last_week_counts();
     char exp_buffer_last[BUFFER_SIZE] = {0};
     char actual_buffer_last[BUFFER_SIZE] = {0};
     generate_bitstring(exp_buffer_last, 1134726115295744);
-    generate_bitstring(actual_buffer_last, actual);
+    generate_bitstring(actual_buffer_last, last);
     TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_last, actual_buffer_last, "Counts for last week are different than expected.");
     current_week_t crt = current_week_counts();
     char exp_buffer_current[BUFFER_SIZE] = {0};
     char actual_buffer_current[BUFFER_SIZE] = {0};
-    generate_bitstring(exp_buffer_current, 11859332552854791);
+    generate_bitstring(exp_buffer_current, 11859332552854789);
     generate_bitstring(actual_buffer_current, crt.counts);
     TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_current, actual_buffer_current, "Counts for the week are different than expected.");
     TEST_ASSERT_EQUAL_UINT64_MESSAGE(7, crt.length, "The number of counts is different than expected.");
 }
 
-// TASK: 4
-void test_today_count_current_week(void) {
-    TEST_IGNORE();
-    const uint8_t actual = today_count();
-    TEST_ASSERT_EQUAL_UINT8_MESSAGE(42, actual, "Today's count is different than expected.");
-}
-
-// TASK: 5
-void test_update_today_count_current_week(void) {
-    TEST_IGNORE();
-    update_today_count(14);
-    const uint8_t actual = today_count();
-    TEST_ASSERT_EQUAL_UINT8_MESSAGE(56, actual, "Today's count is different than expected.");
-}
-
-// TASK: 3
 void test_save_count_wrap_current_week(void) {
     TEST_IGNORE();
     save_count(12);
-    const uint64_t actual = last_week_counts();
+    const uint64_t last = last_week_counts();
     char exp_buffer_last[BUFFER_SIZE] = {0};
     char actual_buffer_last[BUFFER_SIZE] = {0};
-    generate_bitstring(exp_buffer_last, 15799982226803975);
-    generate_bitstring(actual_buffer_last, actual);
+    generate_bitstring(exp_buffer_last, 11859332552854789);
+    generate_bitstring(actual_buffer_last, last);
     TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_last, actual_buffer_last, "Counts for last week are different than expected.");
     current_week_t crt = current_week_counts();
     char exp_buffer_current[BUFFER_SIZE] = {0};
@@ -172,22 +140,6 @@ void test_save_count_wrap_current_week(void) {
     TEST_ASSERT_EQUAL_UINT64_MESSAGE(1, crt.length, "The number of counts is different than expected.");
 }
 
-// TASK: 4
-void test_today_count_new_week(void) {
-    TEST_IGNORE();
-    const uint8_t actual = today_count();
-    TEST_ASSERT_EQUAL_UINT8_MESSAGE(12, actual, "Today's count is different than expected.");
-}
-
-// TASK: 5
-void test_update_today_count_new_week(void) {
-    TEST_IGNORE();
-    update_today_count(29);
-    const uint8_t actual = today_count();
-    TEST_ASSERT_EQUAL_UINT8_MESSAGE(41, actual, "Today's count is different than expected.");
-}
-
-// TASK: 3
 void test_continuous_save_count(void) {
     TEST_IGNORE();
     save_count(45);
@@ -208,11 +160,11 @@ void test_continuous_save_count(void) {
     save_count(6);
     save_count(1);
     save_count(19);
-    const uint64_t actual = last_week_counts();
+    const uint64_t last = last_week_counts();
     char exp_buffer_last[BUFFER_SIZE] = {0};
     char actual_buffer_last[BUFFER_SIZE] = {0};
     generate_bitstring(exp_buffer_last, 7322760359905284);
-    generate_bitstring(actual_buffer_last, actual);
+    generate_bitstring(actual_buffer_last, last);
     TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_last, actual_buffer_last, "Counts for last week are different than expected.");
     current_week_t crt = current_week_counts();
     char exp_buffer_current[BUFFER_SIZE] = {0};
@@ -227,11 +179,11 @@ void test_save_count_finish_week_again(void) {
     TEST_IGNORE();
     save_count(1);
     save_count(7);
-    const uint64_t actual = last_week_counts();
+    const uint64_t last = last_week_counts();
     char exp_buffer_last[BUFFER_SIZE] = {0};
     char actual_buffer_last[BUFFER_SIZE] = {0};
     generate_bitstring(exp_buffer_last, 7322760359905284);
-    generate_bitstring(actual_buffer_last, actual);
+    generate_bitstring(actual_buffer_last, last);
     TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_last, actual_buffer_last, "Counts for last week are different than expected.");
     current_week_t crt = current_week_counts();
     char exp_buffer_current[BUFFER_SIZE] = {0};
@@ -242,15 +194,90 @@ void test_save_count_finish_week_again(void) {
     TEST_ASSERT_EQUAL_UINT64_MESSAGE(7, crt.length, "The number of counts is different than expected.");
 }
 
+// TASK: 4
+void test_today_count_first_entry(void) {
+    TEST_IGNORE();
+    const uint8_t actual = today_count();
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(7, actual, "Today's count is different than expected.");
+}
+
+// TASK: 5
+void test_update_today_count_same_day(void) {
+    TEST_IGNORE();
+    update_today_count(7);
+    const uint64_t last = last_week_counts();
+    char exp_buffer_last[BUFFER_SIZE] = {0};
+    char actual_buffer_last[BUFFER_SIZE] = {0};
+    generate_bitstring(exp_buffer_last, 7322760359905284);
+    generate_bitstring(actual_buffer_last, last);
+    TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_last, actual_buffer_last, "Counts for last week are different than expected.");
+    current_week_t crt = current_week_counts();
+    char exp_buffer_current[BUFFER_SIZE] = {0};
+    char actual_buffer_current[BUFFER_SIZE] = {0};
+    generate_bitstring(exp_buffer_current, 3941830807127328);
+    generate_bitstring(actual_buffer_current, crt.counts);
+    TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_current, actual_buffer_current, "Counts for the week are different than expected.");
+    TEST_ASSERT_EQUAL_UINT64_MESSAGE(7, crt.length, "The number of counts is different than expected.");
+    const uint8_t actual = today_count();
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(14, actual, "Today's count is different than expected.");
+}
+
+void test_update_today_count_start_next_week(void) {
+    TEST_IGNORE();
+    save_count(3);
+    update_today_count(14);
+    const uint64_t last = last_week_counts();
+    char exp_buffer_last[BUFFER_SIZE] = {0};
+    char actual_buffer_last[BUFFER_SIZE] = {0};
+    generate_bitstring(exp_buffer_last, 3941830807127328);
+    generate_bitstring(actual_buffer_last, last);
+    TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_last, actual_buffer_last, "Counts for last week are different than expected.");
+    current_week_t crt = current_week_counts();
+    char exp_buffer_current[BUFFER_SIZE] = {0};
+    char actual_buffer_current[BUFFER_SIZE] = {0};
+    generate_bitstring(exp_buffer_current, 17);
+    generate_bitstring(actual_buffer_current, crt.counts);
+    TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_current, actual_buffer_current, "Counts for the week are different than expected.");
+    TEST_ASSERT_EQUAL_UINT64_MESSAGE(1, crt.length, "The number of counts is different than expected.");
+    const uint8_t actual = today_count();
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(17, actual, "Today's count is different than expected.");
+}
+
+void test_update_today_count_end_next_week(void) {
+    TEST_IGNORE();
+    save_count(4);
+    save_count(17);
+    save_count(2);
+    save_count(13);
+    save_count(8);
+    save_count(15);
+    update_today_count(14);
+    const uint64_t last = last_week_counts();
+    char exp_buffer_last[BUFFER_SIZE] = {0};
+    char actual_buffer_last[BUFFER_SIZE] = {0};
+    generate_bitstring(exp_buffer_last, 3941830807127328);
+    generate_bitstring(actual_buffer_last, last);
+    TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_last, actual_buffer_last, "Counts for last week are different than expected.");
+    current_week_t crt = current_week_counts();
+    char exp_buffer_current[BUFFER_SIZE] = {0};
+    char actual_buffer_current[BUFFER_SIZE] = {0};
+    generate_bitstring(exp_buffer_current, 8171626286875665);
+    generate_bitstring(actual_buffer_current, crt.counts);
+    TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_current, actual_buffer_current, "Counts for the week are different than expected.");
+    TEST_ASSERT_EQUAL_UINT64_MESSAGE(7, crt.length, "The number of counts is different than expected.");
+    const uint8_t actual = today_count();
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(29, actual, "Today's count is different than expected.");
+}
+
 // TASK: 6
 void test_update_week_count_one(void) {
     TEST_IGNORE();
     update_week_counts(321276659632387);
-    const uint64_t actual = last_week_counts();
+    const uint64_t last = last_week_counts();
     char exp_buffer_last[BUFFER_SIZE] = {0};
     char actual_buffer_last[BUFFER_SIZE] = {0};
-    generate_bitstring(exp_buffer_last, 1971505970152736);
-    generate_bitstring(actual_buffer_last, actual);
+    generate_bitstring(exp_buffer_last, 8171626286875665);
+    generate_bitstring(actual_buffer_last, last);
     TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_last, actual_buffer_last, "Counts for last week are different than expected.");
     current_week_t crt = current_week_counts();
     char exp_buffer_current[BUFFER_SIZE] = {0};
@@ -264,11 +291,11 @@ void test_update_week_count_one(void) {
 void test_update_week_count_two(void) {
     TEST_IGNORE();
     update_week_counts(6796120059876119);
-    const uint64_t actual = last_week_counts();
+    const uint64_t last = last_week_counts();
     char exp_buffer_last[BUFFER_SIZE] = {0};
     char actual_buffer_last[BUFFER_SIZE] = {0};
     generate_bitstring(exp_buffer_last, 321276659632387);
-    generate_bitstring(actual_buffer_last, actual);
+    generate_bitstring(actual_buffer_last, last);
     TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_last, actual_buffer_last, "Counts for last week are different than expected.");
     current_week_t crt = current_week_counts();
     char exp_buffer_current[BUFFER_SIZE] = {0};
@@ -284,16 +311,14 @@ int main(void) {
     RUN_TEST(test_last_week_default);
     RUN_TEST(test_current_week_default);
     RUN_TEST(test_save_count_first_day);
-    RUN_TEST(test_today_count_first_entry);
-    RUN_TEST(test_update_today_count_first_entry);
     RUN_TEST(test_save_count_finish_week);
-    RUN_TEST(test_today_count_current_week);
-    RUN_TEST(test_update_today_count_current_week);
     RUN_TEST(test_save_count_wrap_current_week);
-    RUN_TEST(test_today_count_new_week);
-    RUN_TEST(test_update_today_count_new_week);
     RUN_TEST(test_continuous_save_count);
     RUN_TEST(test_save_count_finish_week_again);
+    RUN_TEST(test_today_count_first_entry);
+    RUN_TEST(test_update_today_count_same_day);
+    RUN_TEST(test_update_today_count_start_next_week);
+    RUN_TEST(test_update_today_count_end_next_week);
     RUN_TEST(test_update_week_count_one);
     RUN_TEST(test_update_week_count_two);
     return UNITY_END();

--- a/generators/exercises/bird_watcher.py
+++ b/generators/exercises/bird_watcher.py
@@ -94,20 +94,6 @@ def extra_cases():
             },
         },
         {
-            "task_id": 4,
-            "description": "today_count_first_entry",
-            "property": "today_count",
-            "input": None,
-            "expected": 5,
-        },
-        {
-            "task_id": 5,
-            "description": "update_today_count_first_entry",
-            "property": "update_today_count",
-            "input": 2,
-            "expected": 7,
-        },
-        {
             "task_id": 3,
             "description": "save_count_finish_week",
             "property": "save_count",
@@ -121,7 +107,7 @@ def extra_cases():
                 | (8 << 40)
                 | (4 << 48),
                 "current_week": [
-                    7
+                    5
                     | (13 << 8)
                     | (22 << 16)
                     | (8 << 24)
@@ -133,48 +119,20 @@ def extra_cases():
             },
         },
         {
-            "task_id": 4,
-            "description": "today_count_current_week",
-            "property": "today_count",
-            "input": None,
-            "expected": 42,
-        },
-        {
-            "task_id": 5,
-            "description": "update_today_count_current_week",
-            "property": "update_today_count",
-            "input": 14,
-            "expected": 56,
-        },
-        {
             "task_id": 3,
             "description": "save_count_wrap_current_week",
             "property": "save_count",
             "input": [12],
             "expected": {
-                "last_week": 7
+                "last_week": 5
                 | (13 << 8)
                 | (22 << 16)
                 | (8 << 24)
                 | (0 << 32)
                 | (34 << 40)
-                | (56 << 48),
+                | (42 << 48),
                 "current_week": [12, 1],
             },
-        },
-        {
-            "task_id": 4,
-            "description": "today_count_new_week",
-            "property": "today_count",
-            "input": None,
-            "expected": 12,
-        },
-        {
-            "task_id": 5,
-            "description": "update_today_count_new_week",
-            "property": "update_today_count",
-            "input": 29,
-            "expected": 41,
         },
         {
             "task_id": 3,
@@ -218,6 +176,85 @@ def extra_cases():
             },
         },
         {
+            "task_id": 4,
+            "description": "today_count_first_entry",
+            "property": "today_count",
+            "input": None,
+            "expected": {"today": 7},
+        },
+        {
+            "task_id": 5,
+            "description": "update_today_count_same_day",
+            "property": "update_today_count",
+            "input": [[], 7],
+            "expected": {
+                "last_week": 4
+                | (8 << 8)
+                | (7 << 16)
+                | (2 << 24)
+                | (3 << 32)
+                | (4 << 40)
+                | (26 << 48),
+                "current_week": [
+                    32
+                    | (5 << 8)
+                    | (6 << 16)
+                    | (1 << 24)
+                    | (19 << 32)
+                    | (1 << 40)
+                    | (14 << 48),
+                    7,
+                ],
+                "today": 14,
+            },
+        },
+        {
+            "task_id": 5,
+            "description": "update_today_count_start_next_week",
+            "property": "update_today_count",
+            "input": [[3], 14],
+            "expected": {
+                "last_week": 32
+                | (5 << 8)
+                | (6 << 16)
+                | (1 << 24)
+                | (19 << 32)
+                | (1 << 40)
+                | (14 << 48),
+                "current_week": [
+                    17,
+                    1,
+                ],
+                "today": 17,
+            },
+        },
+        {
+            "task_id": 5,
+            "description": "update_today_count_end_next_week",
+            "property": "update_today_count",
+            "input": [[4, 17, 2, 13, 8, 15], 14],
+            "expected": {
+                "last_week": 32
+                | (5 << 8)
+                | (6 << 16)
+                | (1 << 24)
+                | (19 << 32)
+                | (1 << 40)
+                | (14 << 48),
+                "current_week": [
+                    17
+                    | (4 << 8)
+                    | (17 << 16)
+                    | (2 << 24)
+                    | (13 << 32)
+                    | (8 << 40)
+                    | (29 << 48),
+                    7,
+                ],
+                "today": 29,
+            },
+        },
+        {
             "task_id": 6,
             "description": "update_week_count_one",
             "property": "update_week_counts",
@@ -229,13 +266,13 @@ def extra_cases():
             | (36 << 40)
             | (1 << 48),
             "expected": {
-                "last_week": 32
-                | (5 << 8)
-                | (6 << 16)
-                | (1 << 24)
-                | (19 << 32)
-                | (1 << 40)
-                | (7 << 48),
+                "last_week": 17
+                | (4 << 8)
+                | (17 << 16)
+                | (2 << 24)
+                | (13 << 32)
+                | (8 << 40)
+                | (29 << 48),
                 "current_week": [
                     3
                     | (9 << 8)
@@ -304,11 +341,11 @@ def check_current_week(prop, expected):
 
 def check_last_week(prop, expected):
     str_list = []
-    str_list.append(f"const uint64_t actual = {prop}();")
+    str_list.append(f"const uint64_t last = {prop}();")
     str_list.append("char exp_buffer_last[BUFFER_SIZE] = {0};")
     str_list.append("char actual_buffer_last[BUFFER_SIZE] = {0};")
     str_list.append(f"generate_bitstring(exp_buffer_last, {expected});")
-    str_list.append("generate_bitstring(actual_buffer_last, actual);")
+    str_list.append("generate_bitstring(actual_buffer_last, last);")
     str_list.append(
         'TEST_ASSERT_EQUAL_STRING_MESSAGE(exp_buffer_last, actual_buffer_last, "Counts for last week are different than expected.");'
     )
@@ -337,9 +374,15 @@ def gen_func_body(prop, inp, expected):
         )
         return "\n".join(str_list)
     if prop == "update_today_count":
-        str_list.append(f"{prop}({inp});")
+        for val in inp[0]:
+            str_list.append(f"save_count({val});")
+        str_list.append(f"{prop}({inp[1]});")
+        str_list.append(check_last_week("last_week_counts", expected["last_week"]))
+        str_list.append(
+            check_current_week("current_week_counts", expected["current_week"])
+        )
     str_list.append("const uint8_t actual = today_count();")
     str_list.append(
-        f'TEST_ASSERT_EQUAL_UINT8_MESSAGE({expected}, actual, "Today\'s count is different than expected.");'
+        f'TEST_ASSERT_EQUAL_UINT8_MESSAGE({expected["today"]}, actual, "Today\'s count is different than expected.");'
     )
     return "\n".join(str_list)


### PR DESCRIPTION
A student mentioned on [Discord](https://discord.com/channels/854117591135027261/1512284657784459446) that the tests for task 3 of bird-watcher were failing even with a correct implementation. The problem was that some tests for a more advanced task (task 5) were changing the state of the program, so a standard TDD approach didn't work here.

Since this exercise requires stateful tasks, the best solution I could find was to make the tasks sequential, so that all tests for a task complete before the next task is tested. A task can use functions already defined and tested in previous tasks, but a previous task can't use functions that are yet to be defined.