### PR TITLE
update `loops` concept docs

### DIFF
--- a/concepts/loops/about.md
+++ b/concepts/loops/about.md
@@ -144,10 +144,9 @@ fn:
 ```
 
 ~~~~exercism/caution
-Despite their convenience, `loop`, `loope`, and `loopne` are slow on modern processors.
-They are microcoded: on Intel cores `loop` decodes into roughly seven micro-ops, and `loope`/`loopne` into about eleven, sustaining only one iteration every [five cycles or so][agner-tables].
-The equivalent `sub`/`jnz` or `cmp`/`jnz` sequence is one fused micro-op on most processors, so it is several times faster even though it uses two instructions.
-This is why compilers avoid the `loop` family.
+Despite their convenience, `loop`, `loope`, and `loopne` are usually much slower on modern processors than the equivalent `sub`/`jnz` or `cmp`/`jnz` sequence.
+
+A good reference on the performance of instructions in many different CPUs is the [Agner's tables][agner-tables].
 
 [agner-tables]: https://www.agner.org/optimize/instruction_tables.pdf
 ~~~~

--- a/concepts/loops/about.md
+++ b/concepts/loops/about.md
@@ -29,10 +29,78 @@ maybe_finite_loop:
     je out_of_loop ; jumps to 'out_of_loop' if rax == 1, breaking the loop
 
     inc rax
-    jmp maybe_finite_loop ; always jumps to 'infinite_loop'
+    jmp maybe_finite_loop ; always jumps to 'maybe_finite_loop'
 out_of_loop:
     ...
 ```
+
+## Micro-Ops
+
+A processor does not run an instruction such as `add` or `jnz` directly.
+The front-end of the CPU first _decodes_ each instruction into one or more smaller internal steps, called **micro-operations** (or **micro-ops**).
+The processor then schedules and executes these micro-ops, frequently several per cycle and out of their original order.
+
+Most simple instructions decode into a single micro-op, while a more complex instruction may decode into several.
+Because the processor's real workload is the stream of micro-ops, producing fewer of them for the same task is one way code becomes faster.
+
+## Macrofusion
+
+A counting loop almost always ends the same way: an instruction that updates a counter or compares two values, immediately followed by a conditional jump that decides whether to go around again.
+
+```x86asm
+sum_array:
+    xor rax, rax     ; running total
+.loop:
+    add rax, [rdi]   ; add the current element
+    add rdi, 8       ; advance to the next element
+    sub rsi, 1       ; one fewer element to process, setting ZF at zero
+    jnz .loop        ; repeat while the counter is not yet zero
+    ret
+```
+
+~~~~exercism/note
+`cmp rsi, 0` is not necessary in the code above because `sub rsi, 1` already sets the `zero flag (ZF)` when the result is `0`.
+
+Although `cmp` is the main way conditions are tested in assembly, many instructions update the flags.
+For example, many integer arithmetic or bitwise instructions update `ZF` when the result is `0`, and `SF` when the result is negative (i.e., the top bit is set).
+
+You can check a [reference][reference] to see which flags are affected by each instruction.
+
+[reference]: https://www.felixcloutier.com/x86/
+~~~~
+
+Modern processors recognize this pattern during decoding.
+A flag-setting instruction immediately followed by a conditional jump that reads those flags can be decoded together into a **single** micro-op, rather than one each.
+This is called **macrofusion**.
+
+The fused pair behaves as one operation: the counter is updated and the branch decision is made together, in a single micro-op.
+The control flow of the loop then costs almost nothing on top of the work the loop actually does.
+
+As a rule of thumb, two kinds of pairs usually fuse this way:
+
+- Arithmetic instructions such as `add` or `sub`, immediately followed by a conditional jump.
+- A `cmp`, `test` or `and`, immediately followed by a conditional jump.
+
+```x86asm
+    ...
+    add rdi, 8       ; advance a pointer
+    cmp rdi, rsi     ; compare it against the end address
+    jb .loop         ; repeat while still below the end
+```
+
+Fusion only happens when the conditional jump comes **immediately** after the flag-setting instruction, with nothing in between.
+
+~~~~exercism/note
+Macrofusion depends on the CPU and there is some variation on which instructions fuse with which conditional jump.
+
+A useful reference is [The microarchitecture of Intel, AMD, and VIA CPUs, by Agner Fog][agner-uarch].
+Section 3.4.2.2 (Optimizing for Macrofusion) of the [Intel optimization reference manual][intel-opt] also lists fusible pairs for Intel CPUs.
+
+[intel-opt]: https://cdrdv2-public.intel.com/821612/248966-Optimization-Reference-Manual-V1-050.pdf
+[agner-uarch]: https://www.agner.org/optimize/microarchitecture.pdf
+~~~~
+
+## The `loop` Instruction
 
 There are some instructions which can be used to create loop-like behavior.
 One of them is [loop][loop].
