### PR TITLE
add generator for `eliuds-eggs`, `queen-attack` and `square-root`

### DIFF
--- a/exercises/practice/eliuds-eggs/eliuds_eggs_test.c
+++ b/exercises/practice/eliuds-eggs/eliuds_eggs_test.c
@@ -1,5 +1,3 @@
-// Version: 1.0.0
-
 #include "vendor/unity.h"
 
 extern int egg_count(int number);
@@ -29,11 +27,17 @@ void test_13_eggs(void) {
     TEST_ASSERT_EQUAL_INT(13, egg_count(2000000000));
 }
 
+void test_negative_number(void) {
+    TEST_IGNORE();
+    TEST_ASSERT_EQUAL_INT(32, egg_count(-1));
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_0_eggs);
     RUN_TEST(test_1_egg);
     RUN_TEST(test_4_eggs);
     RUN_TEST(test_13_eggs);
+    RUN_TEST(test_negative_number);
     return UNITY_END();
 }

--- a/exercises/practice/queen-attack/queen_attack_test.c
+++ b/exercises/practice/queen-attack/queen_attack_test.c
@@ -1,5 +1,3 @@
-// Version: 1.0.0
-
 #include "vendor/unity.h"
 
 // Returns 1 if queen can be created, otherwise 0.

--- a/exercises/practice/square-root/square_root_test.c
+++ b/exercises/practice/square-root/square_root_test.c
@@ -1,5 +1,3 @@
-// Version: 1.0.0
-
 #include "vendor/unity.h"
 
 extern int square_root(int radicand);
@@ -39,6 +37,11 @@ void test_root_of_65025(void) {
     TEST_ASSERT_EQUAL_INT(255, square_root(65025));
 }
 
+void test_max_perfect_square_in_range(void) {
+    TEST_IGNORE();
+    TEST_ASSERT_EQUAL_INT(46340, square_root(2147395600));
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_root_of_1);
@@ -47,5 +50,6 @@ int main(void) {
     RUN_TEST(test_root_of_81);
     RUN_TEST(test_root_of_196);
     RUN_TEST(test_root_of_65025);
+    RUN_TEST(test_max_perfect_square_in_range);
     return UNITY_END();
 }

--- a/generators/exercises/eliuds_eggs.py
+++ b/generators/exercises/eliuds_eggs.py
@@ -1,0 +1,22 @@
+FUNC_PROTO = """\
+#include "vendor/unity.h"
+
+extern int egg_count(int number);
+"""
+
+
+def extra_cases():
+    return [
+        {
+            "description": "negative number",
+            "property": "eggCount",
+            "input": {
+                "number": -1,
+            },
+            "expected": 32,
+        },
+    ]
+
+
+def gen_func_body(prop, inp, expected):
+    return f"TEST_ASSERT_EQUAL_INT({expected}, {prop}({inp['number']}));"

--- a/generators/exercises/queen_attack.py
+++ b/generators/exercises/queen_attack.py
@@ -1,0 +1,22 @@
+FUNC_PROTO = """\
+#include "vendor/unity.h"
+
+// Returns 1 if queen can be created, otherwise 0.
+extern int can_create(int row, int column);
+
+// Returns 1 if queens attack, otherwise 0.
+extern int can_attack(int white_row, int white_column, int black_row, int black_column);
+"""
+
+
+def gen_func_body(prop, inp, expected):
+    if prop == "create":
+        pos = inp["queen"]["position"]
+        assertion = (
+            "TEST_ASSERT_FALSE" if isinstance(expected, dict) else "TEST_ASSERT_TRUE"
+        )
+        return f"{assertion}(can_create({pos['row']}, {pos['column']}));"
+    white = inp["white_queen"]["position"]
+    black = inp["black_queen"]["position"]
+    assertion = "TEST_ASSERT_TRUE" if expected else "TEST_ASSERT_FALSE"
+    return f"{assertion}(can_attack({white['row']}, {white['column']}, {black['row']}, {black['column']}));"

--- a/generators/exercises/square_root.py
+++ b/generators/exercises/square_root.py
@@ -1,0 +1,22 @@
+FUNC_PROTO = """\
+#include "vendor/unity.h"
+
+extern int square_root(int radicand);
+"""
+
+
+def extra_cases():
+    return [
+        {
+            "description": "max perfect square in range",
+            "property": "squareRoot",
+            "input": {
+                "radicand": 2147395600,
+            },
+            "expected": 46340,
+        },
+    ]
+
+
+def gen_func_body(prop, inp, expected):
+    return f"TEST_ASSERT_EQUAL_INT({expected}, {prop}({inp['radicand']}));"


### PR DESCRIPTION
I'm going over the practice exercises, adding missing generators. Here `eliuds-eggs`, `queen-attack` and `square-root`.

Also added a new test case for `eliuds-eggs` and for `square-root`.