### PR TITLE
Adjust `integers` concept

### DIFF
--- a/concepts/integers/about.md
+++ b/concepts/integers/about.md
@@ -88,7 +88,7 @@ Step 2 (add 1):
 
 Note that the binary representation of `-23` and the binary representation of `233` are equal.
 
-To provide disambiguation, in a signed integer the uppermost bit (the one corresponding to `2⁶³`) is not summed up to the others.
+To provide disambiguation, in a signed integer the uppermost bit is not summed up to the others.
 Instead, its value is subtracted.
 
 Since this bit corresponds to a higher value than the sum of all the others, in practice this means a number with this bit set is always negative.

--- a/concepts/integers/about.md
+++ b/concepts/integers/about.md
@@ -5,21 +5,19 @@ In an assembly language, most abstractions common in higher-level languages are 
 Values in a register or in memory are simply a sequence of one or more [bytes][byte], each formed of eight [bits][bit].
 Most, if not all, abstractions are built on top of this.
 
-## Binary notation
+## Binary Notation
 
 [Integers][integer] are one of the most important and fundamental abstractions.
 They represent whole numbers such as `4`, `-2`, `0` or `64532`.
 
 To represent an integer as a sequence of bytes, the [binary notation][binary] is used.
-In this system, each bit in the sequence represents a distinct power of two, with the value increasing as the index of the bit increases from right to left.
+In this notation, each bit in the sequence represents a distinct power of two, with the value increasing as the index of the bit increases from right to left.
 
-## Unsigned and Signed Integers
+## Unsigned Numbers
 
-### Unsigned numbers
+If the number can only be non-negative, it's called an **unsigned** number.
 
-If the number is known to be non-negative, it's called an **unsigned** number.
-
-Unsigned numbers are represented directly as the sum of all set bits in their sequence.
+Unsigned numbers are represented directly as the sum of the powers of two corresponding to all set bits in their sequence.
 
 For instance, this represents the number `2⁰ + 2³ + 2⁵ + 2⁶ + 2⁷`, which is `233`:
 
@@ -32,7 +30,13 @@ Given an arbitrary sequence of bytes, any non-negative whole number could be the
 In practice, however, a register can only hold up to 64 bits.
 So, the range of representable non-negative integers in a register goes from `0` (no bit set) to `2⁶⁴ - 1` (sum of all 64 bits set).
 
-### Signed numbers
+Widening an unsigned number to a larger size is done by filling all upper bits with `0`, so that no new bit contributes to the value.
+This is called **zero-extension**.
+
+The instruction [movzx][movzx] (`z` for zero) zero-extends an 8-bit or 16-bit source operand to a larger destination operand.
+A 32-bit source operand is always zero-extended to all 64 bits of the destination operand with a simple `mov`.
+
+## Signed Numbers
 
 If an integer can assume positive or negative values, it's called a **signed** number.
 
@@ -82,15 +86,21 @@ Step 2 (add 1):
 | ----- | --- | --- | --- | --- | --- | --- | --- | --- |
 | bits  | 0   | 0   | 0   | 1   | 0   | 1   | 1   | 1   |
 
-The [neg][neg] instruction can be used to change the sign of a number.
-
 Note that the binary representation of `-23` and the binary representation of `233` are equal.
 
-To provide disambiguation, in a signed integer, the most significant bit is not summed up to the others.
+To provide disambiguation, in a signed integer the uppermost bit (the one corresponding to `2⁶³`) is not summed up to the others.
 Instead, its value is subtracted.
 
-Since this bit corresponds to a higher value than the sum of all the others, a number with this bit set is always negative.
-This bit is called the **sign bit**.
+Since this bit corresponds to a higher value than the sum of all the others, in practice this means a number with this bit set is always negative.
+This special bit is called the **sign bit**.
+
+Widening a signed number to a larger size means filling every new upper bit with a copy of the sign bit, so that the value is preserved.
+This is called **sign-extension**.
+
+The instruction [movsx][movsx] (`s` for sign) sign-extends an 8-bit or 16-bit source operand to a larger destination operand.
+A variant of `movsx` called `movsxd` does the same from a 32-bit source operand to a 64-bit destination operand.
+
+The [neg][neg] instruction can be used to change the sign of a number.
 
 ~~~~exercism/caution
 In assembly, there's no way to tell if a sequence of bytes represents a signed or an unsigned number.
@@ -101,27 +111,38 @@ The use of comments can be a great aid in this task.
 
 ## Immediates
 
-In a previous concept, it was mentioned that a constant number, such as `4` or `15`, can be used as source operand to many instructions.
+In a previous concept, it was mentioned that a constant number, such as `4` or `-15`, can be used as source operand to many instructions.
 Those numbers are called **immediates**.
 
-An immediate is truncated to fit into the destination operand.
-However, in most instructions, an immediate must be at most a _32-bit signed integer_.
-A number that does not fit into this size can not be used directly as operand.
+An immediate is not held in a register or in memory: it is encoded inside the instruction itself.
+In most instructions, the space reserved for it is only 32 bits wide, no matter how large the destination operand is.
 
-The exception to this rule is `mov`, which accepts a _64-bit signed integer_ as source operand.
-
-It is possible to use a signed negative integer as immediate in place of an unsigned integer with the same bit representation:
+When the destination operand is 64 bits wide, those 32 bits are _sign-extended_ to fill it.
+The upper half of the operand receives copies of the uppermost bit of the immediate, so only a number in the range of a _32-bit signed integer_ can be written this way:
 
 ```x86asm
-add rax, -1  ; this is 18446744073709551615 in unsigned representation
-             ; an attempt to use 18446744073709551615 directly wouldn't work because immediates are usually 32-bit signed integers
-
-mov rax, 18446744073709551615  ; this works because mov can take a 64-bit immediate as source operand
+add rax, -1          ; the immediate is sign-extended, so all 64 bits of rax are affected
+add rax, 2147483647  ; the largest immediate an instruction like this accepts
 ```
 
-## Arithmetic
+A number outside that range can not be used as an immediate.
+The exception to this rule is `mov`, which has a special form, available only when the destination operand is a register, that carries a full 64-bit immediate.
+If a 64-bit immediate is needed, first use `mov` to load it into a register, then use the register:
 
-### Sum
+```x86asm
+mov rax, 3435973837           ; this works, mov can take a 64-bit immediate
+mov rdx, 18446744073709551615 ; the largest immediate mov accepts
+sub rdx, rax
+```
+
+Note that a negative immediate and the unsigned number with the same bit representation are equivalent and assemble to exactly the same value:
+
+```x86asm
+mov rax, -1                   ; rax = 18446744073709551615
+mov rax, 18446744073709551615 ; rax = -1
+```
+
+## Sum
 
 The sum of two integers can be represented as setting all bits that are set in only one of the two numbers and carrying over bits that are set in both.
 
@@ -150,7 +171,7 @@ Number `13`:
 The bits in index `1` and `4` are only set in the number `30` and the bit in index `0` is only set in number `13`.
 So they are all set in the resulting sum:
 
