### PR TITLE
misc fixes

### DIFF
--- a/config.json
+++ b/config.json
@@ -248,7 +248,7 @@
       },
       {
         "slug": "mixing-console",
-        "name": "mixing-console",
+        "name": "Mixing Console",
         "uuid": "3bb1c7a8-63d8-47b6-9a92-9f91a60db2ca",
         "concepts": [
           "simd-integers"

--- a/exercises/concept/bookkeeping/helper.asm
+++ b/exercises/concept/bookkeeping/helper.asm
@@ -9,6 +9,15 @@ section .text
     mov r9, 0xFFFFFFFFFFFFFFFF
     mov r10, 0xFFFFFFFFFFFFFFFF
     mov r11, 0xFFFFFFFFFFFFFFFF
+
+    pxor xmm0, xmm0
+    pcmpeqb xmm0, xmm0
+    %assign _i 1
+    %rep 15
+        movdqa xmm %+ _i, xmm0
+        %assign _i _i + 1
+    %endrep
+    %undef _i
 %endmacro
 
 global clobber

--- a/exercises/concept/mixing-console/mixing_console_test.c
+++ b/exercises/concept/mixing-console/mixing_console_test.c
@@ -157,15 +157,15 @@ void test_mix_tracks_mixed_extremes(void) {
 // TASK: 2
 void test_remove_bleed_example(void) {
     TEST_IGNORE();
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(2) int16_t result[8];
     alignas(16) const int16_t track[8] = {10000, -30000, 5000, 32767, 0, 200, -200, 15000};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(2) const int16_t bleed[8] = {2000, 5000, 5000, -5, 0, 300, 300, 5000};
     remove_bleed(result, track, bleed);
-    const int16_t expected[8] = {8000, -32768, 0, 32767, 0, -100, -500, 10000};
+    alignas(2) const int16_t expected[8] = {8000, -32768, 0, 32767, 0, -100, -500, 10000};
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[0], result[0], "The 16-bit sample at lane 0 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[1], result[1], "The 16-bit sample at lane 1 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[2], result[2], "The 16-bit sample at lane 2 is different from expected");
@@ -178,15 +178,15 @@ void test_remove_bleed_example(void) {
 
 void test_remove_bleed_all_zeros(void) {
     TEST_IGNORE();
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(2) int16_t result[8];
     alignas(16) const int16_t track[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(2) const int16_t bleed[8] = {0, 0, 0, 0, 0, 0, 0, 0};
     remove_bleed(result, track, bleed);
-    const int16_t expected[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    alignas(2) const int16_t expected[8] = {0, 0, 0, 0, 0, 0, 0, 0};
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[0], result[0], "The 16-bit sample at lane 0 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[1], result[1], "The 16-bit sample at lane 1 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[2], result[2], "The 16-bit sample at lane 2 is different from expected");
@@ -199,15 +199,15 @@ void test_remove_bleed_all_zeros(void) {
 
 void test_remove_bleed_no_saturation(void) {
     TEST_IGNORE();
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(2) int16_t result[8];
     alignas(16) const int16_t track[8] = {100, 200, 300, 400, 500, 600, 700, 800};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(2) const int16_t bleed[8] = {50, 50, 50, 50, 50, 50, 50, 50};
     remove_bleed(result, track, bleed);
-    const int16_t expected[8] = {50, 150, 250, 350, 450, 550, 650, 750};
+    alignas(2) const int16_t expected[8] = {50, 150, 250, 350, 450, 550, 650, 750};
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[0], result[0], "The 16-bit sample at lane 0 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[1], result[1], "The 16-bit sample at lane 1 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[2], result[2], "The 16-bit sample at lane 2 is different from expected");
@@ -220,15 +220,15 @@ void test_remove_bleed_no_saturation(void) {
 
 void test_remove_bleed_saturates_negative(void) {
     TEST_IGNORE();
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(2) int16_t result[8];
     alignas(16) const int16_t track[8] = {-32768, -32768, -32768, -32768, -32768, -32768, -32768, -32768};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(2) const int16_t bleed[8] = {1, 1, 1, 1, 1, 1, 1, 1};
     remove_bleed(result, track, bleed);
-    const int16_t expected[8] = {-32768, -32768, -32768, -32768, -32768, -32768, -32768, -32768};
+    alignas(2) const int16_t expected[8] = {-32768, -32768, -32768, -32768, -32768, -32768, -32768, -32768};
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[0], result[0], "The 16-bit sample at lane 0 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[1], result[1], "The 16-bit sample at lane 1 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[2], result[2], "The 16-bit sample at lane 2 is different from expected");
@@ -241,15 +241,15 @@ void test_remove_bleed_saturates_negative(void) {
 
 void test_remove_bleed_saturates_positive(void) {
     TEST_IGNORE();
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(2) int16_t result[8];
     alignas(16) const int16_t track[8] = {32767, 32767, 32767, 32767, 32767, 32767, 32767, 32767};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(2) const int16_t bleed[8] = {-1, -1, -1, -1, -1, -1, -1, -1};
     remove_bleed(result, track, bleed);
-    const int16_t expected[8] = {32767, 32767, 32767, 32767, 32767, 32767, 32767, 32767};
+    alignas(2) const int16_t expected[8] = {32767, 32767, 32767, 32767, 32767, 32767, 32767, 32767};
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[0], result[0], "The 16-bit sample at lane 0 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[1], result[1], "The 16-bit sample at lane 1 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[2], result[2], "The 16-bit sample at lane 2 is different from expected");
@@ -262,15 +262,15 @@ void test_remove_bleed_saturates_positive(void) {
 
 void test_remove_bleed_cancels_to_zero(void) {
     TEST_IGNORE();
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(2) int16_t result[8];
     alignas(16) const int16_t track[8] = {5, 10, 15, 20, 25, 30, 35, 40};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(2) const int16_t bleed[8] = {5, 10, 15, 20, 25, 30, 35, 40};
     remove_bleed(result, track, bleed);
-    const int16_t expected[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    alignas(2) const int16_t expected[8] = {0, 0, 0, 0, 0, 0, 0, 0};
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[0], result[0], "The 16-bit sample at lane 0 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[1], result[1], "The 16-bit sample at lane 1 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[2], result[2], "The 16-bit sample at lane 2 is different from expected");
@@ -283,15 +283,15 @@ void test_remove_bleed_cancels_to_zero(void) {
 
 void test_remove_bleed_mixed_extremes(void) {
     TEST_IGNORE();
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(2) int16_t result[8];
     alignas(16) const int16_t track[8] = {0, 0, -100, 100, 32767, -32768, 1000, -1000};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(2) const int16_t bleed[8] = {32767, -32768, 100, -100, -1, 1, 500, -500};
     remove_bleed(result, track, bleed);
-    const int16_t expected[8] = {-32767, 32767, -200, 200, 32767, -32768, 500, -500};
+    alignas(2) const int16_t expected[8] = {-32767, 32767, -200, 200, 32767, -32768, 500, -500};
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[0], result[0], "The 16-bit sample at lane 0 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[1], result[1], "The 16-bit sample at lane 1 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[2], result[2], "The 16-bit sample at lane 2 is different from expected");
@@ -304,15 +304,15 @@ void test_remove_bleed_mixed_extremes(void) {
 
 void test_remove_bleed_goes_negative(void) {
     TEST_IGNORE();
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(2) int16_t result[8];
     alignas(16) const int16_t track[8] = {10, 20, 30, 40, 50, 60, 70, 80};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(2) const int16_t bleed[8] = {100, 100, 100, 100, 100, 100, 100, 100};
     remove_bleed(result, track, bleed);
-    const int16_t expected[8] = {-90, -80, -70, -60, -50, -40, -30, -20};
+    alignas(2) const int16_t expected[8] = {-90, -80, -70, -60, -50, -40, -30, -20};
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[0], result[0], "The 16-bit sample at lane 0 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[1], result[1], "The 16-bit sample at lane 1 is different from expected");
     TEST_ASSERT_EQUAL_INT16_MESSAGE(expected[2], result[2], "The 16-bit sample at lane 2 is different from expected");

--- a/exercises/concept/production-line/production_line_test.c
+++ b/exercises/concept/production-line/production_line_test.c
@@ -124,13 +124,13 @@ void test_sum_yields_both_negative(void) {
 void test_scaled_deviation_example(void) {
     TEST_IGNORE();
     alignas(16) const double measured[2] = {10.5, 20.5};
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(8) const double target[2] = {10.0, 20.0};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(8) const double sensitivity[2] = {2.0, 4.0};
-    const char x3 = 'X';
+    alignas(16) const char x3 = 'X';
     (void)x3;
     alignas(8) double result[2];
     scaled_deviation(measured, target, sensitivity, result);
@@ -142,13 +142,13 @@ void test_scaled_deviation_example(void) {
 void test_scaled_deviation_zero_deviation(void) {
     TEST_IGNORE();
     alignas(16) const double measured[2] = {5.0, 5.0};
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(8) const double target[2] = {5.0, 5.0};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(8) const double sensitivity[2] = {2.0, 2.0};
-    const char x3 = 'X';
+    alignas(16) const char x3 = 'X';
     (void)x3;
     alignas(8) double result[2];
     scaled_deviation(measured, target, sensitivity, result);
@@ -160,13 +160,13 @@ void test_scaled_deviation_zero_deviation(void) {
 void test_scaled_deviation_negative_deviation(void) {
     TEST_IGNORE();
     alignas(16) const double measured[2] = {1.0, 2.0};
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(8) const double target[2] = {3.0, 5.0};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(8) const double sensitivity[2] = {1.0, 1.0};
-    const char x3 = 'X';
+    alignas(16) const char x3 = 'X';
     (void)x3;
     alignas(8) double result[2];
     scaled_deviation(measured, target, sensitivity, result);
@@ -178,13 +178,13 @@ void test_scaled_deviation_negative_deviation(void) {
 void test_scaled_deviation_zero_sensitivity(void) {
     TEST_IGNORE();
     alignas(16) const double measured[2] = {100.0, 200.0};
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(8) const double target[2] = {50.0, 50.0};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(8) const double sensitivity[2] = {0.0, 0.0};
-    const char x3 = 'X';
+    alignas(16) const char x3 = 'X';
     (void)x3;
     alignas(8) double result[2];
     scaled_deviation(measured, target, sensitivity, result);
@@ -196,13 +196,13 @@ void test_scaled_deviation_zero_sensitivity(void) {
 void test_scaled_deviation_fractional_sensitivity(void) {
     TEST_IGNORE();
     alignas(16) const double measured[2] = {4.0, 8.0};
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(8) const double target[2] = {2.0, 4.0};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(8) const double sensitivity[2] = {0.5, 0.25};
-    const char x3 = 'X';
+    alignas(16) const char x3 = 'X';
     (void)x3;
     alignas(8) double result[2];
     scaled_deviation(measured, target, sensitivity, result);
@@ -214,13 +214,13 @@ void test_scaled_deviation_fractional_sensitivity(void) {
 void test_scaled_deviation_negative_target(void) {
     TEST_IGNORE();
     alignas(16) const double measured[2] = {0.0, 0.0};
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(8) const double target[2] = {-3.0, -7.0};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(8) const double sensitivity[2] = {1.0, 1.0};
-    const char x3 = 'X';
+    alignas(16) const char x3 = 'X';
     (void)x3;
     alignas(8) double result[2];
     scaled_deviation(measured, target, sensitivity, result);
@@ -232,13 +232,13 @@ void test_scaled_deviation_negative_target(void) {
 void test_scaled_deviation_negative_sensitivity(void) {
     TEST_IGNORE();
     alignas(16) const double measured[2] = {10.0, 10.0};
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(8) const double target[2] = {5.0, 5.0};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(8) const double sensitivity[2] = {-2.0, -3.0};
-    const char x3 = 'X';
+    alignas(16) const char x3 = 'X';
     (void)x3;
     alignas(8) double result[2];
     scaled_deviation(measured, target, sensitivity, result);
@@ -250,13 +250,13 @@ void test_scaled_deviation_negative_sensitivity(void) {
 void test_scaled_deviation_larger_values(void) {
     TEST_IGNORE();
     alignas(16) const double measured[2] = {1000.0, 2000.0};
-    const char x1 = 'X';
+    alignas(16) const char x1 = 'X';
     (void)x1;
     alignas(8) const double target[2] = {1000.0, 1500.0};
-    const char x2 = 'X';
+    alignas(16) const char x2 = 'X';
     (void)x2;
     alignas(8) const double sensitivity[2] = {3.0, 2.0};
-    const char x3 = 'X';
+    alignas(16) const char x3 = 'X';
     (void)x3;
     alignas(8) double result[2];
     scaled_deviation(measured, target, sensitivity, result);
@@ -268,7 +268,7 @@ void test_scaled_deviation_larger_values(void) {
 // TASK: 3
 void test_calibrate_batch_example(void) {
     TEST_IGNORE();
-    const char x = 'X';
+    alignas(16) const char x = 'X';
     (void)x;
     alignas(4) const float raw[] = {10.0, 20.0, 25.0, 50.0};
     alignas(16) const double reference[2] = {100.0, 100.0};
@@ -288,7 +288,7 @@ void test_calibrate_batch_example(void) {
 
 void test_calibrate_batch_uniform(void) {
     TEST_IGNORE();
-    const char x = 'X';
+    alignas(16) const char x = 'X';
     (void)x;
     alignas(4) const float raw[] = {6.0, 6.0, 6.0, 6.0};
     alignas(16) const double reference[2] = {12.0, 12.0};
@@ -308,7 +308,7 @@ void test_calibrate_batch_uniform(void) {
 
 void test_calibrate_batch_different_offset_per_lane(void) {
     TEST_IGNORE();
-    const char x = 'X';
+    alignas(16) const char x = 'X';
     (void)x;
     alignas(4) const float raw[] = {10.0, 10.0, 10.0, 10.0};
     alignas(16) const double reference[2] = {20.0, 20.0};
@@ -328,7 +328,7 @@ void test_calibrate_batch_different_offset_per_lane(void) {
 
 void test_calibrate_batch_negative_raw(void) {
     TEST_IGNORE();
-    const char x = 'X';
+    alignas(16) const char x = 'X';
     (void)x;
     alignas(4) const float raw[] = {-2.0, -4.0, -8.0, -16.0};
     alignas(16) const double reference[2] = {16.0, 16.0};
@@ -348,7 +348,7 @@ void test_calibrate_batch_negative_raw(void) {
 
 void test_calibrate_batch_different_reference_per_lane(void) {
     TEST_IGNORE();
-    const char x = 'X';
+    alignas(16) const char x = 'X';
     (void)x;
     alignas(4) const float raw[] = {10.0, 10.0, 10.0, 10.0};
     alignas(16) const double reference[2] = {100.0, 50.0};
@@ -368,7 +368,7 @@ void test_calibrate_batch_different_reference_per_lane(void) {
 
 void test_calibrate_batch_fractional_raw(void) {
     TEST_IGNORE();
-    const char x = 'X';
+    alignas(16) const char x = 'X';
     (void)x;
     alignas(4) const float raw[] = {0.5, 1.0, 2.0, 4.0};
     alignas(16) const double reference[2] = {4.0, 4.0};
@@ -388,7 +388,7 @@ void test_calibrate_batch_fractional_raw(void) {
 
 void test_calibrate_batch_offset_exceeds_raw(void) {
     TEST_IGNORE();
-    const char x = 'X';
+    alignas(16) const char x = 'X';
     (void)x;
     alignas(4) const float raw[] = {2.0, 2.0, 6.0, 8.0};
     alignas(16) const double reference[2] = {8.0, 8.0};
@@ -408,7 +408,7 @@ void test_calibrate_batch_offset_exceeds_raw(void) {
 
 void test_calibrate_batch_mixed_reference_offset(void) {
     TEST_IGNORE();
-    const char x = 'X';
+    alignas(16) const char x = 'X';
     (void)x;
     alignas(4) const float raw[] = {3.0, 5.0, 9.0, 17.0};
     alignas(16) const double reference[2] = {2.0, 4.0};

--- a/generators/exercises/mixing_console.py
+++ b/generators/exercises/mixing_console.py
@@ -700,17 +700,19 @@ def gen_func_body(prop, inp, expected):
         str_list.append(f"const int16_t expected[8] = {array_literal(expected)};")
         str_list.extend(int16_lane_asserts())
     elif prop == "remove_bleed":
-        str_list.append("const char x1 = 'X';")
+        str_list.append("alignas(16) const char x1 = 'X';")
         str_list.append("(void)x1;")
         str_list.append("alignas(2) int16_t result[8];")
         str_list.append(
             f"alignas(16) const int16_t track[8] = {array_literal(inp[0])};"
         )
-        str_list.append("const char x2 = 'X';")
+        str_list.append("alignas(16) const char x2 = 'X';")
         str_list.append("(void)x2;")
         str_list.append(f"alignas(2) const int16_t bleed[8] = {array_literal(inp[1])};")
         str_list.append("remove_bleed(result, track, bleed);")
-        str_list.append(f"const int16_t expected[8] = {array_literal(expected)};")
+        str_list.append(
+            f"alignas(2) const int16_t expected[8] = {array_literal(expected)};"
+        )
         str_list.extend(int16_lane_asserts())
     elif prop == "combine_meters":
         str_list.append(

--- a/generators/exercises/production_line.py
+++ b/generators/exercises/production_line.py
@@ -278,15 +278,15 @@ def gen_func_body(prop, inp, expected):
         str_list.append(
             f"alignas(16) const double measured[2] = {array_literal(inp[0])};"
         )
-        str_list.append("const char x1 = 'X';")
+        str_list.append("alignas(16) const char x1 = 'X';")
         str_list.append("(void)x1;")
         str_list.append(f"alignas(8) const double target[2] = {array_literal(inp[1])};")
-        str_list.append("const char x2 = 'X';")
+        str_list.append("alignas(16) const char x2 = 'X';")
         str_list.append("(void)x2;")
         str_list.append(
             f"alignas(8) const double sensitivity[2] = {array_literal(inp[2])};"
         )
-        str_list.append("const char x3 = 'X';")
+        str_list.append("alignas(16) const char x3 = 'X';")
         str_list.append("(void)x3;")
         str_list.append("alignas(8) double result[2];")
         str_list.append(f"{prop}(measured, target, sensitivity, result);")
@@ -298,7 +298,7 @@ def gen_func_body(prop, inp, expected):
             'TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected[1], result[1], "The 64-bit floating-point number at lane 1 is different from expected");'
         )
     elif prop == "calibrate_batch":
-        str_list.append("const char x = 'X';")
+        str_list.append("alignas(16) const char x = 'X';")
         str_list.append("(void)x;")
         str_list.append(f"alignas(4) const float raw[] = {array_literal(inp[0])};")
         str_list.append(


### PR DESCRIPTION
1. Fix the name of Mixing Console.
2. In `bookkeeping`, clobber now also clobbers XMM registers
3. In both `production-line` and `mixing-console`, alignas now correctly forces misalignment of the array, by aligning a dummy 1-byte variable to 16 just before it.