### PR TITLE
add test case to `acronym`

### DIFF
--- a/exercises/practice/acronym/.meta/example.asm
+++ b/exercises/practice/acronym/.meta/example.asm
@@ -1,70 +1,35 @@
 section .text
-isalpha:
-        xor     eax, eax
-        and     edi, -33
-        sub     edi, 65
-        cmp     dil, 25
-        setbe   al
-        ret
-toupper:
-        mov     eax, edi
-        and     eax, -33
-        ret
 global abbreviate
 abbreviate:
-        mov     rax, rdi
-        test    rdi, rdi
-        je      .null
-        mov     dl, [rdi]
-        test    dl, dl
-        je      .empty
-        mov     [rsi], dl
-        push    r14
-        push    r13
-        push    r12
-        lea     r12, [rsi+1]
-        push    rbp
-        mov     rbp, rsi
-        push    rbx
-        lea     rbx, [rdi+1]
+    mov edx, 1
+    xor r8d, r8d
+    xor r9d, r9d
 .loop:
-        mov     al, [rbx]
-        test    al, al
-        je      .fin
-        cmp     al, 45
-        je      .check_alpha
-        cmp     al, 32
-        jne     .next
-.check_alpha:
-        movsx   r13d, byte [rbx]
-        mov     r14, rbx
-        inc     rbx
-        mov     edi, r13d
-        call    isalpha
-        test    eax, eax
-        je      .check_alpha
-        mov     edi, r13d
-        inc     r12
-        mov     rbx, r14
-        call    toupper
-        mov     [r12-1], al
-.next:
-        inc     rbx
-        jmp     .loop
-.fin:
-        mov     byte [r12], 0
-        mov     rax, rbp
-        pop     rbx
-        pop     rbp
-        pop     r12
-        pop     r13
-        pop     r14
-        ret
-.empty:
-        xor     eax, eax
-        ret
-.null:
-        ret
+    movzx eax, byte [rdi]
+    inc rdi
+    test eax, eax
+    jz .exit
+    cmp eax, ' '
+    setz r8b
+    cmp eax, '-'
+    setz r9b
+    or r8b, r9b
+    cmovnz edx, r8d
+    jnz .loop
+    test edx, edx
+    jz .loop
+    and eax, ~32
+    sub eax, 'A'
+    cmp eax, 26
+    jae .loop
+    xor edx, edx
+    add eax, 'A'
+    mov [rsi], al
+    inc rsi
+    jmp .loop
+.exit:
+    mov [rsi], al
+    ret
 
 %ifidn __OUTPUT_FORMAT__,elf64
 section .note.GNU-stack noalloc noexec nowrite progbits

--- a/exercises/practice/acronym/acronym_test.c
+++ b/exercises/practice/acronym/acronym_test.c
@@ -83,6 +83,14 @@ void test_underscore_emphasis(void) {
     TEST_ASSERT_EQUAL_STRING("TRNT", out);
 }
 
+void test_all_lowercase(void) {
+    TEST_IGNORE();
+    const char *in = "point of view";
+    char out[BUFFER_SIZE];
+    abbreviate(in, out);
+    TEST_ASSERT_EQUAL_STRING("POV", out);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_basic);
@@ -94,5 +102,6 @@ int main(void) {
     RUN_TEST(test_consecutive_delimiters);
     RUN_TEST(test_apostrophes);
     RUN_TEST(test_underscore_emphasis);
+    RUN_TEST(test_all_lowercase);
     return UNITY_END();
 }

--- a/generators/exercises/acronym.py
+++ b/generators/exercises/acronym.py
@@ -9,6 +9,17 @@ extern void abbreviate(const char* in, char* out);
 """
 
 
+def extra_cases():
+    return [
+        {
+            "description": "all lowercase",
+            "property": "abbreviate",
+            "input": {"phrase": "point of view"},
+            "expected": "POV",
+        }
+    ]
+
+
 def gen_func_body(prop, inp, expected):
     str_list = []
     value = inp["phrase"].replace("\\", "\\\\")


### PR DESCRIPTION
I asked Claude (an LLM) to review all example solutions in the track, looking for any errors or untested edge cases. It caught some issues (surprisingly few).

This PR adds a test case to `acronym` with an all-lowercase input string. The current example solution copies the first letter without modification, so it fails if the first letter is lowercase.

Other exercises with issues: `gigasecond`, `matrix`, `binary-search-tree` and `nth-prime`. The last two are just minor typos, but the first two require extra test cases and fixing the example solution.