-Step 1 (set all bits present in only of the numbers):
+Step 1 (set all bits present in only one of the numbers):
 
 | index | 7   | 6   | 5   | 4   | 3   | 2   | 1   | 0   |
 | ----- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -188,32 +209,35 @@ The `CF` can also be set by other instructions, performing other operations.
 The instruction [adc][adc] can be used to sum two numbers and also the value in the carry flag.
 It is a two-operand instruction, with the same syntax as `add`.
 
-There's also an [inc][inc] one-operand instruction, that sums 1 to the value in its operand:
+There's also an [inc][inc] one-operand instruction, that adds `1` to the value in its operand:
 
 ```x86asm
-inc dest ; dest = dest + 1
+inc rax ; rax = rax + 1
 ```
 
 The sum of two integers operates in the same way for both unsigned and signed numbers.
 
-### Subtraction
+## Subtraction
 
 The subtraction of two integers is performed using the `sub` instruction.
 
-There's also a [dec][dec] one-operand instruction, that subtracts 1 from the value in its operand:
+In the same way an addition can leave a carry, a subtraction can leave a _borrow_ in `CF`.
+There is an instruction [sbb][sbb] that subtracts both the source operand and also the borrow from the destination operand.
+
+There's also a [dec][dec] one-operand instruction, that subtracts `1` from the value in its operand:
 
 ```x86asm
-dec dest ; dest = dest - 1
+dec rax ; rax = rax - 1
 ```
 
 The subtraction of two integers also operates in the same way for both unsigned and signed numbers.
 
-### Multiplication
+## Multiplication
 
 There are two different instructions to perform multiplication between two numbers in x86-64.
 As a rule, unsigned multiplication uses the instruction [mul][mul], while signed multiplication uses [imul][imul].
 
-The `mul` instruction takes the following one-operand form, where src is the source operand:
+The `mul` instruction takes the following one-operand form, where `src` is the source operand:
 
 ```x86asm
 mul src
@@ -227,7 +251,7 @@ imul dest, src
 imul dest, src1, src2
 ```
 
-#### One-operand form
+### One-Operand Multiplication
 
 As a general rule, the range of bits needed to represent the product of two integers is the sum of the range of bits needed for each integer being multiplied.
 
@@ -236,9 +260,14 @@ This means that the product of two numbers in the range of a 64-bit register nee
 That's why two registers are implicitly used to perform a multiplication in one-operand form: `rax` and `rdx`.
 If the multiplication involves two 64-bit numbers, then the lower 64 bits of the result will be in `rax` and the upper 64 bits will be in `rdx`.
 
-This is usually called `rdx:rax`, to indicate that both registers are used in tandem.
+This is usually called `rdx:rax`, to indicate that both registers are used in tandem:
 
-The same happens if the multiplication involves different register sizes.
+```x86asm
+mul rcx ; rax = lower 64 bits of rax * rcx
+        ; rdx = upper 64 bits of rax * rcx
+```
+
+The same happens for other operand sizes.
 So, for instance, if two 32-bit numbers are being multiplied, `eax` and `edx` will be used.
 
 The exception is the multiplication between two bytes.
@@ -247,53 +276,69 @@ In this case, instead of `dl:al`, `ax` will be used.
 The lower portion of `ax` (`al`) will get the lower 8 bits of the product, while the upper portion (`ah`) will get the upper 8 bits.
 
 ~~~~exercism/caution
-The `rdx` register is implicitly used in one-operand multiplication.
-This means any necessary value in `rdx` must be saved before that operation.
+Registers implicitly used in a multiplication, such as `rax` and `rdx`, are always overwritten.
+The values in those registers should be saved before the operation if they are necessary later.
 ~~~~
 
-#### Two-operand form
+### Two-Operand Multiplication
 
-The two-operand form of `imul` allows for explicitly declaring a different destination operand.
-
-In that case, the product between source and destination operands is placed in the destination operand.
-This product is truncated to fit into the destination operand.
-
-#### Three-operand form
-
-The three-operand form of `imul` multiplies the two source operands and places the result in the destination operand.
-
-This means that the destination operand is not multiplied with any of the source operands, it just receives the result.
-This product is also truncated to fit into the destination operand.
-
-#### Handling overflow
-
-In case of a possible overflow, it is sometimes useful to move operands to a larger register size.
-
-A [movzx][movzx] instruction can be used to convert a value in an 8-bit or 16-bit source operand to a larger destination operand, clearing all remaining bits.
-This is called **zero extension**:
+The two-operand form of `imul` has an explicit destination operand and follows the usual syntax.
+`rdx` is not used. Instead, the result is truncated to fit into the destination operand.
 
 ```x86asm
-mov ax, 1000 ; lower 16 bits of eax are 1000, upper bits are undefined
-mov cx, 200 ; lower 16 bits of ecx are 200, upper bits are undefined
+imul r8, r9 ; r8 = lower 64 bits of r8 * r9
+```
+
+### Three-Operand Multiplication
+
+The three-operand form of `imul` has two source operands, the second of which is always an immediate (a constant number).
+Both source operands are multiplied and the result is truncated and placed in the destination operand:
+
+```x86asm
+imul r8, r9, 100 ; r8 = lower 64 bits of r9 * 100
+```
+
+Note that the destination operand is not used in the multiplication. It just receives the result.
+
+### Handling Overflow
+
+Both two-operand and three-operand multiplication truncate the result to fit into the size of the destination operand.
+A one-operand multiplication preserves the full range, but it is usually split into two registers, `rdx` and `rax`.
+
+So, it is sometimes useful to widen the operands before the multiplication to make room for the whole product in a single register.
+An unsigned operand is zero-extended, while a signed one is sign-extended:
+
+```x86asm
+movzx eax, di ; di and si hold unsigned 16-bit numbers
+movzx ecx, si
+mul ecx       ; the 32-bit product fits in eax, and edx is cleared
+```
+
+Widening is also necessary whenever only part of a register was written, since the remaining bits keep whatever they held before:
+
+```x86asm
+mov ax, 1000 ; lower 16 bits of eax are 1000, upper bits keep their previous contents
+mov cx, 200  ; lower 16 bits of ecx are 200, upper bits keep their previous contents
 
 ; 200 * 1000 does not fit in 16 bits, so a 32-bit multiplication is necessary
-; however, multiplying eax by ecx may produce an incorrect result due to undefined bits
+; however, multiplying eax by ecx would also multiply those leftover upper bits
 
 movzx eax, ax ; lower 16 bits of eax remain 1000, upper bits are cleared
 movzx ecx, cx ; lower 16 bits of ecx remain 200, upper bits are cleared
-mul ecx ; now eax correctly holds 200 * 1000
+mul ecx       ; now eax correctly holds 200 * 1000, and edx holds 0
 ```
 
-A 32-bit source operand is always zero-extended to all 64 bits of the destination operand with a simple `mov`.
-
-#### Using imul with unsigned numbers
+### Using imul With Unsigned Numbers
 
 It is possible to use `imul` to multiply unsigned numbers.
 However, this may give an incorrect result if one of the numbers may be interpreted as negative.
 