@@ -61,7 +129,7 @@ Apart from stopping the loop once `rcx` reaches zero, they also stop when the co
 | `loope`/`loopz`   | `ZF` == 1 |
 | `loopne`/`loopnz` | `ZF` == 0 |
 
-The `ZF` **is not tested** by those instructions.
+The `ZF` **is not set** by those instructions.
 There must be a `cmp`, `test`, or another instruction that changes `ZF` before them:
 
 ```x86asm
@@ -74,6 +142,15 @@ fn:
     cmp rax, 3
     loopne .example ; this repeats the sequence starting in .example while rcx > 0 and rax != 3
 ```
+
+~~~~exercism/caution
+Despite their convenience, `loop`, `loope`, and `loopne` are slow on modern processors.
+They are microcoded: on Intel cores `loop` decodes into roughly seven micro-ops, and `loope`/`loopne` into about eleven, sustaining only one iteration every [five cycles or so][agner-tables].
+The equivalent `sub`/`jnz` or `cmp`/`jnz` sequence is one fused micro-op on most processors, so it is several times faster even though it uses two instructions.
+This is why compilers avoid the `loop` family.
+
+[agner-tables]: https://www.agner.org/optimize/instruction_tables.pdf
+~~~~
 
 [control]: https://en.wikipedia.org/wiki/Control_flow#loop-statement
 [loop]: https://www.felixcloutier.com/x86/loop:loopcc

--- a/concepts/loops/introduction.md
+++ b/concepts/loops/introduction.md
@@ -63,7 +63,9 @@ In some situations, modern CPUs are able to merge two different instructions in 
 This optimization is called **macrofusion**.
 
 Many arithmetic instructions such as `sub` and `add`, as well as `cmp` and `test`, commonly fuse with a conditional jump that follows just after it.
-This means that an instruction such as `cmp rax, rdx` immediately followed by a conditional jump can be treated by the CPU as a single operation.
+This means that an instruction such as `cmp rax, rdx` immediately followed by a conditional jump can usually be treated by the CPU as a single operation.
+
+Macrofusion depends on the CPU and there is some variation on which instructions fuse with which conditional jump.
 
 A useful reference is [The microarchitecture of Intel, AMD, and VIA CPUs, by Agner Fog][agner-uarch].
 Section 3.4.2.2 (Optimizing for Macrofusion) of the [Intel optimization reference manual][intel-opt] also lists fusible pairs for Intel CPUs.

--- a/concepts/loops/introduction.md
+++ b/concepts/loops/introduction.md
@@ -29,48 +29,45 @@ maybe_finite_loop:
     je out_of_loop ; jumps to 'out_of_loop' if rax == 1, breaking the loop
 
     inc rax
-    jmp maybe_finite_loop ; always jumps to 'infinite_loop'
+    jmp maybe_finite_loop ; always jumps to 'maybe_finite_loop'
 out_of_loop:
     ...
 ```
 
-There are some instructions which can be used to create loop-like behavior.
-One of them is **loop**.
-
-Its single operand is a label which has the address to the start of the loop.
-
-The `loop` instruction uses the value in `rcx` as a counter, decrementing it by 1 each time.
-Once the value in `rcx` reaches zero, the loop ends and execution continues sequentially:
+A counting loop almost always ends with an instruction that updates a counter or compares two values, immediately followed by a conditional jump that decides whether to go around again.
 
 ```x86asm
