### PR TITLE
adjust `simd-masks`, `simd-cross-lane`, and `thunks`

### DIFF
--- a/concepts/simd-cross-lane/about.md
+++ b/concepts/simd-cross-lane/about.md
@@ -124,28 +124,6 @@ The instruction is also commonly used for fast table lookup.
 In that case, the control vector holds variable indices, possibly hashed from an initial value, and a 16-entry table is loaded on the data register.
 After the shuffle, each lane in the destination will hold the entry corresponding to its index.
 
-For example, it can be used to select only valid bytes of a string, after aligning-down its address to avoid crossing a page boundary:
-
-```x86asm
-section .rodata
-tab: db 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-     times 16 db 0x80
-
-section .text
-fn:
-  ; assume the string is passed on rsi
-  mov rax, rsi
-  and rsi, -16 ; align-down rsi, it is now safe to load 16 bytes out of it
-  and rax, 15  ; the number of garbage bytes loaded by rsi, before the start of the string
-
-  lea r10, [rel tab]
-  movdqa xmm0, [rsi]       ; rsi is 16-byte aligned
-  movdqu xmm1, [r10 + rax]
-  pshufb xmm0, xmm1        ; only string bytes are selected and put in the low lanes of xmm0
-                           ; other bytes are cleared (the top bit of 0x80 is set)
-  ...
-```
-
 ## Interleaving Lanes
 
 The **unpack** instructions take lanes from two operands and weave them together, alternating between the two.

--- a/concepts/simd-masks/about.md
+++ b/concepts/simd-masks/about.md
@@ -114,8 +114,6 @@ pandn  xmm0, xmm4  ; xmm0 = NOT mask AND b: lanes of b where mask is false
 por    xmm2, xmm0  ; combine the two halves
 ```
 
-Note that the `pandn` asymmetry pays off here: the mask sits in the destination, gets negated, and selects from `b` in a single instruction.
-
 This pattern is the packed form of branchless selection.
 Every lane is computed, and the mask alone decides which value survives, with no `jcc` anywhere.
 

--- a/concepts/simd-masks/introduction.md
+++ b/concepts/simd-masks/introduction.md
@@ -108,8 +108,6 @@ pandn  xmm0, xmm4  ; xmm0 = NOT mask AND b: lanes of b where mask is false
 por    xmm2, xmm0  ; combine the two halves
 ```
 
-Note that the `pandn` asymmetry pays off here: the mask sits in the destination, gets negated, and selects from `b` in a single instruction.
-
 This pattern is the packed form of branchless selection.
 Every lane is computed, and the mask alone decides which value survives, with no `jcc` anywhere.
 

--- a/exercises/concept/bookkeeping/helper.asm
+++ b/exercises/concept/bookkeeping/helper.asm
@@ -23,7 +23,10 @@ section .text
 global clobber
 clobber:
     mov rax, rdi
+    sub rsp, 8
+    movdqa xmm0, [rsp]
     _clobber_regs
+    add rsp, 8
     ret
 
 %ifidn __OUTPUT_FORMAT__,elf64


### PR DESCRIPTION
- remove a duplicated example in the about.md of `simd-cross-lane`.
- remove an unnecessary line in `simd-masks`.
- the last task in `bookkeeping` (`thunks`'s concept exercise) now checks if the stack is correctly aligned before calling an external function.