-Since the sign bit in a signed integer corresponds to the most significant bit in an unsigned integer, in practice, this difference becomes relevant when more than the truncated result is needed, i.e., when the full range of `rdx:rax` is used.
+Since the sign bit in a signed integer corresponds to the most significant bit in an unsigned integer, in practice this difference becomes relevant only when more than the truncated result is needed, that is, when the full range of `rdx:rax` is used.
 
-### Division
+The lower half of the product is the same for both instructions.
+Only the upper half, in `rdx`, differs.
+
+## Division
 
 As is the case with multiplication, there are also two instructions to perform division between two numbers.
 Unsigned division uses the instruction [div][div], while signed division uses [idiv][idiv].
@@ -305,37 +350,44 @@ div src
 idiv src
 ```
 
-In both cases, the value in `rdx:rax` is divided by the value in the source operand.
-The quotient is written to the `rax` register and the remainder is written to the `rdx` register.
+16-bit, 32-bit and 64-bit division use `dx:ax`, `edx:eax` and `rdx:rax` as the dividend, respectively.
+In these cases, both registers act in tandem to create a 2N-bit value, where N is the size of the operation (16-bit, 32-bit or 64-bit).
+This value is then divided by the source operand.
+The quotient is written to `ax`, `eax` or `rax` and the remainder is written to `dx`, `edx` or `rdx`, according to the size of the operation.
 
-Note that as `rdx:rax` is the dividend, both registers must have the appropriate bits set.
+The division between bytes is special: instead of using `dl:al`, `ax` is used.
+The lower 8 bits of `ax` (`al`) will get the quotient of the operation and the higher 8 bits (`ah`) will get the remainder.
 
-So, whenever working with 64-bit integers, the `rdx` register must be set up before the division.
+Note that all bits in the dividend should be appropriately set before the division.
+Any bit set in `rdx` (or in `ah` for 8-bit division) contributes to the value being divided.
 
-For unsigned division, all bits in `rdx` must be cleared.
-This is called **zero extension**.
+In unsigned division, when the value to be divided fits in the lower half, the upper half should be cleared.
+Any instruction that clears those bits will do.
+For example, `mov edx, 0` clears the upper bits in 32-bit division:
 
-For signed division, all bits in `rdx` must be cleared for a non-negative number in `rax`, and set for a negative number.
-This is called **sign extension**.
+```x86asm
+mov eax, edi ; the value to be divided
+mov edx, 0   ; a 32-bit destination is zero-extended, so the upper half is cleared
+div esi      ; eax = edi / esi, edx = edi % esi
+```
 
-Failing to do this can cause a wrong result for the division or, if the quotient is too large to fit in `rax`, an error.
+In signed division, the value should be sign-extended instead.
+There are instructions that automate this process: [cbw][cbw], [cwd][sign-extension], [cdq][sign-extension] and [cqo][sign-extension].
+The first sets the bits in `ah` according to the sign of `al`.
+The others perform sign-extension from `ax` to `dx`, from `eax` to `edx` and from `rax` to `rdx`, respectively.
 
-There are three instructions that automate the sign extension: [cwd][sign-extension], [cdq][sign-extension] and [cqo][sign-extension].
-They perform sign extension from `ax` to `dx`, from `eax` to `edx` and from `rax` to `rdx`, respectively.
+```x86asm
+mov eax, edi ; the value to be divided
+cdq          ; every bit of edx receives a copy of the sign bit of eax
+idiv esi     ; eax = edi / esi, edx = edi % esi
+```
 
-There's no equivalent instruction for sign extending `al` to `dl` because division between two bytes operates differently.
-Instead of using `dl:al`, `ax` is used.
-
-So, the lower 8 bits of `ax` (`al`) will get the quotient of the operation and the higher 8 bits (`ah`) will get the remainder.
-
-There is also the instruction [movsx][movsx] that works similarly to `movzx`, extending from any 8-bit or 16-bit source operand to a larger destination operand.
-While `movzx` performs zero-extension, `movsx` performs sign-extension.
-
-A variant of `movsx` called `movsxd` can sign-extend from a 32-bit source operand to a 64-bit destination operand.
+Failing to set the upper half can produce a wrong quotient.
+It can also stop the program: when the quotient does not fit in the destination register, the processor raises a divide error.
 
 ~~~~exercism/caution
-The `rdx` register is implicitly used in an integer division.
-This means any necessary value in `rdx` must be saved before that operation.
+Registers implicitly used in a division, such as `rax` and `rdx`, are always overwritten.
+The values in those registers should be saved before the division if they are necessary later.
 ~~~~
 
 [byte]: https://en.wikipedia.org/wiki/Byte
@@ -347,11 +399,13 @@ This means any necessary value in `rdx` must be saved before that operation.
 [neg]: https://www.felixcloutier.com/x86/neg
 [adc]: https://www.felixcloutier.com/x86/adc
 [inc]: https://www.felixcloutier.com/x86/inc
+[sbb]: https://www.felixcloutier.com/x86/sbb
 [dec]: https://www.felixcloutier.com/x86/dec
 [mul]: https://www.felixcloutier.com/x86/mul
 [imul]: https://www.felixcloutier.com/x86/imul
 [div]: https://www.felixcloutier.com/x86/div
 [idiv]: https://www.felixcloutier.com/x86/idiv
+[cbw]: https://www.felixcloutier.com/x86/cbw:cwde:cdqe
 [sign-extension]: https://www.felixcloutier.com/x86/cwd:cdq:cqo
 [movzx]: https://www.felixcloutier.com/x86/movzx
 [movsx]: https://www.felixcloutier.com/x86/movsx:movsxd

--- a/concepts/integers/about.md
+++ b/concepts/integers/about.md
@@ -118,7 +118,7 @@ An immediate is not held in a register or in memory: it is encoded inside the in
 In most instructions, the space reserved for it is only 32 bits wide, no matter how large the destination operand is.
 
 When the destination operand is 64 bits wide, those 32 bits are _sign-extended_ to fill it.
-The upper half of the operand receives copies of the uppermost bit of the immediate, so only a number in the range of a _32-bit signed integer_ can be written this way:
+The upper half of the operand is entirely filled with copies of the uppermost bit of the immediate, so only a number in the range of a _32-bit signed integer_ can be written this way:
 
 ```x86asm
 add rax, -1          ; the immediate is sign-extended, so all 64 bits of rax are affected
@@ -126,8 +126,8 @@ add rax, 2147483647  ; the largest immediate an instruction like this accepts
 ```
 
 A number outside that range can not be used as an immediate.
-The exception to this rule is `mov`, which has a special form, available only when the destination operand is a register, that carries a full 64-bit immediate.
-If a 64-bit immediate is needed, first use `mov` to load it into a register, then use the register:
+The exception to this rule is `mov`, which can take a full 64-bit immediate when the destination operand is a register.
+If a 64-bit immediate is needed, first use `mov` to load it into a register, then use that register:
 
 ```x86asm
 mov rax, 3435973837           ; this works, mov can take a 64-bit immediate

