### PR TITLE
CI - bump macOS runner and NASM version on macOS test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
             compiler: gcc
           - os: ubuntu-24.04
             compiler: clang
-          - os: macos-14
+          - os: macos-15
             compiler: clang
 
     steps:
@@ -33,7 +33,7 @@ jobs:
       - name: Install project dependencies (macOS)
         if: ${{ runner.os == 'macOS' }}
         run: |
-          export NASM_VERSION=2.14.02
+          export NASM_VERSION=2.16.01
           curl -O https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/macosx/nasm-${NASM_VERSION}-macosx.zip
           unzip nasm-${NASM_VERSION}-macosx.zip
           echo $(pwd)/nasm-${NASM_VERSION} >> $GITHUB_PATH


### PR DESCRIPTION
- bump macOS runner to macOS-15. macOS-14, the current version, is being deprecated [in a week](https://github.com/actions/runner-images/issues/13518).
- bump NASM version on macOS test to 2.16.01, the same used by [Ubuntu-24.04 (Noble Numbat)](https://launchpad.net/ubuntu/+source/nasm).