### PR TITLE
add `list-ops` generator, add new bob test case

### DIFF
--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -9,17 +9,20 @@
 # As user-added comments (using the # character) will be removed when this file
 # is regenerated, comments can be added via a `comment` key.
 
-[e162fead-606f-437a-a166-d051915cea8e]
-description = "stating something"
+[8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
+description = "asking a question"
 
 [73a966dc-8017-47d6-bb32-cf07d1a5fcd9]
 description = "shouting"
 
-[d6c98afd-df35-4806-b55e-2c457c3ab748]
-description = "shouting gibberish"
+[a5193c61-4a92-4f68-93e2-f554eb385ec6]
+description = "forceful question"
 
-[8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
-description = "asking a question"
+[bc39f7c6-f543-41be-9a43-fd1c2f753fc0]
+description = "silence"
+
+[e162fead-606f-437a-a166-d051915cea8e]
+description = "stating something"
 
 [81080c62-4e4d-4066-b30a-48d8d76920d9]
 description = "asking a numeric question"
@@ -27,32 +30,8 @@ description = "asking a numeric question"
 [2a02716d-685b-4e2e-a804-2adaf281c01e]
 description = "asking gibberish"
 
-[c02f9179-ab16-4aa7-a8dc-940145c385f7]
-description = "talking forcefully"
-
-[153c0e25-9bb5-4ec5-966e-598463658bcd]
-description = "using acronyms in regular speech"
-
-[a5193c61-4a92-4f68-93e2-f554eb385ec6]
-description = "forceful question"
-
-[a20e0c54-2224-4dde-8b10-bd2cdd4f61bc]
-description = "shouting numbers"
-
-[f7bc4b92-bdff-421e-a238-ae97f230ccac]
-description = "no letters"
-
 [bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2]
 description = "question with no letters"
-
-[496143c8-1c31-4c01-8a08-88427af85c66]
-description = "shouting with special characters"
-
-[e6793c1c-43bd-4b8d-bc11-499aea73925f]
-description = "shouting with no exclamation mark"
-
-[aa8097cc-c548-4951-8856-14a404dd236a]
-description = "statement containing question mark"
 
 [9bfc677d-ea3a-45f2-be44-35bc8fa3753e]
 description = "non-letters with question"
@@ -60,14 +39,48 @@ description = "non-letters with question"
 [8608c508-f7de-4b17-985b-811878b3cf45]
 description = "prattling on"
 
-[bc39f7c6-f543-41be-9a43-fd1c2f753fc0]
-description = "silence"
+[05b304d6-f83b-46e7-81e0-4cd3ca647900]
+description = "ending with whitespace"
+
+[2c7278ac-f955-4eb4-bf8f-e33eb4116a15]
+description = "multiple line question"
+reimplements = "66953780-165b-4e7e-8ce3-4bcb80b6385a"
+
+[d6c98afd-df35-4806-b55e-2c457c3ab748]
+description = "shouting gibberish"
+
+[3c954328-86fb-4c71-8961-e18d6a5e2517]
+description = "shouting a statement containing a question mark"
+
+[a20e0c54-2224-4dde-8b10-bd2cdd4f61bc]
+description = "shouting numbers"
+
+[496143c8-1c31-4c01-8a08-88427af85c66]
+description = "shouting with special characters"
+
+[e6793c1c-43bd-4b8d-bc11-499aea73925f]
+description = "shouting with no exclamation mark"
 
 [d6c47565-372b-4b09-b1dd-c40552b8378b]
 description = "prolonged silence"
 
 [4428f28d-4100-4d85-a902-e5a78cb0ecd3]
 description = "alternate silence"
+
+[72bd5ad3-9b2f-4931-a988-dce1f5771de2]
+description = "other whitespace"
+
+[c02f9179-ab16-4aa7-a8dc-940145c385f7]
+description = "talking forcefully"
+
+[153c0e25-9bb5-4ec5-966e-598463658bcd]
+description = "using acronyms in regular speech"
+
+[f7bc4b92-bdff-421e-a238-ae97f230ccac]
+description = "no letters"
+
+[aa8097cc-c548-4951-8856-14a404dd236a]
+description = "statement containing question mark"
 
 [66953780-165b-4e7e-8ce3-4bcb80b6385a]
 description = "multiple line question"
@@ -76,15 +89,5 @@ include = false
 [5371ef75-d9ea-4103-bcfa-2da973ddec1b]
 description = "starting with whitespace"
 
-[05b304d6-f83b-46e7-81e0-4cd3ca647900]
-description = "ending with whitespace"
-
-[72bd5ad3-9b2f-4931-a988-dce1f5771de2]
-description = "other whitespace"
-
 [12983553-8601-46a8-92fa-fcaa3bc4a2a0]
 description = "non-question ending with whitespace"
-
-[2c7278ac-f955-4eb4-bf8f-e33eb4116a15]
-description = "multiple line question"
-reimplements = "66953780-165b-4e7e-8ce3-4bcb80b6385a"

--- a/exercises/practice/bob/bob_test.c
+++ b/exercises/practice/bob/bob_test.c
@@ -1,6 +1,8 @@
 #include "vendor/unity.h"
 
-extern const char *response(const char *hey_bob);
+#include <stdalign.h>
+
+extern const char *response(const char hey_bob[]);
 
 void setUp(void) {
 }
@@ -8,181 +10,188 @@ void setUp(void) {
 void tearDown(void) {
 }
 
-void test_stating_something(void) {
-    char str[] = "Tom-ay-to, tom-aaaah-to.";
-    TEST_ASSERT_EQUAL_STRING("Whatever.", response(str));
+void test_asking_a_question(void) {
+    alignas(16) char str[] = "Does this cryogenic chamber make me look fat?";
+    TEST_ASSERT_EQUAL_STRING("Sure.", response(str));
 }
 
 void test_shouting(void) {
     TEST_IGNORE();
-    char str[] = "WATCH OUT!";
+    alignas(16) char str[] = "WATCH OUT!";
     TEST_ASSERT_EQUAL_STRING("Whoa, chill out!", response(str));
 }
 
-void test_shouting_gibberish(void) {
+void test_forceful_question(void) {
     TEST_IGNORE();
-    char str[] = "FCECDFCAAB";
-    TEST_ASSERT_EQUAL_STRING("Whoa, chill out!", response(str));
+    alignas(16) char str[] = "WHAT'S GOING ON?";
+    TEST_ASSERT_EQUAL_STRING("Calm down, I know what I'm doing!", response(str));
 }
 
-void test_asking_a_question(void) {
+void test_silence(void) {
     TEST_IGNORE();
-    char str[] = "Does this cryogenic chamber make me look fat?";
-    TEST_ASSERT_EQUAL_STRING("Sure.", response(str));
+    alignas(16) char str[] = "";
+    TEST_ASSERT_EQUAL_STRING("Fine. Be that way!", response(str));
+}
+
+void test_stating_something(void) {
+    TEST_IGNORE();
+    alignas(16) char str[] = "Tom-ay-to, tom-aaaah-to.";
+    TEST_ASSERT_EQUAL_STRING("Whatever.", response(str));
 }
 
 void test_asking_a_numeric_question(void) {
     TEST_IGNORE();
-    char str[] = "You are, what, like 15?";
+    alignas(16) char str[] = "You are, what, like 15?";
     TEST_ASSERT_EQUAL_STRING("Sure.", response(str));
 }
 
 void test_asking_gibberish(void) {
     TEST_IGNORE();
-    char str[] = "fffbbcbeab?";
+    alignas(16) char str[] = "fffbbcbeab?";
     TEST_ASSERT_EQUAL_STRING("Sure.", response(str));
-}
-
-void test_talking_forcefully(void) {
-    TEST_IGNORE();
-    char str[] = "Hi there!";
-    TEST_ASSERT_EQUAL_STRING("Whatever.", response(str));
-}
-
-void test_using_acronyms_in_regular_speech(void) {
-    TEST_IGNORE();
-    char str[] = "It's OK if you don't want to go work for NASA.";
-    TEST_ASSERT_EQUAL_STRING("Whatever.", response(str));
-}
-
-void test_forceful_question(void) {
-    TEST_IGNORE();
-    char str[] = "WHAT'S GOING ON?";
-    TEST_ASSERT_EQUAL_STRING("Calm down, I know what I'm doing!", response(str));
-}
-
-void test_shouting_numbers(void) {
-    TEST_IGNORE();
-    char str[] = "1, 2, 3 GO!";
-    TEST_ASSERT_EQUAL_STRING("Whoa, chill out!", response(str));
-}
-
-void test_no_letters(void) {
-    TEST_IGNORE();
-    char str[] = "1, 2, 3";
-    TEST_ASSERT_EQUAL_STRING("Whatever.", response(str));
 }
 
 void test_question_with_no_letters(void) {
     TEST_IGNORE();
-    char str[] = "4?";
+    alignas(16) char str[] = "4?";
     TEST_ASSERT_EQUAL_STRING("Sure.", response(str));
-}
-
-void test_shouting_with_special_characters(void) {
-    TEST_IGNORE();
-    char str[] = "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!";
-    TEST_ASSERT_EQUAL_STRING("Whoa, chill out!", response(str));
-}
-
-void test_shouting_with_no_exclamation_mark(void) {
-    TEST_IGNORE();
-    char str[] = "I HATE THE DENTIST";
-    TEST_ASSERT_EQUAL_STRING("Whoa, chill out!", response(str));
-}
-
-void test_statement_containing_question_mark(void) {
-    TEST_IGNORE();
-    char str[] = "Ending with ? means a question.";
-    TEST_ASSERT_EQUAL_STRING("Whatever.", response(str));
 }
 
 void test_nonletters_with_question(void) {
     TEST_IGNORE();
-    char str[] = ":) ?";
+    alignas(16) char str[] = ":) ?";
     TEST_ASSERT_EQUAL_STRING("Sure.", response(str));
 }
 
 void test_prattling_on(void) {
     TEST_IGNORE();
-    char str[] = "Wait! Hang on. Are you going to be OK?";
+    alignas(16) char str[] = "Wait! Hang on. Are you going to be OK?";
     TEST_ASSERT_EQUAL_STRING("Sure.", response(str));
 }
 
-void test_silence(void) {
+void test_ending_with_whitespace(void) {
     TEST_IGNORE();
-    char str[] = "";
-    TEST_ASSERT_EQUAL_STRING("Fine. Be that way!", response(str));
+    alignas(16) char str[] = "Okay if like my  spacebar  quite a bit?   ";
+    TEST_ASSERT_EQUAL_STRING("Sure.", response(str));
+}
+
+void test_multiple_line_question(void) {
+    TEST_IGNORE();
+    alignas(16) char str[] = "\nDoes this cryogenic chamber make\n me look fat?";
+    TEST_ASSERT_EQUAL_STRING("Sure.", response(str));
+}
+
+void test_shouting_gibberish(void) {
+    TEST_IGNORE();
+    alignas(16) char str[] = "FCECDFCAAB";
+    TEST_ASSERT_EQUAL_STRING("Whoa, chill out!", response(str));
+}
+
+void test_shouting_a_statement_containing_a_question_mark(void) {
+    TEST_IGNORE();
+    alignas(16) char str[] = "DO LIONS EAT PEOPLE? AHHHHH.";
+    TEST_ASSERT_EQUAL_STRING("Whoa, chill out!", response(str));
+}
+
+void test_shouting_numbers(void) {
+    TEST_IGNORE();
+    alignas(16) char str[] = "1, 2, 3 GO!";
+    TEST_ASSERT_EQUAL_STRING("Whoa, chill out!", response(str));
+}
+
+void test_shouting_with_special_characters(void) {
+    TEST_IGNORE();
+    alignas(16) char str[] = "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!";
+    TEST_ASSERT_EQUAL_STRING("Whoa, chill out!", response(str));
+}
+
+void test_shouting_with_no_exclamation_mark(void) {
+    TEST_IGNORE();
+    alignas(16) char str[] = "I HATE THE DENTIST";
+    TEST_ASSERT_EQUAL_STRING("Whoa, chill out!", response(str));
 }
 
 void test_prolonged_silence(void) {
     TEST_IGNORE();
-    char str[] = "          ";
+    alignas(16) char str[] = "          ";
     TEST_ASSERT_EQUAL_STRING("Fine. Be that way!", response(str));
 }
 
 void test_alternate_silence(void) {
     TEST_IGNORE();
-    char str[] = "\t\t\t\t\t\t\t\t\t\t";
+    alignas(16) char str[] = "\t\t\t\t\t\t\t\t\t\t";
     TEST_ASSERT_EQUAL_STRING("Fine. Be that way!", response(str));
-}
-
-void test_multiple_line_question(void) {
-    TEST_IGNORE();
-    char str[] = "\nDoes this cryogenic chamber make\n me look fat?";
-    TEST_ASSERT_EQUAL_STRING("Sure.", response(str));
-}
-
-void test_starting_with_whitespace(void) {
-    TEST_IGNORE();
-    char str[] = "         hmmmmmmm...";
-    TEST_ASSERT_EQUAL_STRING("Whatever.", response(str));
-}
-
-void test_ending_with_whitespace(void) {
-    TEST_IGNORE();
-    char str[] = "Okay if like my  spacebar  quite a bit?   ";
-    TEST_ASSERT_EQUAL_STRING("Sure.", response(str));
 }
 
 void test_other_whitespace(void) {
     TEST_IGNORE();
-    char str[] = "\n\r \t";
+    alignas(16) char str[] = "\n\r \t";
     TEST_ASSERT_EQUAL_STRING("Fine. Be that way!", response(str));
+}
+
+void test_talking_forcefully(void) {
+    TEST_IGNORE();
+    alignas(16) char str[] = "Hi there!";
+    TEST_ASSERT_EQUAL_STRING("Whatever.", response(str));
+}
+
+void test_using_acronyms_in_regular_speech(void) {
+    TEST_IGNORE();
+    alignas(16) char str[] = "It's OK if you don't want to go work for NASA.";
+    TEST_ASSERT_EQUAL_STRING("Whatever.", response(str));
+}
+
+void test_no_letters(void) {
+    TEST_IGNORE();
+    alignas(16) char str[] = "1, 2, 3";
+    TEST_ASSERT_EQUAL_STRING("Whatever.", response(str));
+}
+
+void test_statement_containing_question_mark(void) {
+    TEST_IGNORE();
+    alignas(16) char str[] = "Ending with ? means a question.";
+    TEST_ASSERT_EQUAL_STRING("Whatever.", response(str));
+}
+
+void test_starting_with_whitespace(void) {
+    TEST_IGNORE();
+    alignas(16) char str[] = "         hmmmmmmm...";
+    TEST_ASSERT_EQUAL_STRING("Whatever.", response(str));
 }
 
 void test_nonquestion_ending_with_whitespace(void) {
     TEST_IGNORE();
-    char str[] = "This is a statement ending with whitespace      ";
+    alignas(16) char str[] = "This is a statement ending with whitespace      ";
     TEST_ASSERT_EQUAL_STRING("Whatever.", response(str));
 }
 
 int main(void) {
     UNITY_BEGIN();
-    RUN_TEST(test_stating_something);
-    RUN_TEST(test_shouting);
-    RUN_TEST(test_shouting_gibberish);
     RUN_TEST(test_asking_a_question);
+    RUN_TEST(test_shouting);
+    RUN_TEST(test_forceful_question);
+    RUN_TEST(test_silence);
+    RUN_TEST(test_stating_something);
     RUN_TEST(test_asking_a_numeric_question);
     RUN_TEST(test_asking_gibberish);
-    RUN_TEST(test_talking_forcefully);
-    RUN_TEST(test_using_acronyms_in_regular_speech);
-    RUN_TEST(test_forceful_question);
-    RUN_TEST(test_shouting_numbers);
-    RUN_TEST(test_no_letters);
     RUN_TEST(test_question_with_no_letters);
-    RUN_TEST(test_shouting_with_special_characters);
-    RUN_TEST(test_shouting_with_no_exclamation_mark);
-    RUN_TEST(test_statement_containing_question_mark);
     RUN_TEST(test_nonletters_with_question);
     RUN_TEST(test_prattling_on);
-    RUN_TEST(test_silence);
+    RUN_TEST(test_ending_with_whitespace);
+    RUN_TEST(test_multiple_line_question);
+    RUN_TEST(test_shouting_gibberish);
+    RUN_TEST(test_shouting_a_statement_containing_a_question_mark);
+    RUN_TEST(test_shouting_numbers);
+    RUN_TEST(test_shouting_with_special_characters);
+    RUN_TEST(test_shouting_with_no_exclamation_mark);
     RUN_TEST(test_prolonged_silence);
     RUN_TEST(test_alternate_silence);
-    RUN_TEST(test_multiple_line_question);
-    RUN_TEST(test_starting_with_whitespace);
-    RUN_TEST(test_ending_with_whitespace);
     RUN_TEST(test_other_whitespace);
+    RUN_TEST(test_talking_forcefully);
+    RUN_TEST(test_using_acronyms_in_regular_speech);
+    RUN_TEST(test_no_letters);
+    RUN_TEST(test_statement_containing_question_mark);
+    RUN_TEST(test_starting_with_whitespace);
     RUN_TEST(test_nonquestion_ending_with_whitespace);
     return UNITY_END();
 }

--- a/exercises/practice/list-ops/.meta/tests.toml
+++ b/exercises/practice/list-ops/.meta/tests.toml
@@ -23,12 +23,15 @@ description = "append entries to a list and return the new list -> non-empty lis
 
 [28444355-201b-4af2-a2f6-5550227bde21]
 description = "concatenate a list of lists -> empty list"
+include = false
 
 [331451c1-9573-42a1-9869-2d06e3b389a9]
 description = "concatenate a list of lists -> list of lists"
+include = false
 
 [d6ecd72c-197f-40c3-89a4-aa1f45827e09]
 description = "concatenate a list of lists -> list of nested lists"
+include = false
 
 [0524fba8-3e0f-4531-ad2b-f7a43da86a16]
 description = "filter list returning only values that satisfy the filter function -> empty list"
@@ -38,9 +41,11 @@ description = "filter list returning only values that satisfy the filter functio
 
 [1cf0b92d-8d96-41d5-9c21-7b3c37cb6aad]
 description = "returns the length of a list -> empty list"
+include = false
 
 [d7b8d2d9-2d16-44c4-9a19-6e5f237cb71e]
 description = "returns the length of a list -> non-empty list"
+include = false
 
 [c0bc8962-30e2-4bec-9ae4-668b8ecd75aa]
 description = "return a list of elements whose values equal the list value transformed by the mapping function -> empty list"
@@ -104,3 +109,4 @@ description = "reverse the elements of the list -> non-empty list"
 
 [40872990-b5b8-4cb8-9085-d91fc0d05d26]
 description = "reverse the elements of the list -> list of lists is not flattened"
+include = false

--- a/exercises/practice/list-ops/list_ops_test.c
+++ b/exercises/practice/list-ops/list_ops_test.c
@@ -1,39 +1,36 @@
-// Version: 0
-
 #include "vendor/unity.h"
 
 #include <stdbool.h>
 #include <stddef.h>
 
-#define MAX_ARRAY_SIZE 16
+#define BUFFER_SIZE 16
 
-#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+#define ARRAY_SIZE(x) ((int)(sizeof(x) / sizeof((x)[0])))
 
-extern int append(const int *first_array, const int first_array_size, const int *second_array, const int second_array_size,
-                  int *result_array);
-extern int filter(const int *array, const int array_size, bool (*filter_predicate)(int), int *result_array);
-extern int map(const int *array, const int array_size, int (*map_transform)(int), int *result_array);
-extern int foldl(const int *array, const int array_size, int initial, int (*fold_accumulate)(int, int));
-extern int foldr(const int *array, const int array_size, int initial, int (*fold_accumulate)(int, int));
-extern int reverse(const int *array, const int array_size, int *result_array);
+extern int append(const int *list1, const int list1_size, const int *list2, const int list2_size, int *result);
+extern int filter(const int *list, const int list_size, bool (*filter_predicate)(int), int *result);
+extern int map(const int *list, const int list_size, int (*map_transform)(int), int *result);
+extern int foldl(const int *list, const int list_size, int initial, int (*fold_accumulate)(int, int));
+extern int foldr(const int *list, const int list_size, int initial, int (*fold_accumulate)(int, int));
+extern int reverse(const int *list, const int list_size, int *result);
 
-static bool filter_odd(int x) {
+static bool is_odd(int x) {
     return x % 2 == 1;
 }
 
-static int map_increment(int x) {
+static int plus_one(int x) {
     return x + 1;
 }
 
-static int fold_multiply(int acc, int el) {
+static int multiply(int acc, int el) {
     return el * acc;
 }
 
-static int fold_add(int acc, int el) {
+static int add(int acc, int el) {
     return el + acc;
 }
 
-static int fold_divide(int acc, int el) {
+static int divide(int acc, int el) {
     return acc == 0 ? 0 : el / acc;
 }
 
@@ -44,143 +41,115 @@ void tearDown(void) {
 }
 
 void test_append_empty_lists(void) {
-    int actual[MAX_ARRAY_SIZE];
-    int size = append(NULL, 0, NULL, 0, actual);
-    TEST_ASSERT_EQUAL_INT(0, size);
+    int buffer[BUFFER_SIZE];
+    TEST_ASSERT_EQUAL_INT(0, append(NULL, 0, NULL, 0, buffer));
 }
 
 void test_append_list_to_empty_list(void) {
     TEST_IGNORE();
-    int second_array[] = {1, 2, 3, 4};
-    int expected[] = {1, 2, 3, 4};
-    int actual[MAX_ARRAY_SIZE];
-    int size = append(NULL, 0, second_array, ARRAY_SIZE(second_array), actual);
-    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(expected), size);
-    TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, size);
+    const int list2[] = {1, 2, 3, 4};
+    int buffer[BUFFER_SIZE];
+    const int expected[] = {1, 2, 3, 4};
+    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(expected), append(NULL, 0, list2, ARRAY_SIZE(list2), buffer));
+    TEST_ASSERT_EQUAL_INT_ARRAY(expected, buffer, ARRAY_SIZE(expected));
 }
 
 void test_append_empty_list_to_list(void) {
     TEST_IGNORE();
-    int first_array[] = {1, 2, 3, 4};
-    int expected[] = {1, 2, 3, 4};
-    int actual[MAX_ARRAY_SIZE];
-    int size = append(first_array, ARRAY_SIZE(first_array), NULL, 0, actual);
-    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(expected), size);
-    TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, size);
+    const int list1[] = {1, 2, 3, 4};
+    int buffer[BUFFER_SIZE];
+    const int expected[] = {1, 2, 3, 4};
+    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(expected), append(list1, ARRAY_SIZE(list1), NULL, 0, buffer));
+    TEST_ASSERT_EQUAL_INT_ARRAY(expected, buffer, ARRAY_SIZE(expected));
 }
 
 void test_append_nonempty_lists(void) {
     TEST_IGNORE();
-    int first_array[] = {1, 2};
-    int second_array[] = {2, 3, 4, 5};
-    int expected[] = {1, 2, 2, 3, 4, 5};
-    int actual[MAX_ARRAY_SIZE];
-    int size = append(first_array, ARRAY_SIZE(first_array), second_array, ARRAY_SIZE(second_array), actual);
-    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(expected), size);
-    TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, size);
+    const int list1[] = {1, 2};
+    const int list2[] = {2, 3, 4, 5};
+    int buffer[BUFFER_SIZE];
+    const int expected[] = {1, 2, 2, 3, 4, 5};
+    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(expected), append(list1, ARRAY_SIZE(list1), list2, ARRAY_SIZE(list2), buffer));
+    TEST_ASSERT_EQUAL_INT_ARRAY(expected, buffer, ARRAY_SIZE(expected));
 }
 
 void test_filter_empty_list(void) {
     TEST_IGNORE();
-    int actual[MAX_ARRAY_SIZE];
-    int size = filter(NULL, 0, filter_odd, actual);
-    TEST_ASSERT_EQUAL_INT(0, size);
+    int buffer[BUFFER_SIZE];
+    TEST_ASSERT_EQUAL_INT(0, filter(NULL, 0, is_odd, buffer));
 }
 
 void test_filter_nonempty_list(void) {
     TEST_IGNORE();
-    int array[] = {1, 2, 3, 5};
-    int expected[] = {1, 3, 5};
-    int actual[MAX_ARRAY_SIZE];
-    int size = filter(array, ARRAY_SIZE(array), filter_odd, actual);
-    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(expected), size);
-    TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, size);
+    const int list[] = {1, 2, 3, 5};
+    int buffer[BUFFER_SIZE];
+    const int expected[] = {1, 3, 5};
+    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(expected), filter(list, ARRAY_SIZE(list), is_odd, buffer));
+    TEST_ASSERT_EQUAL_INT_ARRAY(expected, buffer, ARRAY_SIZE(expected));
 }
 
 void test_map_empty_list(void) {
     TEST_IGNORE();
-    int actual[MAX_ARRAY_SIZE];
-    int size = map(NULL, 0, map_increment, actual);
-    TEST_ASSERT_EQUAL_INT(0, size);
+    int buffer[BUFFER_SIZE];
+    TEST_ASSERT_EQUAL_INT(0, map(NULL, 0, plus_one, buffer));
 }
 
 void test_map_nonempty_list(void) {
     TEST_IGNORE();
-    int array[] = {1, 3, 5, 7};
-    int expected[] = {2, 4, 6, 8};
-    int actual[MAX_ARRAY_SIZE];
-    int size = map(array, ARRAY_SIZE(array), map_increment, actual);
-    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(expected), size);
-    TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, size);
+    const int list[] = {1, 3, 5, 7};
+    int buffer[BUFFER_SIZE];
+    const int expected[] = {2, 4, 6, 8};
+    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(expected), map(list, ARRAY_SIZE(list), plus_one, buffer));
+    TEST_ASSERT_EQUAL_INT_ARRAY(expected, buffer, ARRAY_SIZE(expected));
 }
 
 void test_foldl_empty_list(void) {
     TEST_IGNORE();
-    int initial = 2;
-    int expected = 2;
-    int actual = foldl(NULL, 0, initial, fold_multiply);
-    TEST_ASSERT_EQUAL_INT(expected, actual);
+    TEST_ASSERT_EQUAL_INT(2, foldl(NULL, 0, 2, multiply));
 }
 
 void test_foldl_direction_independent_function_applied_to_nonempty_list(void) {
     TEST_IGNORE();
-    int array[] = {1, 2, 3, 4};
-    int initial = 5;
-    int expected = 15;
-    int actual = foldl(array, ARRAY_SIZE(array), initial, fold_add);
-    TEST_ASSERT_EQUAL_INT(expected, actual);
+    const int list[] = {1, 2, 3, 4};
+    TEST_ASSERT_EQUAL_INT(15, foldl(list, ARRAY_SIZE(list), 5, add));
 }
 
 void test_foldl_direction_dependent_function_applied_to_nonempty_list(void) {
     TEST_IGNORE();
-    int array[] = {2, 5};
-    int initial = 5;
-    int expected = 0;
-    int actual = foldl(array, ARRAY_SIZE(array), initial, fold_divide);
-    TEST_ASSERT_EQUAL_INT(expected, actual);
+    const int list[] = {2, 5};
+    TEST_ASSERT_EQUAL_INT(0, foldl(list, ARRAY_SIZE(list), 5, divide));
 }
 
 void test_foldr_empty_list(void) {
     TEST_IGNORE();
-    int initial = 2;
-    int expected = 2;
-    int actual = foldr(NULL, 0, initial, fold_multiply);
-    TEST_ASSERT_EQUAL_INT(expected, actual);
+    TEST_ASSERT_EQUAL_INT(2, foldr(NULL, 0, 2, multiply));
 }
 
 void test_foldr_direction_independent_function_applied_to_nonempty_list(void) {
     TEST_IGNORE();
-    int array[] = {1, 2, 3, 4};
-    int initial = 5;
-    int expected = 15;
-    int actual = foldr(array, ARRAY_SIZE(array), initial, fold_add);
-    TEST_ASSERT_EQUAL_INT(expected, actual);
+    const int list[] = {1, 2, 3, 4};
+    TEST_ASSERT_EQUAL_INT(15, foldr(list, ARRAY_SIZE(list), 5, add));
 }
 
 void test_foldr_direction_dependent_function_applied_to_nonempty_list(void) {
     TEST_IGNORE();
-    int array[] = {2, 5};
-    int initial = 5;
-    int expected = 2;
-    int actual = foldr(array, ARRAY_SIZE(array), initial, fold_divide);
-    TEST_ASSERT_EQUAL_INT(expected, actual);
+    const int list[] = {2, 5};
+    TEST_ASSERT_EQUAL_INT(2, foldr(list, ARRAY_SIZE(list), 5, divide));
 }
 
 void test_reverse_empty_list(void) {
     TEST_IGNORE();
-    int actual[MAX_ARRAY_SIZE];
-    int size = reverse(NULL, 0, actual);
-    TEST_ASSERT_EQUAL_INT(0, size);
+    int buffer[BUFFER_SIZE];
+    TEST_ASSERT_EQUAL_INT(0, reverse(NULL, 0, buffer));
 }
 
 void test_reverse_nonempty_list(void) {
     TEST_IGNORE();
-    int array[] = {1, 3, 5, 7};
-    int expected[] = {7, 5, 3, 1};
-    int actual[MAX_ARRAY_SIZE];
-    int size = reverse(array, ARRAY_SIZE(array), actual);
-    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(expected), size);
-    TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, size);
+    const int list[] = {1, 3, 5, 7};
+    int buffer[BUFFER_SIZE];
+    const int expected[] = {7, 5, 3, 1};
+    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(expected), reverse(list, ARRAY_SIZE(list), buffer));
+    TEST_ASSERT_EQUAL_INT_ARRAY(expected, buffer, ARRAY_SIZE(expected));
 }
 
 int main(void) {

--- a/generators/exercises/bob.py
+++ b/generators/exercises/bob.py
@@ -1,7 +1,9 @@
 FUNC_PROTO = """\
 #include "vendor/unity.h"
 
-extern const char *response(const char *hey_bob);
+#include <stdalign.h>
+
+extern const char *response(const char hey_bob[]);
 """
 
 
@@ -9,6 +11,6 @@ def gen_func_body(prop, inp, expected):
     str_list = []
     value = inp["heyBob"]
     value = value.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
-    str_list.append(f'char str[] = "{value}";\n')
+    str_list.append(f'alignas(16) char str[] = "{value}";\n')
     str_list.append(f'TEST_ASSERT_EQUAL_STRING("{expected}", {prop}(str));\n')
     return "".join(str_list)

--- a/generators/exercises/list_ops.py
+++ b/generators/exercises/list_ops.py
@@ -1,0 +1,127 @@
+FUNC_PROTO = """\
+#include "vendor/unity.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#define BUFFER_SIZE 16
+
+#define ARRAY_SIZE(x) ((int)(sizeof(x) / sizeof((x)[0])))
+
+extern int append(const int *list1, const int list1_size, const int *list2, const int list2_size,
+                  int *result);
+extern int filter(const int *list, const int list_size, bool (*filter_predicate)(int), int *result);
+extern int map(const int *list, const int list_size, int (*map_transform)(int), int *result);
+extern int foldl(const int *list, const int list_size, int initial, int (*fold_accumulate)(int, int));
+extern int foldr(const int *list, const int list_size, int initial, int (*fold_accumulate)(int, int));
+extern int reverse(const int *list, const int list_size, int *result);
+
+static bool is_odd(int x) {
+    return x % 2 == 1;
+}
+
+static int plus_one(int x) {
+    return x + 1;
+}
+
+static int multiply(int acc, int el) {
+    return el * acc;
+}
+
+static int add(int acc, int el) {
+    return el + acc;
+}
+
+static int divide(int acc, int el) {
+    return acc == 0 ? 0 : el / acc;
+}
+"""
+
+
+def array_literal(numbers):
+    return "{" + ", ".join(str(d) for d in numbers) + "}"
+
+
+def describe(case):
+    description = case["description"]
+    property = case["property"]
+    return f"{property} {description}"
+
+
+def gen_func_body(prop, inp, expected):
+    str_list = []
+
+    if prop in ["foldl", "foldr"]:
+        initial = inp["initial"]
+
+    function = None
+    if prop not in ["append", "reverse"]:
+        function = inp["function"]
+        if function == "(x) -> x modulo 2 == 1":
+            function = "is_odd"
+        if function == "(x) -> x + 1":
+            function = "plus_one"
+
+        if function == "(acc, el) -> el * acc":
+            function = "multiply"
+        if function == "(acc, el) -> el + acc":
+            function = "add"
+        if function == "(acc, el) -> el / acc":
+            function = "divide"
+
+    if prop == "append":
+        list1 = inp["list1"]
+        list2 = inp["list2"]
+        if len(list1) > 0:
+            str_list.append(f"const int list1[] = {array_literal(list1)};\n")
+            list1_with_count = "list1, ARRAY_SIZE(list1)"
+        else:
+            list1_with_count = "NULL, 0"
+        if len(list2) > 0:
+            str_list.append(f"const int list2[] = {array_literal(list2)};\n")
+            list2_with_count = "list2, ARRAY_SIZE(list2)"
+        else:
+            list2_with_count = "NULL, 0"
+    else:
+        list_ = inp["list"]
+        if function == "divide":
+            initial = 5
+            list_ = [2, 5]
+            if prop == "foldl":
+                expected = 0
+            else:
+                expected = 2
+
+        if len(list_) > 0:
+            str_list.append(f"const int list[] = {array_literal(list_)};\n")
+            list_with_count = "list, ARRAY_SIZE(list)"
+        else:
+            list_with_count = "NULL, 0"
+
+    match prop:
+        case "append":
+            str_list.append("int buffer[BUFFER_SIZE];\n")
+            call = f"{prop}({list1_with_count}, {list2_with_count}, buffer)"
+        case "filter" | "map":
+            str_list.append("int buffer[BUFFER_SIZE];\n")
+            call = f"{prop}({list_with_count}, {function}, buffer)"
+        case "foldl" | "foldr":
+            call = f"{prop}({list_with_count}, {initial}, {function})"
+        case "reverse":
+            str_list.append("int buffer[BUFFER_SIZE];\n")
+            call = f"{prop}({list_with_count}, buffer)"
+
+    if isinstance(expected, list):
+        if len(expected) == 0:
+            str_list.append(f"TEST_ASSERT_EQUAL_INT(0, {call});\n")
+        else:
+            expected = array_literal(expected)
+            str_list.append(f"const int expected[] = {expected};\n")
+            str_list.append(f"TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(expected), {call});\n")
+            str_list.append(
+                "TEST_ASSERT_EQUAL_INT_ARRAY(expected, buffer, ARRAY_SIZE(expected));\n"
+            )
+    else:
+        str_list.append(f"TEST_ASSERT_EQUAL_INT({expected}, {call});\n")
+
+    return "".join(str_list)

--- a/generators/generate
+++ b/generators/generate
@@ -61,7 +61,7 @@ def flatten_cases(data):
 def add_case(cases_by_id, case):
     if "reimplements" in case:
         cases_by_id[case["reimplements"]] = case
-    else:
+    elif case["uuid"] not in cases_by_id:
         cases_by_id[case["uuid"]] = case
 
 


### PR DESCRIPTION
Add a generator for `list-ops`. It was copied from the arm64-assembly track, but with some changes to keep it compatible with the current test file.

Sync `bob` with upstream, adding a new test case. 

I almost didn't notice it, but one of the test cases already present in `bob` was missing after the sync. With some investigation, I found that the cases were reordered upstream and the "multiple line question" case is now reimplemented before its first implementation. To my knowledge, it is the first time this happens, all reimplementations I've seen before were declared in `tests.toml` _after_ the implementation (which has an "include = false").

The current generator couldn't handle this different order because reimplementations substitute the case with the reimplemented uuid, but otherwise the uuid is added directly. So, if the reimplementation was declared before, it was then replaced by the reimplemented case. Since the reimplemented case has an "include = false", it was filtered out after being added.

Changing the order of cases in `tests.toml` didn't solve the issue because the cases are read by the generator directly from `canonical-data.json`. `tests.toml` is read only after that, to filter out cases with an `include = false`.

So, I made a small change to the generator, so that a case is only added if its uuid was not added before. This fixes the problem.