--- a/concepts/integers/introduction.md
+++ b/concepts/integers/introduction.md
@@ -28,7 +28,7 @@ If an integer can assume positive or negative values, it's called a **signed** n
 To represent negative numbers, x86-64 uses the **two's complement** representation.
 
 In two's complement, signed numbers are also represented as the sum of the powers of two corresponding to set bits.
-However, if the uppermost bit is set (the one corresponding to `2⁶³`), it is subtracted instead of added to the others.
+However, if the uppermost bit is set, it is subtracted instead of added to the others.
 
 Since this bit corresponds to a higher value than the sum of all the others, in practice this means a number with this bit set is always negative.
 This special bit is called the **sign bit**.

--- a/concepts/integers/introduction.md
+++ b/concepts/integers/introduction.md
@@ -5,23 +5,39 @@
 An **integer** is an abstraction that represents whole numbers, such as `4`, `-2`, `0` or `64532`.
 
 To represent an integer as a sequence of bytes, the **binary notation** is used.
-In this system, each bit in the sequence represents a distinct power of two, with the value increasing as the index of the bit increases from right to left.
+In this notation, each bit in the sequence represents a distinct power of two, with the value increasing as the index of the bit increases from right to left.
 
-## Unsigned and Signed Integers
-
-### Unsigned numbers
+## Unsigned Numbers
 
 If the number can only be non-negative, it's called an **unsigned** number.
 
-Unsigned numbers are represented directly as the sum of all set bits in their sequence.
+Unsigned numbers are represented directly as the sum of the powers of two corresponding to all set bits in their sequence.
 
 The range of representable non-negative integers in a register goes from `0` (no bit set) to `2⁶⁴ - 1` (sum of all 64 bits set).
 
-### Signed numbers
+Widening an unsigned number to a larger size is done by filling all upper bits with `0`, so that no new bit contributes to the value.
+This is called **zero-extension**.
+
+The instruction `movzx` (`z` for zero) zero-extends an 8-bit or 16-bit source operand to a larger destination operand.
+A 32-bit source operand is always zero-extended to all 64 bits of the destination operand with a simple `mov`.
+
+## Signed Numbers
 
 If an integer can assume positive or negative values, it's called a **signed** number.
 
 To represent negative numbers, x86-64 uses the **two's complement** representation.
+
+In two's complement, signed numbers are also represented as the sum of the powers of two corresponding to set bits.
+However, if the uppermost bit is set (the one corresponding to `2⁶³`), it is subtracted instead of added to the others.
+
+Since this bit corresponds to a higher value than the sum of all the others, in practice this means a number with this bit set is always negative.
+This special bit is called the **sign bit**.
+
+Widening a signed number to a larger size means filling every new upper bit with a copy of the sign bit, so that the value is preserved.
+This is called **sign-extension**.
+
+The instruction `movsx` (`s` for sign) sign-extends an 8-bit or 16-bit source operand to a larger destination operand.
+A variant of `movsx` called `movsxd` does the same from a 32-bit source operand to a 64-bit destination operand.
 
 The `neg` instruction can be used to change the sign of a number.
 
@@ -34,55 +50,67 @@ The use of comments can be a great aid in this task.
 
 ## Immediates
 
-In a previous concept, it was mentioned that a constant number, such as `4` or `15`, can be used as source operand to many instructions.
+In a previous concept, it was mentioned that a constant number, such as `4` or `-15`, can be used as source operand to many instructions.
 Those numbers are called **immediates**.
 
-An immediate is truncated to fit into the destination operand.
-However, in most instructions, an immediate must be at most a _32-bit signed integer_.
-A number that does not fit into this size can not be used directly as operand.
+An immediate is not held in a register or in memory: it is encoded inside the instruction itself.
+In most instructions, the space reserved for it is only 32 bits wide, no matter how large the destination operand is.
 
-The exception to this rule is `mov`, which accepts a _64-bit signed integer_ as source operand.
-
-It is possible to use a signed negative integer as immediate in place of an unsigned integer with the same bit representation:
+When the destination operand is 64 bits wide, those 32 bits are _sign-extended_ to fill it.
+The upper half of the operand receives copies of the uppermost bit of the immediate, so only a number in the range of a _32-bit signed integer_ can be written this way:
 
 ```x86asm
-add rax, -1  ; this is 18446744073709551615 in unsigned representation
-             ; an attempt to use 18446744073709551615 directly wouldn't work because immediates are usually 32-bit signed integers
-
-mov rax, 18446744073709551615  ; this works because mov can take a 64-bit immediate as source operand
+add rax, -1          ; the immediate is sign-extended, so all 64 bits of rax are affected
+add rax, 2147483647  ; the largest immediate an instruction like this accepts
 ```
 
-## Arithmetic
+A number outside that range can not be used as an immediate.
+The exception to this rule is `mov`, which has a special form, available only when the destination operand is a register, that carries a full 64-bit immediate.
+If a 64-bit immediate is needed, first use `mov` to load it into a register, then use the register:
 
-### Sum
+```x86asm
+mov rax, 3435973837           ; this works, mov can take a 64-bit immediate
+mov rdx, 18446744073709551615 ; the largest immediate mov accepts
+sub rdx, rax
+```
+
+Note that a negative immediate and the unsigned number with the same bit representation are equivalent and assemble to exactly the same value:
+
+```x86asm
+mov rax, -1                   ; rax = 18446744073709551615
+mov rax, 18446744073709551615 ; rax = -1
+```
+
+## Sum
 
 The addition of two numbers can be calculated using the `add` instruction.
 
-Sometimes, the sum of two numbers leaves an excessive bit that does not fit into the destination operand.
-This bit is stored in a special flag called the **carry flag (CF)**.
-The `CF` can also be set by other instructions, performing other operations.
+There's also an `inc` one-operand instruction, that adds `1` to the value in its operand:
 
-The instruction `adc` can be used to sum two numbers and also the value in the carry flag.
-It is a two-operand instruction, with the same syntax as `add`.
-
-There's also an `inc` one-operand instruction, that sums 1 to the value in its operand.
+```x86asm
+inc rax ; rax = rax + 1
+```
 
 The sum of two integers operates in the same way for both unsigned and signed numbers.
 
-### Subtraction
+## Subtraction
 
 The subtraction of two integers is performed using the `sub` instruction.
 
-There's also a `dec` one-operand instruction, that subtracts 1 from the value in its operand.
+There's also a `dec` one-operand instruction, that subtracts `1` from the value in its operand:
+
+```x86asm
+dec rax ; rax = rax - 1
+```
 
 The subtraction of two integers also operates in the same way for both unsigned and signed numbers.
 
-### Multiplication
+## Multiplication
 
 There are two different instructions to perform multiplication between two numbers in x86-64.
 As a rule, unsigned multiplication uses the instruction `mul`, while signed multiplication uses `imul`.
 
