### PR TITLE
Add flag debugging

### DIFF
--- a/exercises/concept/bird-watcher/debug.mac
+++ b/exercises/concept/bird-watcher/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/black-jack/debug.mac
+++ b/exercises/concept/black-jack/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/bookkeeping/debug.mac
+++ b/exercises/concept/bookkeeping/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/color-palette/debug.mac
+++ b/exercises/concept/color-palette/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/currency-exchange/debug.mac
+++ b/exercises/concept/currency-exchange/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/freelancer-rates/debug.mac
+++ b/exercises/concept/freelancer-rates/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/inventory-management/debug.mac
+++ b/exercises/concept/inventory-management/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/lasagna/debug.mac
+++ b/exercises/concept/lasagna/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/lost-and-found/debug.mac
+++ b/exercises/concept/lost-and-found/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/mixed-juices/debug.mac
+++ b/exercises/concept/mixed-juices/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/mixing-console/debug.mac
+++ b/exercises/concept/mixing-console/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/need-for-speed/debug.mac
+++ b/exercises/concept/need-for-speed/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/pipers-pie/debug.mac
+++ b/exercises/concept/pipers-pie/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/pocket-console/debug.mac
+++ b/exercises/concept/pocket-console/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/poetry-club-door-policy/debug.mac
+++ b/exercises/concept/poetry-club-door-policy/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/production-line/debug.mac
+++ b/exercises/concept/production-line/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/concept/secrets/debug.mac
+++ b/exercises/concept/secrets/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/acronym/debug.mac
+++ b/exercises/practice/acronym/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/affine-cipher/debug.mac
+++ b/exercises/practice/affine-cipher/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/all-your-base/debug.mac
+++ b/exercises/practice/all-your-base/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/allergies/debug.mac
+++ b/exercises/practice/allergies/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/anagram/debug.mac
+++ b/exercises/practice/anagram/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/armstrong-numbers/debug.mac
+++ b/exercises/practice/armstrong-numbers/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/atbash-cipher/debug.mac
+++ b/exercises/practice/atbash-cipher/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/baffling-birthdays/debug.mac
+++ b/exercises/practice/baffling-birthdays/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/binary-search-tree/debug.mac
+++ b/exercises/practice/binary-search-tree/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/binary-search/debug.mac
+++ b/exercises/practice/binary-search/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/bob/debug.mac
+++ b/exercises/practice/bob/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/book-store/debug.mac
+++ b/exercises/practice/book-store/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/bottle-song/debug.mac
+++ b/exercises/practice/bottle-song/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/camicia/debug.mac
+++ b/exercises/practice/camicia/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/change/debug.mac
+++ b/exercises/practice/change/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/circular-buffer/debug.mac
+++ b/exercises/practice/circular-buffer/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/clock/debug.mac
+++ b/exercises/practice/clock/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/collatz-conjecture/debug.mac
+++ b/exercises/practice/collatz-conjecture/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/complex-numbers/debug.mac
+++ b/exercises/practice/complex-numbers/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/crypto-square/debug.mac
+++ b/exercises/practice/crypto-square/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/custom-set/debug.mac
+++ b/exercises/practice/custom-set/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/darts/debug.mac
+++ b/exercises/practice/darts/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/diamond/debug.mac
+++ b/exercises/practice/diamond/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/difference-of-squares/debug.mac
+++ b/exercises/practice/difference-of-squares/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/dnd-character/debug.mac
+++ b/exercises/practice/dnd-character/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/dominoes/debug.mac
+++ b/exercises/practice/dominoes/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/eliuds-eggs/debug.mac
+++ b/exercises/practice/eliuds-eggs/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/etl/debug.mac
+++ b/exercises/practice/etl/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/flatten-array/debug.mac
+++ b/exercises/practice/flatten-array/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/flower-field/debug.mac
+++ b/exercises/practice/flower-field/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/food-chain/debug.mac
+++ b/exercises/practice/food-chain/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/game-of-life/debug.mac
+++ b/exercises/practice/game-of-life/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/gigasecond/debug.mac
+++ b/exercises/practice/gigasecond/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/grains/debug.mac
+++ b/exercises/practice/grains/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/hamming/debug.mac
+++ b/exercises/practice/hamming/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/hello-world/debug.mac
+++ b/exercises/practice/hello-world/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/high-scores/debug.mac
+++ b/exercises/practice/high-scores/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/house/debug.mac
+++ b/exercises/practice/house/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/intergalactic-transmission/debug.mac
+++ b/exercises/practice/intergalactic-transmission/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/isbn-verifier/debug.mac
+++ b/exercises/practice/isbn-verifier/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/isogram/debug.mac
+++ b/exercises/practice/isogram/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/killer-sudoku-helper/debug.mac
+++ b/exercises/practice/killer-sudoku-helper/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/kindergarten-garden/debug.mac
+++ b/exercises/practice/kindergarten-garden/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/knapsack/debug.mac
+++ b/exercises/practice/knapsack/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/largest-series-product/debug.mac
+++ b/exercises/practice/largest-series-product/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/leap/debug.mac
+++ b/exercises/practice/leap/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/line-up/debug.mac
+++ b/exercises/practice/line-up/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/linked-list/debug.mac
+++ b/exercises/practice/linked-list/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/list-ops/debug.mac
+++ b/exercises/practice/list-ops/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/luhn/debug.mac
+++ b/exercises/practice/luhn/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/matching-brackets/debug.mac
+++ b/exercises/practice/matching-brackets/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/matrix/debug.mac
+++ b/exercises/practice/matrix/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/meetup/debug.mac
+++ b/exercises/practice/meetup/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/micro-blog/debug.mac
+++ b/exercises/practice/micro-blog/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/minesweeper/debug.mac
+++ b/exercises/practice/minesweeper/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/nth-prime/debug.mac
+++ b/exercises/practice/nth-prime/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/nucleotide-count/debug.mac
+++ b/exercises/practice/nucleotide-count/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/ocr-numbers/debug.mac
+++ b/exercises/practice/ocr-numbers/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/palindrome-products/debug.mac
+++ b/exercises/practice/palindrome-products/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/pangram/debug.mac
+++ b/exercises/practice/pangram/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/pascals-triangle/debug.mac
+++ b/exercises/practice/pascals-triangle/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/perfect-numbers/debug.mac
+++ b/exercises/practice/perfect-numbers/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/phone-number/debug.mac
+++ b/exercises/practice/phone-number/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/pig-latin/debug.mac
+++ b/exercises/practice/pig-latin/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/prime-factors/debug.mac
+++ b/exercises/practice/prime-factors/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/prism/debug.mac
+++ b/exercises/practice/prism/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/protein-translation/debug.mac
+++ b/exercises/practice/protein-translation/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/proverb/debug.mac
+++ b/exercises/practice/proverb/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/pythagorean-triplet/debug.mac
+++ b/exercises/practice/pythagorean-triplet/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/queen-attack/debug.mac
+++ b/exercises/practice/queen-attack/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/rail-fence-cipher/debug.mac
+++ b/exercises/practice/rail-fence-cipher/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/raindrops/debug.mac
+++ b/exercises/practice/raindrops/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/rational-numbers/debug.mac
+++ b/exercises/practice/rational-numbers/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/resistor-color-duo/debug.mac
+++ b/exercises/practice/resistor-color-duo/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/resistor-color-trio/debug.mac
+++ b/exercises/practice/resistor-color-trio/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/resistor-color/debug.mac
+++ b/exercises/practice/resistor-color/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/reverse-string/debug.mac
+++ b/exercises/practice/reverse-string/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/rna-transcription/debug.mac
+++ b/exercises/practice/rna-transcription/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/robot-name/debug.mac
+++ b/exercises/practice/robot-name/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/robot-simulator/debug.mac
+++ b/exercises/practice/robot-simulator/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/roman-numerals/debug.mac
+++ b/exercises/practice/roman-numerals/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/rotational-cipher/debug.mac
+++ b/exercises/practice/rotational-cipher/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/run-length-encoding/debug.mac
+++ b/exercises/practice/run-length-encoding/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/saddle-points/debug.mac
+++ b/exercises/practice/saddle-points/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/save-the-cow/debug.mac
+++ b/exercises/practice/save-the-cow/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/say/debug.mac
+++ b/exercises/practice/say/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/scrabble-score/debug.mac
+++ b/exercises/practice/scrabble-score/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/secret-handshake/debug.mac
+++ b/exercises/practice/secret-handshake/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/series/debug.mac
+++ b/exercises/practice/series/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/sieve/debug.mac
+++ b/exercises/practice/sieve/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/simple-linked-list/debug.mac
+++ b/exercises/practice/simple-linked-list/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/space-age/debug.mac
+++ b/exercises/practice/space-age/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/spiral-matrix/debug.mac
+++ b/exercises/practice/spiral-matrix/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/split-second-stopwatch/debug.mac
+++ b/exercises/practice/split-second-stopwatch/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/square-root/debug.mac
+++ b/exercises/practice/square-root/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/state-of-tic-tac-toe/debug.mac
+++ b/exercises/practice/state-of-tic-tac-toe/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/strain/debug.mac
+++ b/exercises/practice/strain/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/sublist/debug.mac
+++ b/exercises/practice/sublist/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/sum-of-multiples/debug.mac
+++ b/exercises/practice/sum-of-multiples/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/tournament/debug.mac
+++ b/exercises/practice/tournament/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/transpose/debug.mac
+++ b/exercises/practice/transpose/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/triangle/debug.mac
+++ b/exercises/practice/triangle/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/twelve-days/debug.mac
+++ b/exercises/practice/twelve-days/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/two-bucket/debug.mac
+++ b/exercises/practice/two-bucket/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/two-fer/debug.mac
+++ b/exercises/practice/two-fer/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/variable-length-quantity/debug.mac
+++ b/exercises/practice/variable-length-quantity/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/word-count/debug.mac
+++ b/exercises/practice/word-count/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/wordy/debug.mac
+++ b/exercises/practice/wordy/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/practice/yacht/debug.mac
+++ b/exercises/practice/yacht/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 

