### PR TITLE
add generators and fix the `series` generator and its test file.

### DIFF
--- a/exercises/practice/armstrong-numbers/armstrong_numbers_test.c
+++ b/exercises/practice/armstrong-numbers/armstrong_numbers_test.c
@@ -1,8 +1,9 @@
-// Version: 1.0.0
-
 #include "vendor/unity.h"
 
-extern int is_armstrong_number(int number);
+#include <stdbool.h>
+#include <stdint.h>
+
+extern bool is_armstrong_number(uint32_t number);
 
 void setUp(void) {
 }
@@ -65,5 +66,5 @@ int main(void) {
     RUN_TEST(test_four_digit_number_that_is_not_an_armstrong_number);
     RUN_TEST(test_seven_digit_number_that_is_an_armstrong_number);
     RUN_TEST(test_seven_digit_number_that_is_not_an_armstrong_number);
-    return UnityEnd();
+    return UNITY_END();
 }

--- a/exercises/practice/isbn-verifier/isbn_verifier_test.c
+++ b/exercises/practice/isbn-verifier/isbn_verifier_test.c
@@ -1,6 +1,9 @@
 #include "vendor/unity.h"
 
-extern int is_valid(const char *isbn);
+#include <stdbool.h>
+#include <stdalign.h>
+
+extern bool is_valid(const char isbn[]);
 
 void setUp(void) {
 }