-The `mul` instruction takes the following one-operand form, where src is the source operand:
+The `mul` instruction takes the following one-operand form, where `src` is the source operand:
 
 ```x86asm
 mul src
@@ -96,14 +124,19 @@ imul dest, src
 imul dest, src1, src2
 ```
 
-#### One-operand form
+### One-Operand Multiplication
 
 Two registers are implicitly used to perform a multiplication in one-operand form: `rax` and `rdx`.
 If the multiplication involves two 64-bit numbers, then the lower 64 bits of the result will be in `rax` and the upper 64 bits will be in `rdx`.
 
-This is usually called `rdx:rax`, to indicate that both registers are used in tandem.
+This is usually called `rdx:rax`, to indicate that both registers are used in tandem:
 
-The same happens if the multiplication involves different register sizes.
+```x86asm
+mul rcx ; rax = lower 64 bits of rax * rcx
+        ; rdx = upper 64 bits of rax * rcx
+```
+
+The same happens for other operand sizes.
 So, for instance, if two 32-bit numbers are being multiplied, `eax` and `edx` will be used.
 
 The exception is the multiplication between two bytes.
@@ -112,46 +145,47 @@ In this case, instead of `dl:al`, `ax` will be used.
 The lower portion of `ax` (`al`) will get the lower 8 bits of the product, while the upper portion (`ah`) will get the upper 8 bits.
 
 ~~~~exercism/caution
-The `rdx` register is implicitly used in a one-operand multiplication.
-This means any necessary value in `rdx` must be saved before that operation.
+Registers implicitly used in a multiplication, such as `rax` and `rdx`, are always overwritten.
+The values in those registers should be saved before the operation if they are necessary later.
 ~~~~
 
-#### Two-operand form
+### Two-Operand Multiplication
 
-The two-operand form of `imul` allows for explicitly declaring a different destination operand.
-
-In that case, the product between source and destination operands is placed in the destination operand.
-This product is truncated to fit into the destination operand.
-
-#### Three-operand form
-
-The three-operand form of `imul` multiplies the two source operands and places the result in the destination operand.
-
-This means that the destination operand is not multiplied with any of the source operands, it just receives the result.
-This product is also truncated to fit into the destination operand.
-
-#### Handling overflow
-
-In case of a possible overflow, it is sometimes useful to move operands to a larger register size.
-
-A `movzx` instruction can be used to convert a value in an 8-bit or 16-bit source operand to a larger destination operand, clearing all remaining bits.
-This is called **zero extension**:
+The two-operand form of `imul` has an explicit destination operand and follows the usual syntax.
+`rdx` is not used.
+Instead, the result is truncated to fit into the destination operand.
 
 ```x86asm
-mov ax, 1000 ; lower 16 bits of eax are 1000, upper bits are undefined
-mov cx, 200 ; lower 16 bits of ecx are 200, upper bits are undefined
-
-; 200 * 1000 does not fit in 16 bits, so a 32-bit multiplication is necessary
-; however, multiplying eax by ecx may produce an incorrect result due to undefined bits
-
-movzx eax, ax ; lower 16 bits of eax remain 1000, upper bits are cleared
-movzx ecx, cx ; lower 16 bits of ecx remain 200, upper bits are cleared
-mul ecx ; now eax correctly holds 200 * 1000
+imul r8, r9 ; r8 = lower 64 bits of r8 * r9
 ```
 
-A 32-bit source operand is always zero-extended to all 64 bits of the destination operand with a simple `mov`.
+### Three-Operand Multiplication
 
-### Division
+The three-operand form of `imul` has two source operands, the second of which is always an immediate (a constant number).
+Both source operands are multiplied and the result is truncated and placed in the destination operand:
+
+```x86asm
+imul r8, r9, 100 ; r8 = lower 64 bits of r9 * 100
+```
+
+Note that the destination operand is not used in the multiplication.
+It just receives the result.
+
+### Handling Overflow
+
+Both two-operand and three-operand multiplication truncate the result to fit into the size of the destination operand.
+A one-operand multiplication preserves the full range, but it is usually split into two registers, `rdx` and `rax`.
+
+So, it is sometimes useful to widen the operands before the multiplication to make room for the whole product in a single register.
+An unsigned operand is zero-extended, while a signed one is sign-extended:
+
+```x86asm
+movzx eax, di ; di and si hold unsigned 16-bit numbers
+movzx ecx, si
+mul ecx       ; the 32-bit product fits in eax, and edx is cleared
+```
+
+## Division
 
 As is the case with multiplication, there are also two instructions to perform division between two numbers.
 Unsigned division uses the instruction `div`, while signed division uses `idiv`.
@@ -163,35 +197,27 @@ div src
 idiv src
 ```
 
-In both cases, the value in `rdx:rax` is divided by the value in the source operand.
-The quotient is written to the `rax` register and the remainder is written to the `rdx` register.
+16-bit, 32-bit and 64-bit division use `dx:ax`, `edx:eax` and `rdx:rax` as the dividend, respectively.
+In these cases, both registers act in tandem to create a 2N-bit value, where N is the size of the operation (16-bit, 32-bit or 64-bit).
+This value is then divided by the source operand.
+The quotient is written to `ax`, `eax` or `rax` and the remainder is written to `dx`, `edx` or `rdx`, according to the size of the operation.
 
-Note that as `rdx:rax` is the dividend, both registers must have the appropriate bits set.
+The division between bytes is special: instead of using `dl:al`, `ax` is used.
+The lower 8 bits of `ax` (`al`) will get the quotient of the operation and the higher 8 bits (`ah`) will get the remainder.
 
-So, whenever working with 64-bit integers, the `rdx` register must be set up before the division.
+Note that all bits in the dividend should be appropriately set before the division.
+Any bit set in `rdx` (or in `ah` for 8-bit division) contributes to the value being divided.
 
-For unsigned division, all bits in `rdx` must be cleared.
-This is called **zero extension**.
+In unsigned division, when the value to be divided fits in the lower half, the upper half should be cleared.
+Any instruction that clears those bits will do.
+For example, `mov edx, 0` clears the upper bits in 32-bit division.
 
-For signed division, all bits in `rdx` must be cleared for a non-negative number in `rax`, and set for a negative number.
-This is called **sign extension**.
-
-Failing to do this can cause a wrong result for the division or, if the quotient is too large to fit in `rax`, an error.
-
-There are three instructions that automate the sign extension: `cwd`, `cdq` and `cqo`.
-They perform sign extension from `ax` to `dx`, from `eax` to `edx` and from `rax` to `rdx`, respectively.
-
-There's no equivalent instruction for sign extending `al` to `dl` because division between two bytes operates differently.
-Instead of using `dl:al`, `ax` is used.
-
-So, the lower 8 bits of `ax` (`al`) will get the quotient of the operation and the higher 8 bits (`ah`) will get the remainder.
-
-There is also the instruction `movsx` that works similarly to `movzx`, extending from any 8-bit or 16-bit source operand to a larger destination operand.
-While `movzx` performs zero-extension, `movsx` performs sign-extension.
-
-A variant of `movsx` called `movsxd` can sign-extend from a 32-bit source operand to a 64-bit destination operand.
+In signed division, the value should be sign-extended instead.
+There are instructions that automate this process: `cbw`, `cwd`, `cdq` and `cqo`.
+The first sets the bits in `ah` according to the sign of `al`.
+The others perform sign-extension from `ax` to `dx`, from `eax` to `edx` and from `rax` to `rdx`, respectively.
 
 ~~~~exercism/caution
-The `rdx` register is implicitly used in an integer division.
-This means any necessary value in `rdx` must be saved before that operation.
+Registers implicitly used in a division, such as `rax` and `rdx`, are always overwritten.
+The values in those registers should be saved before the division if they are necessary later.
 ~~~~

--- a/concepts/integers/introduction.md
+++ b/concepts/integers/introduction.md
@@ -57,7 +57,7 @@ An immediate is not held in a register or in memory: it is encoded inside the in
 In most instructions, the space reserved for it is only 32 bits wide, no matter how large the destination operand is.
 
 When the destination operand is 64 bits wide, those 32 bits are _sign-extended_ to fill it.
-The upper half of the operand receives copies of the uppermost bit of the immediate, so only a number in the range of a _32-bit signed integer_ can be written this way:
+The upper half of the operand is entirely filled with copies of the uppermost bit of the immediate, so only a number in the range of a _32-bit signed integer_ can be written this way:
 
 ```x86asm
 add rax, -1          ; the immediate is sign-extended, so all 64 bits of rax are affected