-section .text
-fn:
-    mov rax, 0
-    mov rcx, 10
-.example:
-    inc rax
-    loop .example ; this repeats the sequence starting in .example 10 times (the value in rcx)
-                  ; at each time, rcx is decremented by 1
+sum_array:
+    xor rax, rax     ; running total
+.loop:
+    add rax, [rdi]   ; add the current element
+    add rdi, 8       ; advance to the next element
+    sub rsi, 1       ; one fewer element to process, setting ZF at zero
+    jnz .loop        ; repeat while the counter is not yet zero
+    ret
 ```
 
-There are two variants for the `loop` instruction that check for the zero flag (`ZF`) at each iteration.
-Apart from stopping the loop once `rcx` reaches zero, they also stop when the condition is _not_ met.
+~~~~exercism/note
+`cmp rsi, 0` is not necessary in the code above because `sub rsi, 1` already sets the `zero flag (ZF)` when the result is `0`.
 
-| instruction       | condition |
-| ----------------- | --------- |
-| `loope`/`loopz`   | `ZF` == 1 |
-| `loopne`/`loopnz` | `ZF` == 0 |
+Although `cmp` is the main way conditions are tested in assembly, many instructions update the flags.
+For example, many integer arithmetic or bitwise instructions update `ZF` when the result is `0`, and `SF` when the result is negative (i.e., the top bit is set).
 
-The `ZF` **is not tested** by those instructions.
-There must be a `cmp`, `test`, or another instruction that changes `ZF` before them:
+You can check a [reference][reference] to see which flags are affected by each instruction.
 
-```x86asm
-section .text
-fn:
-    mov rax, 0
-    mov rcx, 10
-.example:
-    inc rax
-    cmp rax, 3
-    loopne .example ; this repeats the sequence starting in .example while rcx > 0 and rax != 3
-```
+[reference]: https://www.felixcloutier.com/x86/
+~~~~
+
+~~~~exercism/advanced
+In some situations, modern CPUs are able to merge two different instructions in a single operation.
+This optimization is called **macrofusion**.
+
+Many arithmetic instructions such as `sub` and `add`, as well as `cmp` and `test`, commonly fuse with a conditional jump that follows just after it.
+This means that an instruction such as `cmp rax, rdx` immediately followed by a conditional jump can be treated by the CPU as a single operation.
+
+A useful reference is [The microarchitecture of Intel, AMD, and VIA CPUs, by Agner Fog][agner-uarch].
+Section 3.4.2.2 (Optimizing for Macrofusion) of the [Intel optimization reference manual][intel-opt] also lists fusible pairs for Intel CPUs.
+
+[agner-uarch]: https://www.agner.org/optimize/microarchitecture.pdf
+[intel-opt]: https://cdrdv2-public.intel.com/821612/248966-Optimization-Reference-Manual-V1-050.pdf
+~~~~

--- a/concepts/loops/links.json
+++ b/concepts/loops/links.json
@@ -1,6 +1,18 @@
 [
   {
+    "url": "https://en.wikipedia.org/wiki/Control_flow#loop-statement",
+    "description": "Wikipedia Entry for Loops"
+  },
+  {
     "url": "https://www.felixcloutier.com/x86",
     "description": "Reference for x86-64 Instructions"
+  },
+  {
+    "url": "https://cdrdv2-public.intel.com/821612/248966-Optimization-Reference-Manual-V1-050.pdf",
+    "description": "Intel optimization reference manual: volume 1"
+  },
+  {
+    "url": "https://www.agner.org/optimize/microarchitecture.pdf",
+    "description": "The microarchitecture of Intel, AMD, and VIA CPUs, by Agner Fog"
   }
 ]

--- a/exercises/concept/mixed-juices/.docs/introduction.md
+++ b/exercises/concept/mixed-juices/.docs/introduction.md
@@ -31,48 +31,45 @@ maybe_finite_loop:
     je out_of_loop ; jumps to 'out_of_loop' if rax == 1, breaking the loop
 
     inc rax
-    jmp maybe_finite_loop ; always jumps to 'infinite_loop'
+    jmp maybe_finite_loop ; always jumps to 'maybe_finite_loop'
 out_of_loop:
     ...
 ```
 
-There are some instructions which can be used to create loop-like behavior.
-One of them is **loop**.
-
-Its single operand is a label which has the address to the start of the loop.
-
-The `loop` instruction uses the value in `rcx` as a counter, decrementing it by 1 each time.
-Once the value in `rcx` reaches zero, the loop ends and execution continues sequentially:
+A counting loop almost always ends with an instruction that updates a counter or compares two values, immediately followed by a conditional jump that decides whether to go around again.
 
 ```x86asm
-section .text
-fn:
-    mov rax, 0
-    mov rcx, 10
-.example:
-    inc rax
-    loop .example ; this repeats the sequence starting in .example 10 times (the value in rcx)
-                  ; at each time, rcx is decremented by 1
+sum_array:
+    xor rax, rax     ; running total
+.loop:
+    add rax, [rdi]   ; add the current element
+    add rdi, 8       ; advance to the next element
+    sub rsi, 1       ; one fewer element to process, setting ZF at zero
+    jnz .loop        ; repeat while the counter is not yet zero
+    ret
 ```
 