--- a/exercises/shared/.docs/debug.md
+++ b/exercises/shared/.docs/debug.md
@@ -1,18 +1,19 @@
 # Debug
 
 To help with debugging, there are various macros defined in a [debug.mac file][debug].
-They can be called with one or more arguments of the appropriate size.
+They can be called with one or more arguments of the appropriate type and size.
 For example:
 
 ```x86asm
 debugf32 xmm0, xmm1 ; prints the value of two 32-bit floating-point numbers
 debugd16 ax, cx, dx ; prints the value of three signed 16-bit integers
 debugx64 [rax]      ; prints the value of a 64-bit integer in hexadecimal format
-debugs rsi          ; prints a NUL-terminated string whose address is stored in `rsi`
+debugs rel mem, rsi ; prints two NUL-terminated strings
 debugu8_xmm xmm1    ; prints 16 packed 8-bit unsigned integers
+debug_flag e        ; prints true if je would jump, and false otherwise
 ```
 
-In order to use any of those macros, `debug.mac` must be included at the top of the solution file:
+To use any of those macros, `debug.mac` must be included at the top of the solution file:
 
 ```x86asm
 %include "debug.mac"

--- a/templates/debug.mac
+++ b/templates/debug.mac
@@ -1,6 +1,101 @@
 %ifndef DEBUG_MAC
 %define DEBUG_MAC
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                   DEBUGGING UTILITY FILE FOR EXERCISM'S X86-64 ASSEMBLY TRACK
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      CALLING CONVENTION
+;
+; There are macros for debugging:
+; 1. scalar values
+; 2. strings
+; 3. packed (SIMD) values
+; 4. conditions and flags
+;
+; All the macros may be called with multiple arguments, that must be separated by a comma (`,`).
+;
+; Note that the stack is modified temporarily by all macros.
+; This means any value pointed by RSP won't be valid at the time it is dereferenced.
+; Such value should be loaded on a register before debugging.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SCALAR DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; A scalar debugging macro name is usually of the form: "debug" + type + size.
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; The exception is debugc, which prints an individual character and does not need a size suffix.
+;
+; Scalar debugging macros may be called with registers or memory operands.
+;
+; If the macro is called with a memory operand, it should be passed in brackets and a size prefix may be necessary, e.g.:
+; - byte [<address>]
+; - word [<address>]
+; (where <address> is a valid dereferenceable relative memory address).
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           STRING DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debugs macro prints a NUL-terminated string and does not need a size suffix.
+;
+; It accepts a memory address as argument, without brackets.
+; If this address is given as a label, it must be RIP-relative.
+; This means either the label is passed with a preceding "rel" or there's a "default rel" directive:
+;
+; debugs rel label
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           SIMD DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; For SIMD debug, the form is: "debug" + type + size + "_xmm".
+;
+; The type is one of the following:
+; 1. "d", for signed integers
+; 2. "u", for unsigned integers in decimal format
+; 3. "x", for unsigned integers in hexadecimal format
+; 4. "f", for floating-point numbers
+;
+; The sizes are:
+; 1. 8, for 8-bit values
+; 2. 16, for 16-bit values
+; 3. 32, for 32-bit values
+; 4. 64, for 64-bit values
+;
+; In SIMD debugging, sizes refer to each individual lane.
+; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
+;
+; SIMD debugging macros may be called with registers or memory operands.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FLAG DEBUGGING MACRO CONVENTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; The debug_flag macro prints if a certain condition is true or false.
+; It is called with a condition as tested by, e.g., SETcc or Jcc instructions.
+; For example:
+;
+; debug_flag ae, z, c
+;
+; This example prints true if jae, jz and jc would jump, respectively, and false otherwise.
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 extern printf
 
 section .rodata
@@ -28,6 +123,13 @@ fmtc: db "debug character... %c", 0xA, 0x0
 fmts: db `debug string... "%s"`, 0xA, 0x0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                           FORMATTING STRINGS FOR FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+fmt_flag_true: db "debug flag... true", 0xA, 0x0
+fmt_flag_false: db "debug flag... false", 0xA, 0x0
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                           FORMATTING STRINGS FOR PACKED VALUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -51,6 +153,7 @@ fmts: db `debug string... "%s"`, 0xA, 0x0
         %assign _i_x _i_x + 1
     %endrep
     db "]", 0xA, 0x0
+    %undef  _i_x
 %endmacro
 
 ; generates formatting string for floating-point SIMD values
@@ -66,6 +169,8 @@ _fmt_xmm f64, "%f", 2
         %assign _i_is (_i_is * 2)
         %assign _j_is (_j_is / 2)
     %endrep
+    %undef _i_is
+    %undef _j_is
 %endmacro
 
 ; generates formatting string for integer SIMD values
@@ -103,6 +208,8 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
 
 %endmacro
 
@@ -117,6 +224,9 @@ _fmt_xmm_is zx, "%zX"
     %assign i i + 16
     %assign n n + 1
 %endrep
+%undef i
+%undef n
+
     add rsp, 16 * 16
 
     ; Restore caller-save registers
@@ -173,51 +283,22 @@ _fmt_xmm_is zx, "%zX"
 
 %endmacro
 
+%macro call_print 0
+
+    %ifidn __OUTPUT_FORMAT__,elf64
+        call printf wrt ..plt
+    %else
+        call printf
+    %endif
+
+%endmacro
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;                                      DEBUGGING MACROS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;                                      CALLING CONVENTION
-;
-; All the following macros may be called with: 1. registers or 2. memory operands.
-; The macros may be called with multiple arguments, that must be separated by a comma (`,`)
-;
-; If called with a memory operand, it might be necessary to specify the size, e.g.:
-; - byte [<address>]
-; - word [<address>]
-; (where <address> is a valid dereferenceable relative memory address).
-;
-; Note that the stack is modified temporarily by all macros
-; This means any value pointed by RSP won't be valid at the time it is dereferenced
-; Such value should be loaded on a register before debugging
-;
-; The macro name is usually of the form: "debug" + type + size
-;
-; The type is one of the following:
-; 1. "d", for signed integers
-; 2. "u", for unsigned integers in decimal format
-; 3. "x", for unsigned integers in hexadecimal format
-; 4. "f", for floating-point numbers
-;
-; The sizes are:
-; 1. 8, for 8-bit values
-; 2. 16, for 16-bit values
-; 3. 32, for 32-bit values
-; 4. 64, for 64-bit values
-;
-; For SIMD debug, the form is: "debug" + type + size + "_xmm"
-;
-; In this case, the types are the same and the sizes refer to each individual lane.
-; For example, debugd16_xmm interprets a 128-bit argument as 8 16-bit packed numbers.
-;
-; Finally, "debugc" and "debugs" do not need an explicit size.
-; They print an individual character and a NUL-terminated string, respectively.
-;
-; Note that the `debugs` macro expects a memory address.
-; If not in a register, this address should be passed directly, without brackets:
-; - debugs <address>
-;
+;                                      DEBUGGING SCALAR
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints the value of a 8-bit signed integer
@@ -230,7 +311,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -255,7 +336,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -273,7 +354,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzd]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -291,7 +372,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -316,7 +397,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -334,7 +415,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzu]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -352,7 +433,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -377,7 +458,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -395,7 +476,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtzx]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -413,7 +494,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -431,7 +512,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtf]
         mov eax, 1
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -449,7 +530,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmtc]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -467,13 +548,17 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmts]
         xor eax, eax
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
     %endrep
 
 %endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING SIMD
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; prints a XMM register interpreted as 4 packed 32-bit floating-point numbers
 %macro debugf32_xmm 1-*
@@ -492,7 +577,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f32]
         mov eax, 4
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -515,7 +600,7 @@ _fmt_xmm_is zx, "%zX"
         lea rdi, [rel fmt_xmm_f64]
         mov eax, 2
 
-        call printf wrt ..plt
+        call_print
 
         epilogue
     %rotate 1
@@ -576,10 +661,12 @@ _fmt_xmm_is zx, "%zX"
         mov [rsp + _i_d8_xmm], rax
         %assign _i_d8_xmm _i_d8_xmm + 8
     %endrep
+    %undef _i_d8_xmm
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 8]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -659,10 +746,11 @@ _fmt_xmm_is zx, "%zX"
 
     _mov_xmm r10, ax
     mov [rsp + 16], r10
+    %undefalias _mov_xmm
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 16]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -727,7 +815,7 @@ _fmt_xmm_is zx, "%zX"
 
     lea rdi, [rel fmt_xmm_ %+ %3 %+ 32]
     xor eax, eax
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -782,7 +870,7 @@ _fmt_xmm_is zx, "%zX"
     lea rdi, [rel fmt_xmm_ %+ %2 %+ 64]
     xor eax, eax
 
-    call printf wrt ..plt
+    call_print
 
     epilogue
 
@@ -813,6 +901,35 @@ _fmt_xmm_is zx, "%zX"
 
     %rep %0
         _debug_si_xmm64 %1, zx
+    %rotate 1
+    %endrep
+
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;                                      DEBUGGING FLAGS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%macro debug_flag 1-*
+
+    %rep %0
+        prologue
+
+        xor esi, esi
+
+        push qword [rbp + 16 * 16 + 10 * 8]
+        popfq
+
+        set%1 sil
+
+        lea rdi, [rel fmt_flag_true]
+        lea rdx, [rel fmt_flag_false]
+        test esi, esi
+        cmovz rdi, rdx
+
+        call_print
+
+        epilogue
     %rotate 1
     %endrep
 


### PR DESCRIPTION
1. Add a `debug_flag` macro, which prints true if a condition is true, and false otherwise. A condition is encoded by its suffix in a `jcc` instruction: ae, l, z, c, etc.
2. There's now a check before calling C's printf. The current code uses `call printf wrt ..plt`, but this is only correct for ELF (i.e., Linux), on macOS the call should be a plain `call printf` (considering the Makefile uses `--prefix _`).
3. Undefine all helper one-line macros used for indexing or aliasing, to avoid them "spilling" into student's code.
4. Improve documentation and move the calling convention comments to the top of the file, for ease of reference.