@@ -65,8 +65,8 @@ add rax, 2147483647  ; the largest immediate an instruction like this accepts
 ```
 
 A number outside that range can not be used as an immediate.
-The exception to this rule is `mov`, which has a special form, available only when the destination operand is a register, that carries a full 64-bit immediate.
-If a 64-bit immediate is needed, first use `mov` to load it into a register, then use the register:
+The exception to this rule is `mov`, which can take a full 64-bit immediate when the destination operand is a register.
+If a 64-bit immediate is needed, first use `mov` to load it into a register, then use that register:
 
 ```x86asm
 mov rax, 3435973837           ; this works, mov can take a 64-bit immediate

--- a/exercises/concept/inventory-management/.docs/instructions.md
+++ b/exercises/concept/inventory-management/.docs/instructions.md
@@ -15,8 +15,8 @@ These are the instructions mentioned in this concept:
 | sub a, b      | a = a - b                                                       |
 | dec a         | a = a - 1                                                       |
 | imul a        | rdx:rax = a * rax (signed)                                      |
-| imul a, b     | a = a * b (signed)                                              |
-| imul a, b, c  | a = b * c (signed)                                              |
+| imul a, b     | a = a * b (signed, truncated)                                   |
+| imul a, b, c  | a = b * c (signed, truncated)                                   |
 | mul a         | rdx:rax = a * rax (unsigned)                                    |
 | div a         | rax = quotient, rdx = remainder of rdx:rax / a (unsigned)       |
 | idiv a        | rax = quotient, rdx = remainder of rdx:rax / a (signed)         |

--- a/exercises/concept/inventory-management/.docs/instructions.md
+++ b/exercises/concept/inventory-management/.docs/instructions.md
@@ -11,7 +11,6 @@ These are the instructions mentioned in this concept:
 | Instruction   | Description                                                     |
 |---------------|-----------------------------------------------------------------|
 | add a, b      | a = a + b                                                       |
-| adc a, b      | a = a + b + CF (previous carry)                                 |
 | inc a         | a = a + 1                                                       |
 | sub a, b      | a = a - b                                                       |
 | dec a         | a = a - 1                                                       |

--- a/exercises/concept/inventory-management/.docs/introduction.md
+++ b/exercises/concept/inventory-management/.docs/introduction.md
@@ -30,7 +30,7 @@ If an integer can assume positive or negative values, it's called a **signed** n
 To represent negative numbers, x86-64 uses the **two's complement** representation.
 
 In two's complement, signed numbers are also represented as the sum of the powers of two corresponding to set bits.
-However, if the uppermost bit is set (the one corresponding to `2⁶³`), it is subtracted instead of added to the others.
+However, if the uppermost bit is set, it is subtracted instead of added to the others.
 
 Since this bit corresponds to a higher value than the sum of all the others, in practice this means a number with this bit set is always negative.
 This special bit is called the **sign bit**.
@@ -59,7 +59,7 @@ An immediate is not held in a register or in memory: it is encoded inside the in
 In most instructions, the space reserved for it is only 32 bits wide, no matter how large the destination operand is.
 
 When the destination operand is 64 bits wide, those 32 bits are _sign-extended_ to fill it.
-The upper half of the operand receives copies of the uppermost bit of the immediate, so only a number in the range of a _32-bit signed integer_ can be written this way:
+The upper half of the operand is entirely filled with copies of the uppermost bit of the immediate, so only a number in the range of a _32-bit signed integer_ can be written this way:
 
 ```x86asm
 add rax, -1          ; the immediate is sign-extended, so all 64 bits of rax are affected
@@ -67,8 +67,8 @@ add rax, 2147483647  ; the largest immediate an instruction like this accepts
 ```
 
 A number outside that range can not be used as an immediate.