-There are two variants for the `loop` instruction that check for the zero flag (`ZF`) at each iteration.
-Apart from stopping the loop once `rcx` reaches zero, they also stop when the condition is _not_ met.
+~~~~exercism/note
+`cmp rsi, 0` is not necessary in the code above because `sub rsi, 1` already sets the `zero flag (ZF)` when the result is `0`.
 
-| instruction       | condition |
-| ----------------- | --------- |
-| `loope`/`loopz`   | `ZF` == 1 |
-| `loopne`/`loopnz` | `ZF` == 0 |
+Although `cmp` is the main way conditions are tested in assembly, many instructions update the flags.
+For example, many integer arithmetic or bitwise instructions update `ZF` when the result is `0`, and `SF` when the result is negative (i.e., the top bit is set).
 
-The `ZF` **is not tested** by those instructions.
-There must be a `cmp`, `test`, or another instruction that changes `ZF` before them:
+You can check a [reference][reference] to see which flags are affected by each instruction.
 
-```x86asm
-section .text
-fn:
-    mov rax, 0
-    mov rcx, 10
-.example:
-    inc rax
-    cmp rax, 3
-    loopne .example ; this repeats the sequence starting in .example while rcx > 0 and rax != 3
-```
+[reference]: https://www.felixcloutier.com/x86/
+~~~~
+
+~~~~exercism/advanced
+In some situations, modern CPUs are able to merge two different instructions in a single operation.
+This optimization is called **macrofusion**.
+
+Many arithmetic instructions such as `sub` and `add`, as well as `cmp` and `test`, commonly fuse with a conditional jump that follows just after it.
+This means that an instruction such as `cmp rax, rdx` immediately followed by a conditional jump can be treated by the CPU as a single operation.
+
+A useful reference is [The microarchitecture of Intel, AMD, and VIA CPUs, by Agner Fog][agner-uarch].
+Section 3.4.2.2 (Optimizing for Macrofusion) of the [Intel optimization reference manual][intel-opt] also lists fusible pairs for Intel CPUs.
+
+[agner-uarch]: https://www.agner.org/optimize/microarchitecture.pdf
+[intel-opt]: https://cdrdv2-public.intel.com/821612/248966-Optimization-Reference-Manual-V1-050.pdf
+~~~~

--- a/exercises/concept/mixed-juices/.meta/exemplar.asm
+++ b/exercises/concept/mixed-juices/.meta/exemplar.asm
@@ -27,7 +27,8 @@ time_to_prepare:
     mov edi, dword [rdx + 4*rcx - 4]
     call time_to_make_juice
     add r8d, eax
-    loop .loop
+    sub ecx, 1
+    jnz .loop
 
     mov eax, r8d
     ret
@@ -85,7 +86,6 @@ remaining_orders:
     call time_to_make_juice
 
     sub ecx, eax
-    cmp ecx, 0
     jg .loop
 
     mov eax, edx


### PR DESCRIPTION
I'm using two LLMs (Claude and Gemini) to review every concept in the syllabus for typos and conceptual gaps. Two suggestions seemed interesting:

1. The `loops` concept emphasizes the `loop` instructions, but they are rarely used in practice because they are slow. I confirmed this against Agner Fog's instruction tables, a classic reference. Only a few AMD CPUs support them with a reasonable speed.
2. The `recursion` concept glosses over the stack frame, without going into practical concerns such as saving variables on the stack and using a prologue to keep track of each call frame.

This PR addresses the first suggestion.

I removed the section on the `loop` instructions from the `loops` concept's introduction.md, but kept it in about.md, now with a note explaining that these instructions are slow.

While there, I added two notes to introduction.md: one on using instructions other than `cmp` to set flags (a student coming from the `conditionals` concept would be using `cmp` for everything), and an advanced note on macrofusion. Both topics are explored in more depth in about.md.