@@ -9,148 +12,127 @@ void tearDown(void) {
 }
 
 void test_valid_isbn(void) {
-    const char *isbn = "3-598-21508-8";
-
+    alignas(16) const char isbn[] = "3-598-21508-8";
     TEST_ASSERT_TRUE(is_valid(isbn));
 }
 
 void test_invalid_isbn_check_digit(void) {
     TEST_IGNORE();
-    const char *isbn = "3-598-21508-9";
-
+    alignas(16) const char isbn[] = "3-598-21508-9";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_valid_isbn_with_a_check_digit_of_10(void) {
     TEST_IGNORE();
-    const char *isbn = "3-598-21507-X";
-
+    alignas(16) const char isbn[] = "3-598-21507-X";
     TEST_ASSERT_TRUE(is_valid(isbn));
 }
 
 void test_check_digit_is_a_character_other_than_x(void) {
     TEST_IGNORE();
-    const char *isbn = "3-598-21507-A";
-
+    alignas(16) const char isbn[] = "3-598-21507-A";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_invalid_check_digit_in_isbn_is_not_treated_as_zero(void) {
     TEST_IGNORE();
-    const char *isbn = "4-598-21507-B";
-
+    alignas(16) const char isbn[] = "4-598-21507-B";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_invalid_character_in_isbn_is_not_treated_as_zero(void) {
     TEST_IGNORE();
-    const char *isbn = "3-598-P1581-X";
-
+    alignas(16) const char isbn[] = "3-598-P1581-X";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_x_is_only_valid_as_a_check_digit(void) {
     TEST_IGNORE();
-    const char *isbn = "3-598-2X507-9";
-
+    alignas(16) const char isbn[] = "3-598-2X507-9";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_only_one_check_digit_is_allowed(void) {
     TEST_IGNORE();
-    const char *isbn = "3-598-21508-96";
-
+    alignas(16) const char isbn[] = "3-598-21508-96";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_x_is_not_substituted_by_the_value_10(void) {
     TEST_IGNORE();
-    const char *isbn = "3-598-2X507-5";
-
+    alignas(16) const char isbn[] = "3-598-2X507-5";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_valid_isbn_without_separating_dashes(void) {
     TEST_IGNORE();
-    const char *isbn = "3598215088";
-
+    alignas(16) const char isbn[] = "3598215088";
     TEST_ASSERT_TRUE(is_valid(isbn));
 }
 
 void test_isbn_without_separating_dashes_and_x_as_check_digit(void) {
     TEST_IGNORE();
-    const char *isbn = "359821507X";
-
+    alignas(16) const char isbn[] = "359821507X";
     TEST_ASSERT_TRUE(is_valid(isbn));
 }
 
 void test_isbn_without_check_digit_and_dashes(void) {
     TEST_IGNORE();
-    const char *isbn = "359821507";
-
+    alignas(16) const char isbn[] = "359821507";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_too_long_isbn_and_no_dashes(void) {
     TEST_IGNORE();
-    const char *isbn = "3598215078X";
-
+    alignas(16) const char isbn[] = "3598215078X";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_too_short_isbn(void) {
     TEST_IGNORE();
-    const char *isbn = "00";
-
+    alignas(16) const char isbn[] = "00";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_isbn_without_check_digit(void) {
     TEST_IGNORE();
-    const char *isbn = "3-598-21507";
-
+    alignas(16) const char isbn[] = "3-598-21507";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_check_digit_of_x_should_not_be_used_for_0(void) {
     TEST_IGNORE();
-    const char *isbn = "3-598-21515-X";
-
+    alignas(16) const char isbn[] = "3-598-21515-X";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_empty_isbn(void) {
     TEST_IGNORE();
-    const char *isbn = "";
-
+    alignas(16) const char isbn[] = "";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_input_is_9_characters(void) {
     TEST_IGNORE();
-    const char *isbn = "134456729";
-
+    alignas(16) const char isbn[] = "134456729";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_invalid_characters_are_not_ignored_after_checking_length(void) {
     TEST_IGNORE();
-    const char *isbn = "3132P34035";
-
+    alignas(16) const char isbn[] = "3132P34035";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_invalid_characters_are_not_ignored_before_checking_length(void) {
     TEST_IGNORE();
-    const char *isbn = "3598P215088";
-
+    alignas(16) const char isbn[] = "3598P215088";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 
 void test_input_is_too_long_but_contains_a_valid_isbn(void) {
     TEST_IGNORE();
-    const char *isbn = "98245726788";
-
+    alignas(16) const char isbn[] = "98245726788";
     TEST_ASSERT_FALSE(is_valid(isbn));
 }
 

--- a/exercises/practice/nucleotide-count/nucleotide_count_test.c
+++ b/exercises/practice/nucleotide-count/nucleotide_count_test.c
@@ -28,7 +28,7 @@ void test_empty_strand(void) {
     TEST_ASSERT_EQUAL_INT64(0, counts[THYMINE]);
 }
 
-void test_can_count_one_nucleotide_in_singlecharacter_input(void) {
+void test_can_count_one_nucleotide_in_single_character_input(void) {
     TEST_IGNORE();
     alignas(16) const char strand[] = "G";
     int64_t counts[4];
@@ -75,7 +75,7 @@ void test_strand_with_invalid_nucleotides(void) {
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_empty_strand);
-    RUN_TEST(test_can_count_one_nucleotide_in_singlecharacter_input);
+    RUN_TEST(test_can_count_one_nucleotide_in_single_character_input);
     RUN_TEST(test_strand_with_repeated_nucleotide);
     RUN_TEST(test_strand_with_multiple_nucleotides);
     RUN_TEST(test_strand_with_invalid_nucleotides);

--- a/exercises/practice/nucleotide-count/nucleotide_count_test.c
+++ b/exercises/practice/nucleotide-count/nucleotide_count_test.c
@@ -1,15 +1,16 @@
-// Version: 1.0.0
-
 #include "vendor/unity.h"
 
+#include <stdint.h>
+#include <stdalign.h>
+
 enum nucleotide {
-    ADENINE,
+    ADENINE = 0,
     CYTOSINE,
     GUANINE,
     THYMINE
 };
 
-extern void nucleotide_counts(const char* strand, int64_t* counts);
+extern void nucleotide_counts(const char strand[], int64_t counts[]);
 
 void setUp(void) {
 }
@@ -18,63 +19,63 @@ void tearDown(void) {
 }
 
 void test_empty_strand(void) {
+    alignas(16) const char strand[] = "";
     int64_t counts[4];
-
-    nucleotide_counts("", counts);
-    TEST_ASSERT_EQUAL_INT(0, counts[ADENINE]);
-    TEST_ASSERT_EQUAL_INT(0, counts[CYTOSINE]);
-    TEST_ASSERT_EQUAL_INT(0, counts[GUANINE]);
-    TEST_ASSERT_EQUAL_INT(0, counts[THYMINE]);
+    nucleotide_counts(strand, counts);
+    TEST_ASSERT_EQUAL_INT64(0, counts[ADENINE]);
+    TEST_ASSERT_EQUAL_INT64(0, counts[CYTOSINE]);
+    TEST_ASSERT_EQUAL_INT64(0, counts[GUANINE]);
+    TEST_ASSERT_EQUAL_INT64(0, counts[THYMINE]);
 }
 
-void test_can_count_one_nucleotide_in_single_character_input(void) {
+void test_can_count_one_nucleotide_in_singlecharacter_input(void) {
     TEST_IGNORE();
+    alignas(16) const char strand[] = "G";
     int64_t counts[4];
-
-    nucleotide_counts("G", counts);
-    TEST_ASSERT_EQUAL_INT(0, counts[ADENINE]);
-    TEST_ASSERT_EQUAL_INT(0, counts[CYTOSINE]);
-    TEST_ASSERT_EQUAL_INT(1, counts[GUANINE]);
-    TEST_ASSERT_EQUAL_INT(0, counts[THYMINE]);
+    nucleotide_counts(strand, counts);
+    TEST_ASSERT_EQUAL_INT64(0, counts[ADENINE]);
+    TEST_ASSERT_EQUAL_INT64(0, counts[CYTOSINE]);
+    TEST_ASSERT_EQUAL_INT64(1, counts[GUANINE]);
+    TEST_ASSERT_EQUAL_INT64(0, counts[THYMINE]);
 }
 
 void test_strand_with_repeated_nucleotide(void) {
     TEST_IGNORE();
+    alignas(16) const char strand[] = "GGGGGGG";
     int64_t counts[4];
-
-    nucleotide_counts("GGGGGGG", counts);
-    TEST_ASSERT_EQUAL_INT(0, counts[ADENINE]);
-    TEST_ASSERT_EQUAL_INT(0, counts[CYTOSINE]);
-    TEST_ASSERT_EQUAL_INT(7, counts[GUANINE]);
-    TEST_ASSERT_EQUAL_INT(0, counts[THYMINE]);
+    nucleotide_counts(strand, counts);
+    TEST_ASSERT_EQUAL_INT64(0, counts[ADENINE]);
+    TEST_ASSERT_EQUAL_INT64(0, counts[CYTOSINE]);
+    TEST_ASSERT_EQUAL_INT64(7, counts[GUANINE]);
+    TEST_ASSERT_EQUAL_INT64(0, counts[THYMINE]);
 }
 
 void test_strand_with_multiple_nucleotides(void) {
     TEST_IGNORE();
+    alignas(16) const char strand[] = "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC";
     int64_t counts[4];
-
-    nucleotide_counts("AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC", counts);
-    TEST_ASSERT_EQUAL_INT(20, counts[ADENINE]);
-    TEST_ASSERT_EQUAL_INT(12, counts[CYTOSINE]);
-    TEST_ASSERT_EQUAL_INT(17, counts[GUANINE]);
-    TEST_ASSERT_EQUAL_INT(21, counts[THYMINE]);
+    nucleotide_counts(strand, counts);
+    TEST_ASSERT_EQUAL_INT64(20, counts[ADENINE]);
+    TEST_ASSERT_EQUAL_INT64(12, counts[CYTOSINE]);
+    TEST_ASSERT_EQUAL_INT64(17, counts[GUANINE]);
+    TEST_ASSERT_EQUAL_INT64(21, counts[THYMINE]);
 }
 
 void test_strand_with_invalid_nucleotides(void) {
     TEST_IGNORE();
+    alignas(16) const char strand[] = "AGXXACT";
     int64_t counts[4];
-
-    nucleotide_counts("AGXXACT", counts);
-    TEST_ASSERT_EQUAL_INT(-1, counts[ADENINE]);
-    TEST_ASSERT_EQUAL_INT(-1, counts[CYTOSINE]);
-    TEST_ASSERT_EQUAL_INT(-1, counts[GUANINE]);
-    TEST_ASSERT_EQUAL_INT(-1, counts[THYMINE]);
+    nucleotide_counts(strand, counts);
+    TEST_ASSERT_EQUAL_INT64(-1, counts[ADENINE]);
+    TEST_ASSERT_EQUAL_INT64(-1, counts[CYTOSINE]);
+    TEST_ASSERT_EQUAL_INT64(-1, counts[GUANINE]);
+    TEST_ASSERT_EQUAL_INT64(-1, counts[THYMINE]);
 }
 
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_empty_strand);
-    RUN_TEST(test_can_count_one_nucleotide_in_single_character_input);
+    RUN_TEST(test_can_count_one_nucleotide_in_singlecharacter_input);
     RUN_TEST(test_strand_with_repeated_nucleotide);
     RUN_TEST(test_strand_with_multiple_nucleotides);
     RUN_TEST(test_strand_with_invalid_nucleotides);

--- a/exercises/practice/resistor-color-duo/resistor_color_duo_test.c
+++ b/exercises/practice/resistor-color-duo/resistor_color_duo_test.c
@@ -1,5 +1,3 @@
-// Version: 1.0.0
-
 #include "vendor/unity.h"
 
 extern int value(const char *first, const char *second, const char *third);
@@ -11,37 +9,44 @@ void tearDown(void) {
 }
 
 void test_brown_and_black(void) {
-    TEST_ASSERT_EQUAL_INT(10, value("brown", "black", NULL));
+    const int result = value("brown", "black", NULL);
+    TEST_ASSERT_EQUAL_INT(10, result);
 }
 
 void test_blue_and_grey(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(68, value("blue", "grey", NULL));
+    const int result = value("blue", "grey", NULL);
+    TEST_ASSERT_EQUAL_INT(68, result);
 }
 
 void test_yellow_and_violet(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(47, value("yellow", "violet", NULL));
+    const int result = value("yellow", "violet", NULL);
+    TEST_ASSERT_EQUAL_INT(47, result);
 }
 
 void test_white_and_red(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(92, value("white", "red", NULL));
+    const int result = value("white", "red", NULL);
+    TEST_ASSERT_EQUAL_INT(92, result);
 }
 
 void test_orange_and_orange(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(33, value("orange", "orange", NULL));
+    const int result = value("orange", "orange", NULL);
+    TEST_ASSERT_EQUAL_INT(33, result);
 }
 
 void test_ignore_additional_colors(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(51, value("green", "brown", "orange"));
+    const int result = value("green", "brown", "orange");
+    TEST_ASSERT_EQUAL_INT(51, result);
 }
 
 void test_black_and_brown_one_digit(void) {
     TEST_IGNORE();
-    TEST_ASSERT_EQUAL_INT(1, value("black", "brown", NULL));
+    const int result = value("black", "brown", NULL);
+    TEST_ASSERT_EQUAL_INT(1, result);
 }
 
 int main(void) {

--- a/exercises/practice/series/series_test.c
+++ b/exercises/practice/series/series_test.c
@@ -1,6 +1,5 @@
 #include "vendor/unity.h"
 
-#include <stddef.h>
 #include <stdint.h>
 
 #define BUFFER_SIZE 20
@@ -12,7 +11,7 @@
 #define NEGATIVE_LENGTH -3
 #define EXCESSIVE_LENGTH -4
 
-extern int64_t slices(char buffer[][SLICE_SIZE], const char *series, size_t slice_length);
+extern int64_t slices(char buffer[][SLICE_SIZE], const char *series, int64_t slice_length);
 
 void setUp(void) {
 }
@@ -22,7 +21,7 @@ void tearDown(void) {
 
 void test_slices_of_one_from_one(void) {
     char buffer[BUFFER_SIZE][SLICE_SIZE];
-    const char *expected[] = {"1"};
+    const char expected[][SLICE_SIZE] = {"1"};
     TEST_ASSERT_EQUAL_INT64(ARRAY_SIZE(expected), slices(buffer, "1", 1));
     for (size_t i = 0; i < ARRAY_SIZE(expected); ++i) {
         TEST_ASSERT_EQUAL_STRING(expected[i], buffer[i]);
@@ -32,7 +31,7 @@ void test_slices_of_one_from_one(void) {
 void test_slices_of_one_from_two(void) {
     TEST_IGNORE();
     char buffer[BUFFER_SIZE][SLICE_SIZE];
-    const char *expected[] = {"1", "2"};
+    const char expected[][SLICE_SIZE] = {"1", "2"};
     TEST_ASSERT_EQUAL_INT64(ARRAY_SIZE(expected), slices(buffer, "12", 1));
     for (size_t i = 0; i < ARRAY_SIZE(expected); ++i) {
         TEST_ASSERT_EQUAL_STRING(expected[i], buffer[i]);
@@ -42,7 +41,7 @@ void test_slices_of_one_from_two(void) {
 void test_slices_of_two(void) {
     TEST_IGNORE();
     char buffer[BUFFER_SIZE][SLICE_SIZE];
-    const char *expected[] = {"35"};
+    const char expected[][SLICE_SIZE] = {"35"};
     TEST_ASSERT_EQUAL_INT64(ARRAY_SIZE(expected), slices(buffer, "35", 2));
     for (size_t i = 0; i < ARRAY_SIZE(expected); ++i) {
         TEST_ASSERT_EQUAL_STRING(expected[i], buffer[i]);
@@ -52,7 +51,7 @@ void test_slices_of_two(void) {
 void test_slices_of_two_overlap(void) {
     TEST_IGNORE();
     char buffer[BUFFER_SIZE][SLICE_SIZE];
-    const char *expected[] = {"91", "14", "42"};
+    const char expected[][SLICE_SIZE] = {"91", "14", "42"};
     TEST_ASSERT_EQUAL_INT64(ARRAY_SIZE(expected), slices(buffer, "9142", 2));
     for (size_t i = 0; i < ARRAY_SIZE(expected); ++i) {
         TEST_ASSERT_EQUAL_STRING(expected[i], buffer[i]);
@@ -62,7 +61,7 @@ void test_slices_of_two_overlap(void) {
 void test_slices_can_include_duplicates(void) {
     TEST_IGNORE();
     char buffer[BUFFER_SIZE][SLICE_SIZE];
-    const char *expected[] = {"777", "777", "777", "777"};
+    const char expected[][SLICE_SIZE] = {"777", "777", "777", "777"};
     TEST_ASSERT_EQUAL_INT64(ARRAY_SIZE(expected), slices(buffer, "777777", 3));
     for (size_t i = 0; i < ARRAY_SIZE(expected); ++i) {
         TEST_ASSERT_EQUAL_STRING(expected[i], buffer[i]);
@@ -72,7 +71,7 @@ void test_slices_can_include_duplicates(void) {
 void test_slices_of_a_long_series(void) {
     TEST_IGNORE();
     char buffer[BUFFER_SIZE][SLICE_SIZE];
-    const char *expected[] = {"91849", "18493", "84939", "49390", "93904", "39042", "90424", "04243"};
+    const char expected[][SLICE_SIZE] = {"91849", "18493", "84939", "49390", "93904", "39042", "90424", "04243"};
     TEST_ASSERT_EQUAL_INT64(ARRAY_SIZE(expected), slices(buffer, "918493904243", 5));
     for (size_t i = 0; i < ARRAY_SIZE(expected); ++i) {
         TEST_ASSERT_EQUAL_STRING(expected[i], buffer[i]);

--- a/generators/exercises/armstrong_numbers.py
+++ b/generators/exercises/armstrong_numbers.py
@@ -1,0 +1,17 @@
+FUNC_PROTO = """\
+#include "vendor/unity.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+extern bool is_armstrong_number(uint32_t number);
+"""
+
+
+def describe(case):
+    return case["description"].replace("-", " ")
+
+
+def gen_func_body(prop, inp, expected):
+    assertion = "TEST_ASSERT_TRUE" if expected else "TEST_ASSERT_FALSE"
+    return f"{assertion}({prop}({inp['number']}));"

--- a/generators/exercises/isbn_verifier.py
+++ b/generators/exercises/isbn_verifier.py
@@ -1,0 +1,16 @@
+FUNC_PROTO = """\
+#include "vendor/unity.h"
+
+#include <stdbool.h>
+#include <stdalign.h>
+
+extern bool is_valid(const char isbn[]);
+"""
+
+
+def gen_func_body(prop, inp, expected):
+    assertion = "TEST_ASSERT_TRUE" if expected else "TEST_ASSERT_FALSE"
+    str_list = []
+    str_list.append(f'alignas(16) const char isbn[] = "{inp["isbn"]}";')
+    str_list.append(f"{assertion}({prop}(isbn));")
+    return "\n".join(str_list)

--- a/generators/exercises/nucleotide_count.py
+++ b/generators/exercises/nucleotide_count.py
@@ -1,0 +1,33 @@
+FUNC_PROTO = """\
+#include "vendor/unity.h"
+
+#include <stdint.h>
+#include <stdalign.h>
+
+enum nucleotide {
+    ADENINE = 0,
+    CYTOSINE,
+    GUANINE,
+    THYMINE
+};
+
+extern void nucleotide_counts(const char strand[], int64_t counts[]);
+"""
+
+
+def gen_func_body(prop, inp, expected):
+    strand = inp["strand"]
+    counts = (
+        [-1, -1, -1, -1]
+        if "error" in expected
+        else [expected["A"], expected["C"], expected["G"], expected["T"]]
+    )
+    str_list = []
+    str_list.append(f'alignas(16) const char strand[] = "{strand}";')
+    str_list.append("int64_t counts[4];")
+    str_list.append(f"{prop}(strand, counts);")
+    str_list.append(f"TEST_ASSERT_EQUAL_INT64({counts[0]}, counts[ADENINE]);")
+    str_list.append(f"TEST_ASSERT_EQUAL_INT64({counts[1]}, counts[CYTOSINE]);")
+    str_list.append(f"TEST_ASSERT_EQUAL_INT64({counts[2]}, counts[GUANINE]);")
+    str_list.append(f"TEST_ASSERT_EQUAL_INT64({counts[3]}, counts[THYMINE]);")
+    return "\n".join(str_list)

--- a/generators/exercises/nucleotide_count.py
+++ b/generators/exercises/nucleotide_count.py
@@ -15,6 +15,10 @@ extern void nucleotide_counts(const char strand[], int64_t counts[]);
 """
 
 
+def describe(case):
+    return case["description"].replace("-", " ")
+
+
 def gen_func_body(prop, inp, expected):
     strand = inp["strand"]
     counts = (

--- a/generators/exercises/resistor_color_duo.py
+++ b/generators/exercises/resistor_color_duo.py
@@ -1,0 +1,20 @@
+FUNC_PROTO = """\
+#include "vendor/unity.h"
+
+extern int value(const char *first, const char *second, const char *third);
+"""
+
+
+def describe(case):
+    return case["description"].replace("-", " ")
+
+
+def gen_func_body(prop, inp, expected):
+    colors = inp["colors"]
+    third = f'"{colors[2]}"' if len(colors) > 2 else "NULL"
+    str_list = []
+    str_list.append(
+        f'const int result = {prop}("{colors[0]}", "{colors[1]}", {third});'
+    )
+    str_list.append(f"TEST_ASSERT_EQUAL_INT({expected}, result);")
+    return "\n".join(str_list)

--- a/generators/exercises/series.py
+++ b/generators/exercises/series.py
@@ -1,7 +1,6 @@
 FUNC_PROTO = """\
 #include "vendor/unity.h"
 
-#include <stddef.h>
 #include <stdint.h>
 
 #define BUFFER_SIZE 20
@@ -13,7 +12,7 @@ FUNC_PROTO = """\
 #define NEGATIVE_LENGTH -3
 #define EXCESSIVE_LENGTH -4
 
-extern int64_t slices(char buffer[][SLICE_SIZE], const char *series, size_t slice_length);
+extern int64_t slices(char buffer[][SLICE_SIZE], const char *series, int64_t slice_length);
 """
 
 
@@ -25,29 +24,31 @@ def gen_func_body(prop, inp, expected):
     series = inp["series"]
     slice_length = inp["sliceLength"]
     str_list = []
-    str_list += "char buffer[BUFFER_SIZE][SLICE_SIZE];\n"
+    str_list.append("char buffer[BUFFER_SIZE][SLICE_SIZE];")
     if len(series) == 0:
         str_list.append(
-            f'TEST_ASSERT_EQUAL_INT64(EMPTY_SERIES, {prop}(buffer, "{series}", {slice_length}));\n'
+            f'TEST_ASSERT_EQUAL_INT64(EMPTY_SERIES, {prop}(buffer, "{series}", {slice_length}));'
         )
     elif slice_length == 0:
         str_list.append(
-            f'TEST_ASSERT_EQUAL_INT64(ZERO_LENGTH, {prop}(buffer, "{series}", {slice_length}));\n'
+            f'TEST_ASSERT_EQUAL_INT64(ZERO_LENGTH, {prop}(buffer, "{series}", {slice_length}));'
         )
     elif slice_length < 0:
         str_list.append(
-            f'TEST_ASSERT_EQUAL_INT64(NEGATIVE_LENGTH, {prop}(buffer, "{series}", {slice_length}));\n'
+            f'TEST_ASSERT_EQUAL_INT64(NEGATIVE_LENGTH, {prop}(buffer, "{series}", {slice_length}));'
         )
     elif slice_length > len(series):
         str_list.append(
-            f'TEST_ASSERT_EQUAL_INT64(EXCESSIVE_LENGTH, {prop}(buffer, "{series}", {slice_length}));\n'
+            f'TEST_ASSERT_EQUAL_INT64(EXCESSIVE_LENGTH, {prop}(buffer, "{series}", {slice_length}));'
         )
     else:
-        str_list.append("const char *expected[] = " + array_literal(expected) + ";\n")
         str_list.append(
-            f'TEST_ASSERT_EQUAL_INT64(ARRAY_SIZE(expected), {prop}(buffer, "{series}", {slice_length}));\n'
+            f"const char expected[][SLICE_SIZE] = {array_literal(expected)};"
         )
-        str_list.append("for (size_t i = 0; i < ARRAY_SIZE(expected); ++i) " + "{\n")
-        str_list.append("TEST_ASSERT_EQUAL_STRING(expected[i], buffer[i]);\n")
-        str_list.append("}\n")
-    return "".join(str_list)
+        str_list.append(
+            f'TEST_ASSERT_EQUAL_INT64(ARRAY_SIZE(expected), {prop}(buffer, "{series}", {slice_length}));'
+        )
+        str_list.append("for (size_t i = 0; i < ARRAY_SIZE(expected); ++i) " + "{")
+        str_list.append("TEST_ASSERT_EQUAL_STRING(expected[i], buffer[i]);")
+        str_list.append("}")
+    return "\n".join(str_list)


### PR DESCRIPTION
Add generators for `nucleotide-count`, `resistor-color-duo`, `armstrong-numbers` and `isbn-verifier`. Fix the `series` generator and its test file.

- use `alignas(16)` on `nucleotide-count` and `isbn-verifier`. This should not affect existing solutions, but makes it easier for students to use SIMD instructions.
- use `bool` as the return type on `armstrong-numbers` and `isbn-verifier`, and use `uint32_t` as the input type on `armstrong-numbers`. Most easy exercises use only `int` for both, but it is good to have some variety and these types are a better fit.
- use `int64_t` instead of `size_t` as the type of `slice_length` on `series`. The length might be negative (this is one of the errors students should check), so `size_t` is technically wrong and confusing for students.
- use `TEST_ASSERT_EQUAL_INT64` instead of `TEST_ASSERT_EQUAL_INT` on `nucleotide-count`. The `counts` array is `int64_t`.
- use `[]` instead of a pointer when passing arrays as arguments.