-The exception to this rule is `mov`, which has a special form, available only when the destination operand is a register, that carries a full 64-bit immediate.
-If a 64-bit immediate is needed, first use `mov` to load it into a register, then use the register:
+The exception to this rule is `mov`, which can take a full 64-bit immediate when the destination operand is a register.
+If a 64-bit immediate is needed, first use `mov` to load it into a register, then use that register:
 
 ```x86asm
 mov rax, 3435973837           ; this works, mov can take a 64-bit immediate

--- a/exercises/concept/inventory-management/.docs/introduction.md
+++ b/exercises/concept/inventory-management/.docs/introduction.md
@@ -1,27 +1,45 @@
 # Introduction
 
-## Binary Notation
+## Integers
+
+### Binary Notation
 
 An **integer** is an abstraction that represents whole numbers, such as `4`, `-2`, `0` or `64532`.
 
 To represent an integer as a sequence of bytes, the **binary notation** is used.
-In this system, each bit in the sequence represents a distinct power of two, with the value increasing as the index of the bit increases from right to left.
+In this notation, each bit in the sequence represents a distinct power of two, with the value increasing as the index of the bit increases from right to left.
 
-## Unsigned and Signed Integers
-
-### Unsigned numbers
+### Unsigned Numbers
 
 If the number can only be non-negative, it's called an **unsigned** number.
 
-Unsigned numbers are represented directly as the sum of all set bits in their sequence.
+Unsigned numbers are represented directly as the sum of the powers of two corresponding to all set bits in their sequence.
 
 The range of representable non-negative integers in a register goes from `0` (no bit set) to `2⁶⁴ - 1` (sum of all 64 bits set).
 
-### Signed numbers
+Widening an unsigned number to a larger size is done by filling all upper bits with `0`, so that no new bit contributes to the value.
+This is called **zero-extension**.
+
+The instruction `movzx` (`z` for zero) zero-extends an 8-bit or 16-bit source operand to a larger destination operand.
+A 32-bit source operand is always zero-extended to all 64 bits of the destination operand with a simple `mov`.
+
+### Signed Numbers
 
 If an integer can assume positive or negative values, it's called a **signed** number.
 
 To represent negative numbers, x86-64 uses the **two's complement** representation.
+
+In two's complement, signed numbers are also represented as the sum of the powers of two corresponding to set bits.
+However, if the uppermost bit is set (the one corresponding to `2⁶³`), it is subtracted instead of added to the others.
+
+Since this bit corresponds to a higher value than the sum of all the others, in practice this means a number with this bit set is always negative.
+This special bit is called the **sign bit**.
+
+Widening a signed number to a larger size means filling every new upper bit with a copy of the sign bit, so that the value is preserved.
+This is called **sign-extension**.
+
+The instruction `movsx` (`s` for sign) sign-extends an 8-bit or 16-bit source operand to a larger destination operand.
+A variant of `movsx` called `movsxd` does the same from a 32-bit source operand to a 64-bit destination operand.
 
 The `neg` instruction can be used to change the sign of a number.
 
@@ -32,40 +50,48 @@ It's the programmer's responsibility to give meaning to those bytes.
 The use of comments can be a great aid in this task.
 ~~~~
 
-## Immediates
+### Immediates
 
-In a previous concept, it was mentioned that a constant number, such as `4` or `15`, can be used as source operand to many instructions.
+In a previous concept, it was mentioned that a constant number, such as `4` or `-15`, can be used as source operand to many instructions.
 Those numbers are called **immediates**.
 
-An immediate is truncated to fit into the destination operand.
-However, in most instructions, an immediate must be at most a _32-bit signed integer_.
-A number that does not fit into this size can not be used directly as operand.
+An immediate is not held in a register or in memory: it is encoded inside the instruction itself.
+In most instructions, the space reserved for it is only 32 bits wide, no matter how large the destination operand is.
 
-The exception to this rule is `mov`, which accepts a _64-bit signed integer_ as source operand.
-
-It is possible to use a signed negative integer as immediate in place of an unsigned integer with the same bit representation:
+When the destination operand is 64 bits wide, those 32 bits are _sign-extended_ to fill it.
+The upper half of the operand receives copies of the uppermost bit of the immediate, so only a number in the range of a _32-bit signed integer_ can be written this way:
 
 ```x86asm
-add rax, -1  ; this is 18446744073709551615 in unsigned representation
-             ; an attempt to use 18446744073709551615 directly wouldn't work because immediates are usually 32-bit signed integers
-
-mov rax, 18446744073709551615  ; this works because mov can take a 64-bit immediate as source operand
+add rax, -1          ; the immediate is sign-extended, so all 64 bits of rax are affected
+add rax, 2147483647  ; the largest immediate an instruction like this accepts
 ```
 
-## Arithmetic
+A number outside that range can not be used as an immediate.
+The exception to this rule is `mov`, which has a special form, available only when the destination operand is a register, that carries a full 64-bit immediate.
+If a 64-bit immediate is needed, first use `mov` to load it into a register, then use the register:
+
+```x86asm
+mov rax, 3435973837           ; this works, mov can take a 64-bit immediate
+mov rdx, 18446744073709551615 ; the largest immediate mov accepts
+sub rdx, rax
+```
+
+Note that a negative immediate and the unsigned number with the same bit representation are equivalent and assemble to exactly the same value:
+
+```x86asm
+mov rax, -1                   ; rax = 18446744073709551615
+mov rax, 18446744073709551615 ; rax = -1
+```
 
 ### Sum
 
 The addition of two numbers can be calculated using the `add` instruction.
 
-Sometimes, the sum of two numbers leaves an excessive bit that does not fit into the destination operand.
-This bit is stored in a special flag called the **carry flag (CF)**.
-The `CF` can also be set by other instructions, performing other operations.
+There's also an `inc` one-operand instruction, that adds `1` to the value in its operand:
 
-The instruction `adc` can be used to sum two numbers and also the value in the carry flag.
-It is a two-operand instruction, with the same syntax as `add`.
-
-There's also an `inc` one-operand instruction, that sums 1 to the value in its operand.
+```x86asm
+inc rax ; rax = rax + 1
+```
 
 The sum of two integers operates in the same way for both unsigned and signed numbers.
 
@@ -73,7 +99,11 @@ The sum of two integers operates in the same way for both unsigned and signed nu
 
 The subtraction of two integers is performed using the `sub` instruction.
 
-There's also a `dec` one-operand instruction, that subtracts 1 from the value in its operand.
+There's also a `dec` one-operand instruction, that subtracts `1` from the value in its operand:
+
+```x86asm
+dec rax ; rax = rax - 1
+```
 
 The subtraction of two integers also operates in the same way for both unsigned and signed numbers.
 
@@ -82,7 +112,7 @@ The subtraction of two integers also operates in the same way for both unsigned 
 There are two different instructions to perform multiplication between two numbers in x86-64.
 As a rule, unsigned multiplication uses the instruction `mul`, while signed multiplication uses `imul`.
 
-The `mul` instruction takes the following one-operand form, where src is the source operand:
+The `mul` instruction takes the following one-operand form, where `src` is the source operand:
 
 ```x86asm
 mul src
@@ -96,14 +126,19 @@ imul dest, src
 imul dest, src1, src2
 ```
 
-#### One-operand form
+#### One-Operand Multiplication
 
 Two registers are implicitly used to perform a multiplication in one-operand form: `rax` and `rdx`.
 If the multiplication involves two 64-bit numbers, then the lower 64 bits of the result will be in `rax` and the upper 64 bits will be in `rdx`.
 
-This is usually called `rdx:rax`, to indicate that both registers are used in tandem.
+This is usually called `rdx:rax`, to indicate that both registers are used in tandem:
 
-The same happens if the multiplication involves different register sizes.
+```x86asm
+mul rcx ; rax = lower 64 bits of rax * rcx
+        ; rdx = upper 64 bits of rax * rcx
+```
+
+The same happens for other operand sizes.
 So, for instance, if two 32-bit numbers are being multiplied, `eax` and `edx` will be used.
 
 The exception is the multiplication between two bytes.
@@ -112,44 +147,45 @@ In this case, instead of `dl:al`, `ax` will be used.
 The lower portion of `ax` (`al`) will get the lower 8 bits of the product, while the upper portion (`ah`) will get the upper 8 bits.
 
 ~~~~exercism/caution
-The `rdx` register is implicitly used in a one-operand multiplication.
-This means any necessary value in `rdx` must be saved before that operation.
+Registers implicitly used in a multiplication, such as `rax` and `rdx`, are always overwritten.
+The values in those registers should be saved before the operation if they are necessary later.
 ~~~~
 
-#### Two-operand form
+#### Two-Operand Multiplication
 
-The two-operand form of `imul` allows for explicitly declaring a different destination operand.
-
-In that case, the product between source and destination operands is placed in the destination operand.
-This product is truncated to fit into the destination operand.
-
-#### Three-operand form
-
-The three-operand form of `imul` multiplies the two source operands and places the result in the destination operand.
-
-This means that the destination operand is not multiplied with any of the source operands, it just receives the result.
-This product is also truncated to fit into the destination operand.
-
-#### Handling overflow
-
-In case of a possible overflow, it is sometimes useful to move operands to a larger register size.
-
-A `movzx` instruction can be used to convert a value in an 8-bit or 16-bit source operand to a larger destination operand, clearing all remaining bits.
-This is called **zero extension**:
+The two-operand form of `imul` has an explicit destination operand and follows the usual syntax.
+`rdx` is not used.
+Instead, the result is truncated to fit into the destination operand.
 
 ```x86asm
-mov ax, 1000 ; lower 16 bits of eax are 1000, upper bits are undefined
-mov cx, 200 ; lower 16 bits of ecx are 200, upper bits are undefined
-
-; 200 * 1000 does not fit in 16 bits, so a 32-bit multiplication is necessary
-; however, multiplying eax by ecx may produce an incorrect result due to undefined bits
-
-movzx eax, ax ; lower 16 bits of eax remain 1000, upper bits are cleared
-movzx ecx, cx ; lower 16 bits of ecx remain 200, upper bits are cleared
-mul ecx ; now eax correctly holds 200 * 1000
+imul r8, r9 ; r8 = lower 64 bits of r8 * r9
 ```
 
-A 32-bit source operand is always zero-extended to all 64 bits of the destination operand with a simple `mov`.
+#### Three-Operand Multiplication
+
+The three-operand form of `imul` has two source operands, the second of which is always an immediate (a constant number).
+Both source operands are multiplied and the result is truncated and placed in the destination operand:
+
+```x86asm
+imul r8, r9, 100 ; r8 = lower 64 bits of r9 * 100
+```
+
+Note that the destination operand is not used in the multiplication.
+It just receives the result.
+
+#### Handling Overflow
+
+Both two-operand and three-operand multiplication truncate the result to fit into the size of the destination operand.
+A one-operand multiplication preserves the full range, but it is usually split into two registers, `rdx` and `rax`.
+
+So, it is sometimes useful to widen the operands before the multiplication to make room for the whole product in a single register.
+An unsigned operand is zero-extended, while a signed one is sign-extended:
+
+```x86asm
+movzx eax, di ; di and si hold unsigned 16-bit numbers
+movzx ecx, si
+mul ecx       ; the 32-bit product fits in eax, and edx is cleared
+```
 
 ### Division
 
@@ -163,35 +199,27 @@ div src
 idiv src
 ```
 
-In both cases, the value in `rdx:rax` is divided by the value in the source operand.
-The quotient is written to the `rax` register and the remainder is written to the `rdx` register.
+16-bit, 32-bit and 64-bit division use `dx:ax`, `edx:eax` and `rdx:rax` as the dividend, respectively.
+In these cases, both registers act in tandem to create a 2N-bit value, where N is the size of the operation (16-bit, 32-bit or 64-bit).
+This value is then divided by the source operand.
+The quotient is written to `ax`, `eax` or `rax` and the remainder is written to `dx`, `edx` or `rdx`, according to the size of the operation.
 
-Note that as `rdx:rax` is the dividend, both registers must have the appropriate bits set.
+The division between bytes is special: instead of using `dl:al`, `ax` is used.
+The lower 8 bits of `ax` (`al`) will get the quotient of the operation and the higher 8 bits (`ah`) will get the remainder.
 
-So, whenever working with 64-bit integers, the `rdx` register must be set up before the division.
+Note that all bits in the dividend should be appropriately set before the division.
+Any bit set in `rdx` (or in `ah` for 8-bit division) contributes to the value being divided.
 
-For unsigned division, all bits in `rdx` must be cleared.
-This is called **zero extension**.
+In unsigned division, when the value to be divided fits in the lower half, the upper half should be cleared.
+Any instruction that clears those bits will do.
+For example, `mov edx, 0` clears the upper bits in 32-bit division.
 
-For signed division, all bits in `rdx` must be cleared for a non-negative number in `rax`, and set for a negative number.
-This is called **sign extension**.
-
-Failing to do this can cause a wrong result for the division or, if the quotient is too large to fit in `rax`, an error.
-
-There are three instructions that automate the sign extension: `cwd`, `cdq` and `cqo`.
-They perform sign extension from `ax` to `dx`, from `eax` to `edx` and from `rax` to `rdx`, respectively.
-
-There's no equivalent instruction for sign extending `al` to `dl` because division between two bytes operates differently.
-Instead of using `dl:al`, `ax` is used.
-
-So, the lower 8 bits of `ax` (`al`) will get the quotient of the operation and the higher 8 bits (`ah`) will get the remainder.
-
-There is also the instruction `movsx` that works similarly to `movzx`, extending from any 8-bit or 16-bit source operand to a larger destination operand.
-While `movzx` performs zero-extension, `movsx` performs sign-extension.
-
-A variant of `movsx` called `movsxd` can sign-extend from a 32-bit source operand to a 64-bit destination operand.
+In signed division, the value should be sign-extended instead.
+There are instructions that automate this process: `cbw`, `cwd`, `cdq` and `cqo`.
+The first sets the bits in `ah` according to the sign of `al`.
+The others perform sign-extension from `ax` to `dx`, from `eax` to `edx` and from `rax` to `rdx`, respectively.
 
 ~~~~exercism/caution
-The `rdx` register is implicitly used in an integer division.
-This means any necessary value in `rdx` must be saved before that operation.
+Registers implicitly used in a division, such as `rax` and `rdx`, are always overwritten.
+The values in those registers should be saved before the division if they are necessary later.
 ~~~~

--- a/exercises/concept/lasagna/.docs/instructions.md
+++ b/exercises/concept/lasagna/.docs/instructions.md
@@ -10,9 +10,9 @@ These are the instructions mentioned in this concept:
 | Instruction | Description                     |
 |-------------|---------------------------------|
 | mov a, b    | copies the contents from b to a |
-| add a, b    | sets a to a + b                 |
-| sub a, b    | sets a to a - b                 |
-| imul a, b   | sets a to a * b                 |
+| add a, b    | a = a + b                       |
+| sub a, b    | a = a - b                       |
+| imul a, b   | a = a * b                       |
 | call a      | calls function a                |
 | ret         | returns from a function         |
 ~~~~


### PR DESCRIPTION
1. Clarify the Immediates section. It was oversimplified and contained an incorrect example.
2. Clarify signedness in introduction.md, using it as a hook to introduce sign-extension.
3. Move zero-extension and sign-extension into the Unsigned Numbers and Signed Numbers sections, respectively. This puts more focus on `movzx` and `movsx`, and since sign-extension is now needed to explain immediates, it has to be introduced earlier.
4. Remove `adc` from introduction.md and instructions.md, since it is not used in the exercise. Move it to about.md, along with its subtraction counterpart `sbb`.
5. Reword the multiplication and division sections to make them easier to follow.